### PR TITLE
fix: remove programmeMemberships attached to LeaveManagerApprovers

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.7.6</version>
+  <version>6.7.7</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 

--- a/tcs-service/src/main/resources/db/migration/V3.114__delete_programmeMembership_for_leaveManagerApprovers.sql
+++ b/tcs-service/src/main/resources/db/migration/V3.114__delete_programmeMembership_for_leaveManagerApprovers.sql
@@ -1,0 +1,3 @@
+DELETE FROM `ProgrammeMembership`
+WHERE `programmeId` = 18344
+OR `programmeId` = 18356;


### PR DESCRIPTION
There're 2 programmes named LeaveManagerApprovers: 18344 and 18356.

TISNEW-4200

Please don't merge it to prod yet. Need to let James and Ashley know before we do this.