### PR TITLE
fix: some Posts missing on PPT

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.7.12</version>
+  <version>6.7.13</version>
   <packaging>war</packaging>
   <name>tcs-service</name>
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementPlannerServiceImp.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementPlannerServiceImp.java
@@ -152,9 +152,7 @@ public class PlacementPlannerServiceImp {
           if (sitesToPosts.containsKey(siteDTO)) {
             Map<Post, List<Placement>> postListMap = sitesToPosts.get(siteDTO);
             if (!postListMap.containsKey(foundPost)) {
-              Map<Post, List<Placement>> emptyPlacementPosts = Maps.newHashMap();
-              emptyPlacementPosts.put(foundPost, Lists.newArrayList());
-              sitesToPosts.put(siteDTO, emptyPlacementPosts);
+              sitesToPosts.get(siteDTO).put(foundPost, Lists.newArrayList());
             }
           }
         }


### PR DESCRIPTION
The cause of the bug is when there's a post without placements exists, the codes creates a empty Post to overwrite the whole element in sitesToPosts map. 

TISNEW-3855