### PR TITLE
Remove NI number from people v2 API result

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>4.5.2</version>
+  <version>4.5.3</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PersonResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PersonResource.java
@@ -8,6 +8,7 @@ import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonLiteDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonV2DTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonViewDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PersonalDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementSummaryDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementViewDTO;
 import com.transformuk.hee.tis.tcs.api.dto.validation.Create;
@@ -351,6 +352,13 @@ public class PersonResource {
     personService.canLoggedInUserViewOrAmend(id);
 
     PersonV2DTO personDTO = personService.findPersonV2WithProgrammeMembershipsSorted(id);
+
+    // Remove the national insurance number form personal details, as it is not needed in the UI.
+    PersonalDetailsDTO personalDetailsDto = personDTO.getPersonalDetails();
+    if (personalDetailsDto != null) {
+        personalDetailsDto.setNationalInsuranceNumber(null);
+    }
+
     return ResponseUtil.wrapOrNotFound(Optional.ofNullable(personDTO));
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PersonResourceTest2.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PersonResourceTest2.java
@@ -16,6 +16,7 @@ import com.transformuk.hee.tis.tcs.TestUtils;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonV2DTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonViewDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PersonalDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.Application;
 import com.transformuk.hee.tis.tcs.service.api.decorator.PersonViewDecorator;
@@ -263,6 +264,25 @@ public class PersonResourceTest2 {
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.qualifications").doesNotExist());
+
+    verify(personServiceMock).findPersonV2WithProgrammeMembershipsSorted(personId);
+  }
+
+  @Test
+  public void getPersonV2ShouldReturnPersonWithNoNationalInsuranceNumber() throws Exception {
+    long personId = 1L;
+    PersonV2DTO foundPerson = new PersonV2DTO();
+    PersonalDetailsDTO personalDetailsDto = new PersonalDetailsDTO();
+    personalDetailsDto.setNationalInsuranceNumber("niNumber");
+    foundPerson.setPersonalDetails(personalDetailsDto);
+
+    when(personServiceMock.findPersonV2WithProgrammeMembershipsSorted(personId))
+        .thenReturn(foundPerson);
+
+    mockMvc.perform(get("/api/people/v2/{id}", personId)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.personalDetails.nationalInsuranceNumber").isEmpty());
 
     verify(personServiceMock).findPersonV2WithProgrammeMembershipsSorted(personId);
   }


### PR DESCRIPTION
The national insurance number is not needed for the TIS UI, so should
not be included in the returned payload.
Update the v2 people api endpoint to clear the national insurance
number.