### PR TITLE
Remove end-to-end tests from TCS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,10 +92,6 @@ node {
             }
           }
 
-          stage('End-to-end Tests') {
-            build job: 'e2e-tests'
-          }
-
           milestone 5
 
           stage('Approval') {


### PR DESCRIPTION
They're currently blocking TCS from building. During standup on 11/12/18
it was decided that we remove them from the build entirely.

Signed-off-by: Chris Mills <me@christophermills.co.uk>