### PR TITLE
Update Post Grade, Site and Speciality DTOs

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>5.0.2</version>
+  <version>5.1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PostGradeDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PostGradeDTO.java
@@ -1,8 +1,8 @@
 package com.transformuk.hee.tis.tcs.api.dto;
 
 import com.transformuk.hee.tis.tcs.api.enumeration.PostGradeType;
-
 import java.io.Serializable;
+import java.util.Objects;
 
 public class PostGradeDTO implements Serializable {
 
@@ -11,6 +11,19 @@ public class PostGradeDTO implements Serializable {
   private Long gradeId;
   private PostGradeType postGradeType;
 
+  /**
+   * @deprecated Use {@link #PostGradeDTO(Long, Long, PostGradeType)} instead.
+   */
+  @Deprecated()
+  public PostGradeDTO() {
+
+  }
+
+  public PostGradeDTO(Long postId, Long gradeId, PostGradeType postGradeType) {
+    this.postId = postId;
+    this.gradeId = gradeId;
+    this.postGradeType = postGradeType;
+  }
 
   public Long getId() {
     return id;
@@ -46,31 +59,36 @@ public class PostGradeDTO implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     PostGradeDTO that = (PostGradeDTO) o;
 
-    if (postId != null ? !postId.equals(that.postId) : that.postId != null) return false;
-    if (gradeId != null ? !gradeId.equals(that.gradeId) : that.gradeId != null) return false;
-    return postGradeType == that.postGradeType;
+    if (!Objects.equals(postId, that.postId)) {
+      return false;
+    }
+    if (!Objects.equals(gradeId, that.gradeId)) {
+      return false;
+    }
+    return Objects.equals(postGradeType, that.postGradeType);
   }
 
   @Override
   public int hashCode() {
-    int result = postId != null ? postId.hashCode() : 0;
-    result = 31 * result + (gradeId != null ? gradeId.hashCode() : 0);
-    result = 31 * result + (postGradeType != null ? postGradeType.hashCode() : 0);
-    return result;
+    return Objects.hash(postId, gradeId, postGradeType);
   }
 
   @Override
   public String toString() {
     return "PostGradeDTO{" +
-        "id=" + id +
-        ", postId=" + postId +
-        ", gradeId='" + gradeId + '\'' +
-        ", postGradeType=" + postGradeType +
-        '}';
+      "id=" + id +
+      ", postId=" + postId +
+      ", gradeId='" + gradeId + '\'' +
+      ", postGradeType=" + postGradeType +
+      '}';
   }
 }

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PostSiteDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PostSiteDTO.java
@@ -1,8 +1,8 @@
 package com.transformuk.hee.tis.tcs.api.dto;
 
 import com.transformuk.hee.tis.tcs.api.enumeration.PostSiteType;
-
 import java.io.Serializable;
+import java.util.Objects;
 
 public class PostSiteDTO implements Serializable {
 
@@ -10,6 +10,20 @@ public class PostSiteDTO implements Serializable {
   private Long postId;
   private Long siteId;
   private PostSiteType postSiteType;
+
+  /**
+   * @deprecated Use {@link #PostSiteDTO(Long, Long, PostSiteType)} instead.
+   */
+  @Deprecated
+  public PostSiteDTO() {
+
+  }
+
+  public PostSiteDTO(Long postId, Long siteId, PostSiteType postSiteType) {
+    this.postId = postId;
+    this.siteId = siteId;
+    this.postSiteType = postSiteType;
+  }
 
   public Long getId() {
     return id;
@@ -45,31 +59,36 @@ public class PostSiteDTO implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
-    PostSiteDTO siteDTO = (PostSiteDTO) o;
+    PostSiteDTO that = (PostSiteDTO) o;
 
-    if (postId != null ? !postId.equals(siteDTO.postId) : siteDTO.postId != null) return false;
-    if (siteId != null ? !siteId.equals(siteDTO.siteId) : siteDTO.siteId != null) return false;
-    return postSiteType == siteDTO.postSiteType;
+    if (!Objects.equals(postId, that.postId)) {
+      return false;
+    }
+    if (!Objects.equals(siteId, that.siteId)) {
+      return false;
+    }
+    return Objects.equals(postSiteType, that.postSiteType);
   }
 
   @Override
   public int hashCode() {
-    int result = postId != null ? postId.hashCode() : 0;
-    result = 31 * result + (siteId != null ? siteId.hashCode() : 0);
-    result = 31 * result + (postSiteType != null ? postSiteType.hashCode() : 0);
-    return result;
+    return Objects.hash(postId, siteId, postSiteType);
   }
 
   @Override
   public String toString() {
     return "PostSiteDTO{" +
-        "id=" + id +
-        ", postId=" + postId +
-        ", siteId='" + siteId + '\'' +
-        ", postSiteType=" + postSiteType +
-        '}';
+      "id=" + id +
+      ", postId=" + postId +
+      ", siteId='" + siteId + '\'' +
+      ", postSiteType=" + postSiteType +
+      '}';
   }
 }

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PostSpecialtyDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/PostSpecialtyDTO.java
@@ -1,8 +1,8 @@
 package com.transformuk.hee.tis.tcs.api.dto;
 
 import com.transformuk.hee.tis.tcs.api.enumeration.PostSpecialtyType;
-
 import java.io.Serializable;
+import java.util.Objects;
 
 public class PostSpecialtyDTO implements Serializable {
 
@@ -10,6 +10,21 @@ public class PostSpecialtyDTO implements Serializable {
   private Long postId;
   private SpecialtyDTO specialty;
   private PostSpecialtyType postSpecialtyType;
+
+  /**
+   * @deprecated Use {@link #PostSpecialtyDTO(Long, SpecialtyDTO, PostSpecialtyType)} instead.
+   */
+  @Deprecated
+  public PostSpecialtyDTO() {
+
+  }
+
+  public PostSpecialtyDTO(Long postId, SpecialtyDTO specialty,
+    PostSpecialtyType postSpecialtyType) {
+    this.postId = postId;
+    this.specialty = specialty;
+    this.postSpecialtyType = postSpecialtyType;
+  }
 
   public Long getId() {
     return id;
@@ -45,31 +60,36 @@ public class PostSpecialtyDTO implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     PostSpecialtyDTO that = (PostSpecialtyDTO) o;
 
-    if (postId != null ? !postId.equals(that.postId) : that.postId != null) return false;
-    if (specialty != null ? !specialty.equals(that.specialty) : that.specialty != null) return false;
-    return postSpecialtyType == that.postSpecialtyType;
+    if (!Objects.equals(postId, that.postId)) {
+      return false;
+    }
+    if (!Objects.equals(specialty, that.specialty)) {
+      return false;
+    }
+    return Objects.equals(postSpecialtyType, that.postSpecialtyType);
   }
 
   @Override
   public int hashCode() {
-    int result = postId != null ? postId.hashCode() : 0;
-    result = 31 * result + (specialty != null ? specialty.hashCode() : 0);
-    result = 31 * result + (postSpecialtyType != null ? postSpecialtyType.hashCode() : 0);
-    return result;
+    return Objects.hash(postId, specialty, postSpecialtyType);
   }
 
   @Override
   public String toString() {
     return "PostSpecialtyDTO{" +
-        "id=" + id +
-        ", postId=" + postId +
-        ", specialty=" + specialty +
-        ", postSpecialtyType=" + postSpecialtyType +
-        '}';
+      "id=" + id +
+      ", postId=" + postId +
+      ", specialty=" + specialty +
+      ", postSpecialtyType=" + postSpecialtyType +
+      '}';
   }
 }

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>4.0.2</version>
+  <version>4.1.0</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>5.0.2</version>
+      <version>5.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
Update PostGradeDTO, PostSiteDTO and PostSpecialityDTO to add a
constructor which accepts the common fields, this removes the need to
call the same setters whenever the DTO is initialized.

Update tcs-api's pom.xml to bump the minor version.

Update tcs-client's pom.xml to update the tcs-api dependency and bump
its own minor version.