### PR TITLE
TISDEV-2579 : allow validations on the embedded ContactDetailsDTO in …

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>3.1.10</version>
+  <version>3.1.11</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PersonDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PersonDTO.java
@@ -5,6 +5,7 @@ import com.transformuk.hee.tis.tcs.api.dto.validation.Create;
 import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 
+import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
@@ -45,6 +46,7 @@ public class PersonDTO implements Serializable {
 
   private String regulator;
 
+  @Valid
   private ContactDetailsDTO contactDetails;
 
   private PersonalDetailsDTO personalDetails;

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>3.0.33</version>
+  <version>3.0.34</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>3.1.10</version>
+      <version>3.1.11</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -159,7 +159,7 @@ public class TcsServiceImpl extends AbstractClientService {
 				.getBody());
 
 		personDTOUpdated.setContactDetails(tcsRestTemplate
-				.exchange(serviceUrl + "/api/contact-details", HttpMethod.PUT, new HttpEntity<>(personDTO.getContactDetails(), headers), new ParameterizedTypeReference<ContactDetailsDTO>() {})
+				.exchange(serviceUrl + "/api/contact-details/", HttpMethod.PUT, new HttpEntity<>(personDTO.getContactDetails(), headers), new ParameterizedTypeReference<ContactDetailsDTO>() {})
 				.getBody());
 
 		personDTOUpdated.setPersonalDetails(tcsRestTemplate

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>3.4.25</version>
+  <version>3.4.26</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>3.1.10</version>
+      <version>3.1.11</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/api/dto/ContactDetailsDTOValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/api/dto/ContactDetailsDTOValidatorTest.java
@@ -1,0 +1,142 @@
+package com.transformuk.hee.tis.tcs.api.dto;
+
+import com.transformuk.hee.tis.tcs.service.Application;
+import com.transformuk.hee.tis.tcs.service.api.*;
+import com.transformuk.hee.tis.tcs.service.api.decorator.PersonViewDecorator;
+import com.transformuk.hee.tis.tcs.service.api.decorator.PlacementSummaryDecorator;
+import com.transformuk.hee.tis.tcs.service.api.decorator.PlacementViewDecorator;
+import com.transformuk.hee.tis.tcs.service.api.validation.PersonValidator;
+import com.transformuk.hee.tis.tcs.service.exception.ExceptionTranslator;
+import com.transformuk.hee.tis.tcs.service.model.ContactDetails;
+import com.transformuk.hee.tis.tcs.service.model.Person;
+import com.transformuk.hee.tis.tcs.service.repository.PersonViewRepository;
+import com.transformuk.hee.tis.tcs.service.repository.PlacementViewRepository;
+import com.transformuk.hee.tis.tcs.service.service.ContactDetailsService;
+import com.transformuk.hee.tis.tcs.service.service.PersonService;
+import com.transformuk.hee.tis.tcs.service.service.PlacementService;
+import com.transformuk.hee.tis.tcs.service.service.impl.PermissionService;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ContactDetailsMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.PersonMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.PlacementViewMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import javax.persistence.EntityManager;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class)
+public class ContactDetailsDTOValidatorTest {
+	@Autowired
+	private EntityManager em;
+	@Autowired
+	private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+	@Autowired
+	private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+	@Autowired
+	private ExceptionTranslator exceptionTranslator;
+	@Autowired
+	private ContactDetailsService contactDetailsService;
+	@Autowired
+	private ContactDetailsMapper contactDetailsMapper;
+
+	@Autowired
+	private PersonMapper personMapper;
+	@Autowired
+	private PersonService personService;
+	@Autowired
+	private PlacementViewRepository placementViewRepository;
+	@Autowired
+	private PlacementViewMapper placementViewMapper;
+	@Autowired
+	private PlacementViewDecorator placementViewDecorator;
+	@Autowired
+	private PersonViewDecorator personViewDecorator;
+	@Autowired
+	private PersonViewRepository personViewRepository;
+	@Autowired
+	private PlacementService placementService;
+	@Autowired
+	private PlacementSummaryDecorator placementSummaryDecorator;
+	@Autowired
+	private PersonValidator personValidator;
+
+	@MockBean
+	private PermissionService permissionServiceMock;
+
+	private MockMvc restContactDetailsMockMvc;
+	private MockMvc restPersonMockMvc;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		ContactDetailsResource contactDetailsResource = new ContactDetailsResource(contactDetailsService);
+		PersonResource personResource = new PersonResource(personService, placementViewRepository, placementViewMapper,
+				placementViewDecorator, personViewDecorator, placementService, placementSummaryDecorator,personValidator);
+		this.restContactDetailsMockMvc = MockMvcBuilders.standaloneSetup(contactDetailsResource)
+				.setCustomArgumentResolvers(pageableArgumentResolver)
+				.setControllerAdvice(exceptionTranslator)
+				.setMessageConverters(jacksonMessageConverter).build();
+		this.restPersonMockMvc = MockMvcBuilders.standaloneSetup(personResource)
+				.setCustomArgumentResolvers(pageableArgumentResolver)
+				.setControllerAdvice(exceptionTranslator)
+				.setMessageConverters(jacksonMessageConverter).build();
+
+		when(permissionServiceMock.canViewSensitiveData()).thenReturn(true);
+		when(permissionServiceMock.canEditSensitiveData()).thenReturn(true);
+	}
+
+	@Test
+	public void validationIsInvokedBeforeSavingContact() throws Exception {
+		ContactDetails contactDetails = ContactDetailsResourceIntTest.createEntity(em);
+
+		//given
+		ContactDetailsDTO contactDetailsDTO = contactDetailsMapper.toDto(contactDetails);
+		contactDetailsDTO.setEmail("test@test.com;");
+
+		//when & then
+		restContactDetailsMockMvc.perform(put("/api/contact-details")
+				.contentType(TestUtil.APPLICATION_JSON_UTF8)
+				.content(TestUtil.convertObjectToJsonBytes(contactDetailsDTO)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("error.validation"))
+				.andExpect(jsonPath("$.fieldErrors[*].field").
+						value(containsInAnyOrder("email")));
+	}
+
+	@Test
+	public void validationIsInvokedBeforeCreatingContactViaPerson() throws Exception {
+		Person person = PersonResourceIntTest.createEntity();
+		PersonDTO personDTO = personMapper.toDto(person);
+
+		ContactDetails contactDetails = ContactDetailsResourceIntTest.createEntity(em);
+		ContactDetailsDTO contactDetailsDTO = contactDetailsMapper.toDto(contactDetails);
+		contactDetailsDTO.setEmail("test@test.com;");
+		personDTO.setContactDetails(contactDetailsDTO);
+
+		restPersonMockMvc.perform(MockMvcRequestBuilders.post("/api/people")
+				.contentType(TestUtil.APPLICATION_JSON_UTF8)
+				.content(TestUtil.convertObjectToJsonBytes(personDTO)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("error.validation"))
+				.andExpect(jsonPath("$.fieldErrors[*].field").
+						value(containsInAnyOrder("contactDetails.email")));
+	}
+}


### PR DESCRIPTION
…the PersonDTO object

it was observed that emails with trailing semicolons were being flagged as invalid by the validation framework on updates but not on creates. This fix allows for a consistent approach