### PR TITLE
Fix placement queries for esr notification service

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module that would ideally be further decomposed into </description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/PlacementRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/PlacementRepository.java
@@ -72,22 +72,24 @@ public interface PlacementRepository extends JpaRepository<Placement, Long> {
   @Query(value =
       "SELECT pl.* FROM Placement pl WHERE pl.placementType IN (:placementTypes) AND postId IN " +
           "(SELECT id FROM Post WHERE nationalPostNumber IN (:deaneryNumbers))" +
-          "AND (dateFrom >= :futureStartDate AND dateFrom < :futureEndDate)", nativeQuery = true)
+          "AND (dateFrom >= :futureStartDate AND dateFrom < :futureEndDate)" +
+          "AND lifecycleState IN (:lifecycleState)", nativeQuery = true)
   List<Placement> findFuturePlacementsForPosts(
       @Param("futureStartDate") LocalDate futureStartDate,
       @Param("futureEndDate") LocalDate futureEndDate,
       @Param("deaneryNumbers") List<String> deaneryNumbers,
-      @Param("placementTypes") List<String> placementTypes);
+      @Param("placementTypes") List<String> placementTypes,
+      @Param("lifecycleState") List<String> lifecycleState);
 
   @Query(value =
       "SELECT pl.* FROM Placement pl WHERE pl.placementType IN (:placementTypes) AND postId IN " +
           "(SELECT id FROM Post WHERE nationalPostNumber IN (:deaneryNumbers))" +
-          "AND (dateFrom <= :asOfDate AND dateTo >= :asOfDate)", nativeQuery = true)
+          "AND (dateFrom <= :asOfDate AND dateTo >= :asOfDate) AND lifecycleState IN (:lifecycleState)", nativeQuery = true)
   List<Placement> findCurrentPlacementsForPosts(
       @Param("asOfDate") LocalDate asOfDate,
       @Param("deaneryNumbers") List<String> deaneryNumbers,
-      @Param("placementTypes") List<String> placementTypes);
-
+      @Param("placementTypes") List<String> placementTypes,
+      @Param("lifecycleState") List<String> lifecycleState);
 
   @Query(value =
       "select pl.* from Placement pl where traineeId = :traineeId and pl.placementType IN (:placementTypes) "

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>5.6.1</version>
+  <version>5.6.2</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/EsrNotificationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/EsrNotificationServiceImpl.java
@@ -12,6 +12,7 @@ import com.transformuk.hee.tis.reference.client.ReferenceService;
 import com.transformuk.hee.tis.tcs.api.dto.EsrNotificationDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.LifecycleState;
 import com.transformuk.hee.tis.tcs.service.api.util.ObjectCloner;
 import com.transformuk.hee.tis.tcs.service.model.ContactDetails;
 import com.transformuk.hee.tis.tcs.service.model.EsrNotification;
@@ -23,15 +24,8 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.EsrNotificationMapper;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
@@ -50,6 +44,7 @@ public class EsrNotificationServiceImpl implements EsrNotificationService {
   private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.#");
   private static final List<String> placementTypes = asList("In post", "In Post - Acting Up",
       "In post - Extension", "Parental Leave", "Long-term sick", "Suspended", "Phased Return");
+  private static final List<String> lifecycleStates = asList(LifecycleState.APPROVED.name());
   private final PlacementRepository placementRepository;
   private EsrNotificationRepository esrNotificationRepository;
   private EsrNotificationMapper esrNotificationMapper;
@@ -259,7 +254,7 @@ public class EsrNotificationServiceImpl implements EsrNotificationService {
       Map<Long, String> siteIdsToKnownAs) {
 
     List<Placement> currentPlacements = placementRepository.findCurrentPlacementsForPosts(
-        asOfDate, Collections.singletonList(nationalPostNumber), placementTypes);
+        asOfDate, Collections.singletonList(nationalPostNumber), placementTypes, lifecycleStates);
     LOG.info("Identified {} current Placements for post {} as of date {}",
         isNotEmpty(currentPlacements) ? currentPlacements.size() : 0, nationalPostNumber, asOfDate);
 
@@ -287,7 +282,7 @@ public class EsrNotificationServiceImpl implements EsrNotificationService {
 
     List<Placement> futurePlacements = placementRepository.findFuturePlacementsForPosts(
         asOfDate.plusDays(2), getNotificationPeriodEndDate(asOfDate),
-        Collections.singletonList(nationalPostNumber), placementTypes);
+        Collections.singletonList(nationalPostNumber), placementTypes, lifecycleStates);
     LOG.info("Identified {} future Placements for post {} as of date {}", futurePlacements.size(),
         nationalPostNumber, asOfDate);
 
@@ -316,7 +311,7 @@ public class EsrNotificationServiceImpl implements EsrNotificationService {
     String nationalPostNumber = newFuturePlacement.getPost().getNationalPostNumber();
 
     List<Placement> currentPlacements = placementRepository.findCurrentPlacementsForPosts(
-        asOfDate, Collections.singletonList(nationalPostNumber), placementTypes);
+        asOfDate, Collections.singletonList(nationalPostNumber), placementTypes, lifecycleStates);
 
     LOG.info("Identified {} current Placements for post {} as of date {}", currentPlacements.size(),
         nationalPostNumber, asOfDate);
@@ -361,10 +356,10 @@ public class EsrNotificationServiceImpl implements EsrNotificationService {
     LocalDate asOfDate = LocalDate.now();
     String nationalPostNumber = placementToDelete.getPost().getNationalPostNumber();
     List<Placement> currentPlacements = placementRepository.findCurrentPlacementsForPosts(asOfDate,
-        Collections.singletonList(nationalPostNumber), placementTypes);
+        Collections.singletonList(nationalPostNumber), placementTypes, lifecycleStates);
     List<Placement> futurePlacements = placementRepository
         .findFuturePlacementsForPosts(asOfDate, asOfDate.plusMonths(3),
-            Collections.singletonList(nationalPostNumber), placementTypes);
+            Collections.singletonList(nationalPostNumber), placementTypes, lifecycleStates);
 
     Placement currentPlacement = null;
     Placement futurePlacement = null;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PlacementResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PlacementResourceIntTest.java
@@ -983,6 +983,7 @@ public class PlacementResourceIntTest {
     nextPlacement.setDateTo(tomorrow.plusMonths(3));
     nextPlacement.setPostId(post.getId());
     nextPlacement.setPlacementType("In Post");
+    nextPlacement.setLifecycleState(LifecycleState.APPROVED);
     placementDetailsRepository.saveAndFlush(nextPlacement);
 
     final ContactDetails cd1 = createContactDetails(nextPlacement, "NextTraineeFN",

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/EsrNotificationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/EsrNotificationServiceImplTest.java
@@ -15,6 +15,7 @@ import com.transformuk.hee.tis.reference.api.dto.SiteDTO;
 import com.transformuk.hee.tis.reference.client.ReferenceService;
 import com.transformuk.hee.tis.tcs.api.dto.EsrNotificationDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.LifecycleState;
 import com.transformuk.hee.tis.tcs.service.model.ContactDetails;
 import com.transformuk.hee.tis.tcs.service.model.EsrNotification;
 import com.transformuk.hee.tis.tcs.service.model.Person;
@@ -45,6 +46,7 @@ public class EsrNotificationServiceImplTest {
   private static final List<String> placementTypes = Arrays
       .asList("In post", "In Post - Acting Up", "In post - Extension", "Parental Leave",
           "Long-term sick", "Suspended", "Phased Return");
+  private static final List<String> lifecycleStates = asList(LifecycleState.APPROVED.name());
   @InjectMocks
   private EsrNotificationServiceImpl testService;
   @Mock
@@ -404,7 +406,7 @@ public class EsrNotificationServiceImplTest {
     Placement placement = aPlacement(deaneryPostNumber);
 
     when(placementRepository.findCurrentPlacementsForPosts(asOfDate,
-        singletonList(deaneryPostNumber), placementTypes)).thenReturn(emptyList());
+        singletonList(deaneryPostNumber), placementTypes, lifecycleStates)).thenReturn(emptyList());
     EsrNotification returnedNotification = anEsrNotification(deaneryPostNumber);
     when(esrNotificationRepository.saveAll(any(List.class))).thenReturn(
         singletonList(returnedNotification));
@@ -419,7 +421,7 @@ public class EsrNotificationServiceImplTest {
         .isEqualTo(returnedNotification.getDeaneryPostNumber());
 
     verify(placementRepository).findCurrentPlacementsForPosts(asOfDate,
-        singletonList(deaneryPostNumber), placementTypes);
+        singletonList(deaneryPostNumber), placementTypes, lifecycleStates);
     verify(esrNotificationRepository).saveAll(any(List.class));
   }
 
@@ -440,7 +442,7 @@ public class EsrNotificationServiceImplTest {
     currentPlacement.setPlacementWholeTimeEquivalent(new BigDecimal(1.0F));
 
     when(placementRepository.findCurrentPlacementsForPosts(
-        asOfDate, singletonList(deaneryPostNumber), placementTypes))
+        asOfDate, singletonList(deaneryPostNumber), placementTypes, lifecycleStates))
         .thenReturn(singletonList(currentPlacement));
     EsrNotification returnedNotification = anEsrNotification(deaneryPostNumber);
     when(esrNotificationRepository.saveAll(savedEsrNotificationsCaptor.capture())).thenReturn(
@@ -465,7 +467,7 @@ public class EsrNotificationServiceImplTest {
         .isEqualTo(placement.getPlacementWholeTimeEquivalent().doubleValue());
 
     verify(placementRepository).findCurrentPlacementsForPosts(asOfDate,
-        singletonList(deaneryPostNumber), placementTypes);
+        singletonList(deaneryPostNumber), placementTypes, lifecycleStates);
     verify(esrNotificationRepository).saveAll(any(List.class));
   }
 
@@ -484,7 +486,7 @@ public class EsrNotificationServiceImplTest {
     currentPlacement.setSiteCode(null);
 
     when(placementRepository.findCurrentPlacementsForPosts(
-        asOfDate, singletonList(deaneryPostNumber), placementTypes))
+        asOfDate, singletonList(deaneryPostNumber), placementTypes, lifecycleStates))
         .thenReturn(singletonList(currentPlacement));
     EsrNotification returnedNotification = anEsrNotification(deaneryPostNumber);
 
@@ -501,7 +503,7 @@ public class EsrNotificationServiceImplTest {
         .isEqualTo(returnedNotification.getDeaneryPostNumber());
 
     verify(placementRepository).findCurrentPlacementsForPosts(asOfDate,
-        singletonList(deaneryPostNumber), placementTypes);
+        singletonList(deaneryPostNumber), placementTypes, lifecycleStates);
     verify(esrNotificationRepository).saveAll(any(List.class));
   }
 


### PR DESCRIPTION
When EsrNotificationService creates new notifications, it also queries from Placement table to get current or future placements and then maps the dateFrom or dateTo fields in the records to the new notification. 
So I think I need to filter the Approved ones.