### PR TITLE
Changed ElasticSearch query to use new position of programmeId

### DIFF
--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
@@ -73,7 +73,7 @@ public class PersonElasticSearchService {
   public Page<PersonViewDTO> findPeopleOnProgramme(Long programmeId, String searchQuery, Pageable pageable) {
     BoolQueryBuilder query = new BoolQueryBuilder();
 
-    query = query.must(new MatchQueryBuilder("programmeId", programmeId));
+    query = query.must(new NestedQueryBuilder("programmeMemberships", new MatchQueryBuilder("programmeMemberships.programmeId", programmeId), ScoreMode.None));
     query = query.must(new MatchQueryBuilder("status", CURRENT_STATUS));
 
     if (StringUtils.isNotEmpty(searchQuery)) {


### PR DESCRIPTION
[TISNEW-3140] Searching for people in the planner returns no results

[TISNEW-3140]: https://hee-tis.atlassian.net/browse/TISNEW-3140