### PR TITLE
[TISNEW-2364] - Foreign key checks set/unset

### DIFF
--- a/tcs-service/src/main/resources/db/migration/V4.06__update_programmeMembership.sql
+++ b/tcs-service/src/main/resources/db/migration/V4.06__update_programmeMembership.sql
@@ -1,3 +1,4 @@
+SET FOREIGN_KEY_CHECKS = 0;
 UPDATE ProgrammeMembership SET personid=5877 where id=63;
 UPDATE ProgrammeMembership SET personid=31959 where id=2518;
 UPDATE ProgrammeMembership SET personid=40403 where id=2646;
@@ -1045,3 +1046,4 @@ UPDATE ProgrammeMembership SET personid=165855 where id=282333;
 UPDATE ProgrammeMembership SET personid=248578 where id=282339;
 UPDATE ProgrammeMembership SET personid=207918 where id=282655;
 UPDATE ProgrammeMembership SET personid=253219 where id=282972;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/tcs-service/src/main/resources/db/migration/V4.07__update_placements.sql
+++ b/tcs-service/src/main/resources/db/migration/V4.07__update_placements.sql
@@ -1,3 +1,4 @@
+SET FOREIGN_KEY_CHECKS = 0;
 UPDATE Placement SET traineeid=80166 where id=7644;
 UPDATE Placement SET traineeid=5877 where id=8317;
 UPDATE Placement SET traineeid=104180 where id=8835;
@@ -5258,3 +5259,4 @@ UPDATE Placement SET traineeid=253219 where id=1603716;
 UPDATE Placement SET traineeid=198268 where id=1607156;
 UPDATE Placement SET traineeid=247494 where id=1609297;
 UPDATE Placement SET traineeid=253343 where id=1611597;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/tcs-service/src/main/resources/db/migration/V4.08__update_qualifications.sql
+++ b/tcs-service/src/main/resources/db/migration/V4.08__update_qualifications.sql
@@ -1,3 +1,4 @@
+SET FOREIGN_KEY_CHECKS = 0;
 UPDATE Qualification SET personid=80166 where id=1772;
 UPDATE Qualification SET personid=25568 where id=10494;
 UPDATE Qualification SET personid=31713 where id=12083;
@@ -1424,3 +1425,4 @@ UPDATE Qualification SET personid=5877 where id=245780;
 UPDATE Qualification SET personid=46444 where id=245789;
 UPDATE Qualification SET personid=250495 where id=245796;
 UPDATE Qualification SET personid=253400 where id=245870;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/tcs-service/src/main/resources/db/migration/V4.09__update_documents.sql
+++ b/tcs-service/src/main/resources/db/migration/V4.09__update_documents.sql
@@ -1,3 +1,4 @@
+SET FOREIGN_KEY_CHECKS = 0;
 UPDATE Document SET personId=688 where personId=145934;
 UPDATE Document SET personId=688 where personId=145934;
 UPDATE Document SET personId=1279 where personId=198325;
@@ -10291,3 +10292,4 @@ UPDATE Document SET personId=254966 where personId=73510;
 UPDATE Document SET personId=254966 where personId=73510;
 UPDATE Document SET personId=254966 where personId=73510;
 UPDATE Document SET personId=254966 where personId=73510;
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
-Foreign key checking to fix Error: Cannot add or update a child row: a foreign key constraint fails (`tcs`.`ProgrammeMembership`, CONSTRAINT `fk_ProgrammeMembership_person_id` FOREIGN KEY (`personId`) REFERENCES `Person` (`id`))
