### PR TITLE
fix: Allow multiple flyway locations in config

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.14.3</version>
+  <version>6.14.4</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/FlywayConfig.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/FlywayConfig.java
@@ -40,7 +40,7 @@ public class FlywayConfig {
   Flyway flyway() {
     Flyway flyway = new Flyway();
     flyway.setBaselineOnMigrate(baseLineOnMigrate);
-    flyway.setLocations(migrationFilesLocations);
+    flyway.setLocations(migrationFilesLocations.split(","));
     flyway.setDataSource(url, user, password);
     flyway.setCleanOnValidationError(cleanOnValidationError);
     flyway.setOutOfOrder(outOfOrder);


### PR DESCRIPTION
The FlywayConfig was ignoring command separated locations, split the
string before setting the location in the config.

TISNEW-5640