### PR TITLE
fix: bug - updating specialty deletes the PostSpecialty records

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -105,7 +105,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
   </properties>
 
-  <version>2.6.2</version>
+  <version>2.6.3</version>
 
   <build>
     <plugins>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
@@ -63,7 +63,8 @@ public class Specialty implements Serializable {
   @OneToMany(mappedBy = "specialty", fetch = FetchType.LAZY)
   private List<Curriculum> curricula;
 
-  @OneToMany(mappedBy = "specialty", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "specialty", cascade = {CascadeType.REMOVE,
+      CascadeType.REFRESH}, orphanRemoval = true)
   private Set<PostSpecialty> posts = new HashSet<>();
 
   @OneToMany(mappedBy = "specialty", fetch = FetchType.LAZY)

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.7.5</version>
+  <version>6.7.6</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.3</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
1. modify the CascadeType from All to Remove&Refresh on PostSpecialty set in Specialty to stop updating PostSpecialty on cascade.
2. add tests to validate if the PostSpecialty still exists after updating Specialty. Also have run it on old codes.

TISNEW-3854