### PR TITLE
[TISNEW-2165] - Method for getting all of a trainees placement implemented on BE

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>3.0.75</version>
+  <version>3.0.76</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -40,6 +40,7 @@ public class TcsServiceImpl extends AbstractClientService {
 	private static final String API_CONTACT_DETAILS = "/api/contact-details/";
 	private static final String API_RIGHT_TO_WORKS = "/api/right-to-works/";
 	private static final String API_PROGRAMME_MEMBERSHIPS = "/api/programme-memberships/";
+	private static final String API_TRAINEE_PLACEMENTS = "/api/people/%d/placements/new";
 	private static final String API_CURRENT_SPECIALTIES_COLUMN_FILTERS = "/api/specialties?columnFilters=";
 	private static final String API_ROTATION_COLUMN_FILTERS = "/api/rotations?columnFilters=";
 	private static final String API_CURRENT_CURRICULA_COLUMN_FILTERS = "/api/current/curricula?columnFilters=";
@@ -195,6 +196,12 @@ public class TcsServiceImpl extends AbstractClientService {
 		return tcsRestTemplate
 				.exchange(serviceUrl + API_PLACEMENTS, HttpMethod.PUT, httpEntity, new ParameterizedTypeReference<PlacementDetailsDTO>() {})
 				.getBody();
+	}
+
+	public List<PlacementDetailsDTO> getPlacementForTrainee(Long traineeId) {
+		String uri = String.format(API_TRAINEE_PLACEMENTS, traineeId);
+		return tcsRestTemplate.exchange(serviceUrl + uri,
+				HttpMethod.GET, null, new ParameterizedTypeReference<List<PlacementDetailsDTO>>() {}).getBody();
 	}
 
 	public Void deletePlacement(Long id) {


### PR DESCRIPTION
- getPlacementForTrainee method implemented in BE
- This is done to because the generic-upload service needs to be able to get all the placements associated with a trainee record and perform some business-driven logic on them.