### PR TITLE
renamed getRotationPosts to getRotationPost

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>3.7.19</version>
+  <version>3.7.20</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RotationPostResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RotationPostResource.java
@@ -91,7 +91,7 @@ public class RotationPostResource {
    */
   @GetMapping("/rotation-posts/{id}")
   @Timed
-  public ResponseEntity<?> getRotationPosts(@PathVariable Long id) {
+  public ResponseEntity<?> getRotationPost(@PathVariable Long id) {
     log.debug("REST request to get RotationPost : {}", id);
 
     List<RotationPostDTO> rotationPostDTOS = rotationPostService.findByPostId(id);


### PR DESCRIPTION
TCS auditing requires the method not to be pluarlised. It is doing a get before deleting in order to do the audit. It builds up the method name programmatically and uses singular post instead of posts.

Need to do some refactoring of these end points to tidy things up