### PR TITLE
fix: Avoid cyclic reference from mapper

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.7.3</version>
+  <version>6.7.4</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/QualificationMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/QualificationMapper.java
@@ -1,14 +1,17 @@
 package com.transformuk.hee.tis.tcs.service.service.mapper;
 
+import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.QualificationDTO;
+import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.Qualification;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * Mapper for the entity Qualification and its DTO QualificationDTO.
  */
-@Mapper(componentModel = "spring", uses = {PersonMapper.class})
+@Mapper(componentModel = "spring")
 public interface QualificationMapper {
 
   QualificationDTO toDto(Qualification qualification);
@@ -18,4 +21,14 @@ public interface QualificationMapper {
   List<Qualification> toEntities(List<QualificationDTO> qualificationDtos);
 
   List<QualificationDTO> toDTOs(List<Qualification> qualifications);
+
+  // TODO: Look at other options to avoid cyclic mapping such as using @Context.
+  @Mapping(target = "programmeMemberships", ignore = true)
+  @Mapping(target = "qualifications", ignore = true)
+  PersonDTO personToPersonDto(Person person);
+
+  // TODO: Look at other options to avoid cyclic mapping such as using @Context.
+  @Mapping(target = "programmeMemberships", ignore = true)
+  @Mapping(target = "qualifications", ignore = true)
+  Person personDtoToPerson(PersonDTO personDto);
 }


### PR DESCRIPTION
The QualificationMapper and PersonMapper cause a cyclic mapping, remove
the PersonMapper usage from QualificationMapper to avoid this. Add
PersonDTO to/from Person mappings to the QualificationMapper as a
workaround.

TISNEW-3686