### PR TITLE
fix for trust users not being able to see posts that are linked to th…

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>4.1.3</version>
+  <version>4.1.4</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PersonPlacementEmployingBodyTrustJob.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PersonPlacementEmployingBodyTrustJob.java
@@ -44,7 +44,7 @@ public class PersonPlacementEmployingBodyTrustJob extends TrustAdminSyncJobTempl
     private SqlQuerySupplier sqlQuerySupplier;
 
     @Scheduled(cron = "0 10 0 * * *")
-    @SchedulerLock(name = "personTrustScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
+    @SchedulerLock(name = "personTrustEmployingBodyScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
     @ManagedOperation(description = "Run sync of the PersonTrust table with Person to Placement EmployingBody")
     public void PersonPlacementEmployingBodyFullSync() {
         runSyncJob();

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PersonPlacementTrainingBodyTrustJob.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PersonPlacementTrainingBodyTrustJob.java
@@ -41,7 +41,7 @@ public class PersonPlacementTrainingBodyTrustJob extends TrustAdminSyncJobTempla
     private SqlQuerySupplier sqlQuerySupplier;
 
     @Scheduled(cron = "0 30 0 * * *")
-    @SchedulerLock(name = "personTrustScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
+    @SchedulerLock(name = "personTrustTrainingBodyScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
     @ManagedOperation(description = "Run sync of the PersonTrust table with Person to Placement TrainingBody")
     public void PersonPlacementTrainingBodyFullSync() {
         runSyncJob();

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PostEmployingBodyTrustJob.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PostEmployingBodyTrustJob.java
@@ -45,7 +45,7 @@ public class PostEmployingBodyTrustJob extends TrustAdminSyncJobTemplate<PostTru
 
 
   @Scheduled(cron = "0 10 1 * * *")
-  @SchedulerLock(name = "postTrustScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
+  @SchedulerLock(name = "postTrustEmployingBodyScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
   @ManagedOperation(description = "Run sync of the PostTrust table with Post to Employing Body Trust")
   public void PostEmployingBodyTrustFullSync() {
     runSyncJob();

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PostTrainingBodyTrustJob.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/job/PostTrainingBodyTrustJob.java
@@ -42,7 +42,7 @@ public class PostTrainingBodyTrustJob extends TrustAdminSyncJobTemplate<PostTrus
 
 
   @Scheduled(cron = "0 20 1 * * *")
-  @SchedulerLock(name = "postTrustScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
+  @SchedulerLock(name = "postTrustTrainingBodyScheduledTask", lockAtLeastFor = FIFTEEN_MIN, lockAtMostFor = FIFTEEN_MIN)
   @ManagedOperation(description = "Run sync of the PostTrust table with Post to Training Body Trust")
   public void PostTrainingBodyTrustFullSync() {
     runSyncJob();

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/repository/SpecialtyRepository.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/repository/SpecialtyRepository.java
@@ -42,6 +42,14 @@ public interface SpecialtyRepository extends JpaRepository<Specialty, Long>, Jpa
    */
   Page<Specialty> findSpecialtyDistinctByCurriculaProgrammesIdAndNameContainingIgnoreCaseAndStatusIs(Long programmeId, String name, Status status, Pageable pageable);
 
+  /**
+   * Get a Page of Specialties linked to a Post whereby the Post is linked to a Programme Id
+   *
+   * @param programmeId The Programme Id
+   * @param status      The status which the Specialty needs to be in
+   * @param pageable    Pageable containing sort and paging information
+   * @return A Page of Specialties found
+   */
   @Query("SELECT DISTINCT sp " +
       "FROM Specialty sp " +
       "JOIN sp.posts psp " +
@@ -49,8 +57,17 @@ public interface SpecialtyRepository extends JpaRepository<Specialty, Long>, Jpa
       "JOIN p.programmes pr " +
       "WHERE pr.id = :programmeId " +
       "AND sp.status = :status ")
-  Page<Specialty> findSpecialtiesByProgrammeId(@Param("programmeId") Long programmeId, @Param("status") Status stats, Pageable pageable);
+  Page<Specialty> findSpecialtiesByProgrammeId(@Param("programmeId") Long programmeId, @Param("status") Status status, Pageable pageable);
 
+  /**
+   * Get a Page of Specialties linked to a Post whereby the Post is linked to a Programme Id and the Specialty name is like the provided query
+   *
+   * @param programmeId The Programme Id
+   * @param query       The name of the Specialty to look for
+   * @param status      The status of the Specialty needs to be in
+   * @param pageable    Pageable containing sort and paging information
+   * @return A Page of Specialties found
+   */
   @Query("SELECT DISTINCT sp " +
       "FROM Specialty sp " +
       "JOIN sp.posts psp " +
@@ -60,7 +77,7 @@ public interface SpecialtyRepository extends JpaRepository<Specialty, Long>, Jpa
       "AND sp.status = :status " +
       "AND sp.name LIKE %:query%")
   Page<Specialty> findSpecialtiesByProgrammeIdAndName(@Param("programmeId") Long programmeId, @Param("query") String query,
-                                                      @Param("status") Status stats, Pageable pageable);
+                                                      @Param("status") Status status, Pageable pageable);
 
   /**
    * Get a Set of Specialties that a trainee is on


### PR DESCRIPTION
…eir trust via the training body trust. turnt out that the scheduled job, when split into 2, the names werent changed and the times where too close, 1:10 and 1:20 with a lock of at least 15 minutes which meant that the second run wouldnt happen