### PR TITLE
fix: Create and update placement errors

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.13.0</version>
+  <version>2.13.1</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/PlacementSpecialtyPK.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/PlacementSpecialtyPK.java
@@ -11,9 +11,9 @@ public class PlacementSpecialtyPK implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private Placement placement;
+  private Long placement;
 
-  private Specialty specialty;
+  private Long specialty;
 
   @Override
   public boolean equals(Object o) {

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
Errors like `org.springframework.beans.ConversionNotSupportedException:
Failed to convert property value of type 'java.lang.Long' to required
type 'com.transformuk.hee.tis.tcs.service.model.Specialty' for property
'specialty'` are being thrown for create and update of placement.

Spring Data JPA is unable to correctly map the Specialty and Placement
for the PlacementSpecialtyPK object. A proposed solution to this is to
use the Long ID instead of the object in the PK object.

Open issue: https://jira.spring.io/browse/DATAJPA-1391

TISNEW-4806