### PR TITLE
Disable surefire test forking on Windows OS

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -89,6 +89,7 @@
     <sonar.tests>${project.basedir}/src/test/</sonar.tests>
 
     <spock.version>1.1-groovy-2.4</spock.version>
+    <surefire.forkCount>1</surefire.forkCount>
     <!-- Spring properties -->
     <tis.shared.modules.version>2.3.0</tis.shared.modules.version>
     <undertow.version>2.0.15.Final</undertow.version>
@@ -484,6 +485,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <forkCount>${surefire.forkCount}</forkCount>
           <!-- Force alphabetical order to have a reproducible build -->
           <runOrder>alphabetical</runOrder>
           <includes>
@@ -586,6 +588,17 @@
           <version>${mapstruct.version}</version>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>platform-windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <surefire.forkCount>0</surefire.forkCount>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
When running tcs-service tests in Windows the tests will always fail due
to an error creating surefire forks for parallel test runs. Set forkMode
to "never" when the tests are being ran on Windows OS.