### PR TITLE
Fix for  issue with PPT not rendering Anaesthetics placements

### DIFF
--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementPlannerServiceImp.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementPlannerServiceImp.java
@@ -123,10 +123,12 @@ public class PlacementPlannerServiceImp {
             postsToPlacement.put(post, placements);
           }
 
-          // if placements are within the given timeline, include them in the post
-          if ((placement.getDateFrom().isBefore(toDate) || placement.getDateFrom().isEqual(toDate)) &&
-              (placement.getDateTo().isAfter(fromDate)) || placement.getDateTo().isEqual(fromDate)) {
-            placements.add(placement);
+          // if placements are within the given timeline and have placement start and end dates, include them in the post
+          if (placement.getDateFrom() != null || placement.getDateTo() != null) {
+            if ((placement.getDateFrom().isBefore(toDate) || placement.getDateFrom().isEqual(toDate)) &&
+                (placement.getDateTo().isAfter(fromDate)) || placement.getDateTo().isEqual(fromDate)) {
+              placements.add(placement);
+            }
           }
         } else {
           LOGGER.info("Site missing");


### PR DESCRIPTION
https://hee-tis.atlassian.net/browse/TISNEW-2975

- The PPT throws an error when a user attemps to render Placements within a certain date range.
- The error is due to the fact that we have Placements in our database that have either a missing start or end date.
- We have addressed this by only returning Placements within the specified range that have both sets of dates.
