### PR TITLE
chore: Remove unused awaitility dependency

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -137,12 +137,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>${awaitility.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
       <version>5.2.4</version>
@@ -299,7 +293,6 @@
   <properties>
     <argLine>-Djava.security.egd=file:/dev/./urandom -Xmx1g</argLine>
     <assertj.version>3.6.2</assertj.version>
-    <awaitility.version>2.0.0</awaitility.version>
     <commons-io.version>2.5</commons-io.version>
     <commons-lang.version>3.5</commons-lang.version>
     <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>


### PR DESCRIPTION
The awaitility dependency was flagged by dependabot as needing an
upgrade, but it is not used.

NO-TICKET