### PR TITLE
Fix deletion of placements with other sites

### DIFF
--- a/tcs-service/src/main/resources/db/migration/V3.95__create_placementsite.sql
+++ b/tcs-service/src/main/resources/db/migration/V3.95__create_placementsite.sql
@@ -4,7 +4,7 @@ CREATE TABLE PlacementSite (
    siteId bigint(20) NULL DEFAULT NULL,
    placementSiteType varchar(255) NULL DEFAULT NULL,
    PRIMARY KEY (`id`),
-   CONSTRAINT fk_placement_site_id FOREIGN KEY (placementId) REFERENCES Placement (id)
+   CONSTRAINT fk_placement_site_id FOREIGN KEY (placementId) REFERENCES Placement (id) ON DELETE CASCADE
 )ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 


### PR DESCRIPTION
When deleting placements with other sites an error is displayed due to a
foreign key violation related to the PlacementSite table.
Update V3.95__create_placementsite.sql to include `ON DELETE CASCADE` to
the placement ID foreign key.