### PR TITLE
TISDEV-2579 changes to support the programmes current api being depre…

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>3.1.7</version>
+  <version>3.1.8</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -189,25 +189,17 @@ public class ProgrammeMembershipDTO implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    ProgrammeMembershipDTO programmeMembershipDTO = (ProgrammeMembershipDTO) o;
-
-    if (!Objects.equals(id, programmeMembershipDTO.id)) {
-      return false;
-    }
-
-    return true;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProgrammeMembershipDTO that = (ProgrammeMembershipDTO) o;
+    return Objects.equals(id, that.id) &&
+        Objects.equals(programmeId, that.programmeId) &&
+        Objects.equals(curriculumId, that.curriculumId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id);
+    return Objects.hash(id, programmeId, curriculumId);
   }
 
   @Override

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>3.0.28</version>
+  <version>3.0.29</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>3.1.7</version>
+      <version>3.1.8</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -52,7 +52,7 @@ public class TcsServiceImpl extends AbstractClientService {
 	static {
 		try {
 			curriculumJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec().encode("{\"name\":[\"PARAMETER_NAME\"]}");
-			programmeJsonQuerystringURLEncoded  = new org.apache.commons.codec.net.URLCodec().encode("{\"programmeName\":[\"PARAMETER_NAME\"],\"programmeNumber\":[\"PARAMETER_NUMBER\"]}");
+			programmeJsonQuerystringURLEncoded  = new org.apache.commons.codec.net.URLCodec().encode("{\"programmeName\":[\"PARAMETER_NAME\"],\"programmeNumber\":[\"PARAMETER_NUMBER\"],\"status\":[\"CURRENT\"]}");
 		} catch (EncoderException e) {
 			e.printStackTrace();
 		}
@@ -198,7 +198,7 @@ public class TcsServiceImpl extends AbstractClientService {
   public List<ProgrammeDTO> getProgrammeByNameAndNumber(String name, String number) {
 		log.debug("calling getProgrammeByNameAndNumber with {} and number {}", name, number);
 		return tcsRestTemplate
-				.exchange(serviceUrl + "/api/current/programmes?columnFilters=" +
+				.exchange(serviceUrl + "/api/programmes?columnFilters=" +
 								programmeJsonQuerystringURLEncoded
 										.replace("PARAMETER_NAME", name)
 										.replace("PARAMETER_NUMBER", number),

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>3.4.11</version>
+  <version>3.4.12</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>3.1.7</version>
+      <version>3.1.8</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
…cated

ProgrammeMemberhsip DTO's were being used by the generic upload api. Since the hashcode was computed on the id only, this broke the scenario with multiple Programme DTOs in a Set, and no id being present. Refactoring the hashcode equals methods to include a combination of ids

Author : @sfkamath