### PR TITLE
chore: Remove keycloak url

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.11.6</version>
+  <version>6.11.7</version>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/tcs-service/src/main/resources/config/application-local.yml
+++ b/tcs-service/src/main/resources/config/application-local.yml
@@ -34,9 +34,9 @@ kc:
   client:
     id: ${KC_CLIENT_ID:api-tokens}
   server:
-    url: ${KC_SERVER_URL:https://dev-apps.tis.nhs.uk/auth/}
-  username: ${KC_USERNAME:tcs_trust_admin}
-  password: ${KC_PASSWORD:tcs_trust_admin}
+    url: ${KC_SERVER_URL:}
+  username: ${KC_USERNAME:}
+  password: ${KC_PASSWORD:}
   timeout: ${KC_TIMEOUT:10000}
 
 enable.es.search: true

--- a/tcs-service/src/test/resources/config/application.yml
+++ b/tcs-service/src/test/resources/config/application.yml
@@ -101,9 +101,9 @@ kc:
   client:
     id: ${KC_CLIENT_ID:api-tokens}
   server:
-    url: ${KC_SERVER_URL:https://dev-apps.tis.nhs.uk/auth/}
-  username: ${KC_USERNAME:tcs_trust_admin}
-  password: ${KC_PASSWORD:tcs_trust_admin}
+    url: ${KC_SERVER_URL:}
+  username: ${KC_USERNAME:}
+  password: ${KC_PASSWORD:}
   timeout: ${KC_TIMEOUT:10000}
 
 enable.es.search: false


### PR DESCRIPTION
The keycloak URL is pointing at the dev env when running tests, but
that env no longer exists. Update the config to default to an empty url
for KC.

NO-TICKET