### PR TITLE
feat: Add organization spring config profiles

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.14.2</version>
+  <version>6.14.3</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/resources/config/application-hee.yml
+++ b/tcs-service/src/main/resources/config/application-hee.yml
@@ -1,0 +1,3 @@
+spring:
+  flyway:
+    locations: classpath:db/migration/schema,classpath:db/migration/data/hee

--- a/tcs-service/src/main/resources/config/application-nimdta.yml
+++ b/tcs-service/src/main/resources/config/application-nimdta.yml
@@ -1,0 +1,3 @@
+spring:
+  flyway:
+    locations: classpath:db/migration/schema,classpath:db/migration/data/nimdta


### PR DESCRIPTION
To allow data migrations to run for only one organization two new
profiles are needed to be used in conjuction with the existing profiles.

TISNEW-5640