### PR TITLE
fix: NPE when programme has null curricular set

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.15.1</version>
+  <version>6.15.2</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMapper.java
@@ -5,6 +5,7 @@ import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeCurriculum;
 import java.util.List;
+import java.util.Set;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
@@ -30,8 +31,13 @@ public interface ProgrammeMapper {
 
   @AfterMapping
   default void addProgrammeToCurricula(ProgrammeDTO source, @MappingTarget Programme target) {
-    for (ProgrammeCurriculum curriculum : target.getCurricula()) {
-      curriculum.setProgramme(target);
+    Set<ProgrammeCurriculum> curricula = target.getCurricula();
+
+    if (curricula != null) {
+
+      for (ProgrammeCurriculum curriculum : target.getCurricula()) {
+        curriculum.setProgramme(target);
+      }
     }
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMapperTest.java
@@ -1,0 +1,63 @@
+package com.transformuk.hee.tis.tcs.service.service.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.Sets;
+import com.transformuk.hee.tis.tcs.service.model.Programme;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeCurriculum;
+import java.util.Collections;
+import java.util.Iterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProgrammeMapperTest {
+
+  private ProgrammeMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ProgrammeMapperImpl();
+  }
+
+  @Test
+  void shouldAddProgrammeOnCurriculumWhenHasCurriculum() {
+    Programme target = new Programme();
+
+    ProgrammeCurriculum curriculum1 = new ProgrammeCurriculum(null, null, "1");
+    ProgrammeCurriculum curriculum2 = new ProgrammeCurriculum(null, null, "2");
+    target.setCurricula(Sets.newHashSet(curriculum1, curriculum2));
+
+    mapper.addProgrammeToCurricula(null, target);
+
+    assertThat("Unexpected number of curricula.", target.getCurricula().size(), is(2));
+    Iterator<ProgrammeCurriculum> curriculumIterator = target.getCurricula().iterator();
+
+    ProgrammeCurriculum curriculum = curriculumIterator.next();
+    assertThat("Unexpected curriculum programme.", curriculum.getProgramme(), is(target));
+
+    curriculum = curriculumIterator.next();
+    assertThat("Unexpected curriculum programme.", curriculum.getProgramme(), is(target));
+  }
+
+  @Test
+  void shouldNotAddProgrammeOnCurriculumWhenEmptyCurriculum() {
+    Programme target = new Programme();
+    target.setCurricula(Collections.emptySet());
+
+    mapper.addProgrammeToCurricula(null, target);
+
+    assertThat("Unexpected number of curricula.", target.getCurricula().size(), is(0));
+  }
+
+  @Test
+  void shouldNotAddProgrammeOnCurriculumWhenNullCurriculum() {
+    Programme target = new Programme();
+    target.setCurricula(null);
+
+    mapper.addProgrammeToCurricula(null, target);
+
+    assertThat("Unexpected curricula value.", target.getCurricula(), nullValue());
+  }
+}


### PR DESCRIPTION
When the Programme entity has a null value in the curricula field a NPE
is thrown, handle this scenario properly so that the logic is skipped
instead of failing.

TISNEW-3822