### PR TITLE
fix: Flyway migration error

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.15.3</version>
+  <version>6.15.4</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/resources/db/migration/schema/V2.6__TISDEV-2177_delete_dates_from_curricula.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V2.6__TISDEV-2177_delete_dates_from_curricula.sql
@@ -1,2 +1,2 @@
-ALTER TABLE Curriculum DROP COLUMN start;
-ALTER TABLE Curriculum DROP COLUMN end;
+ALTER TABLE `Curriculum` DROP COLUMN `start`;
+ALTER TABLE `Curriculum` DROP COLUMN `end`;


### PR DESCRIPTION
The flyway migration failed due to a keyword being used as a column key,
surround the table/column names with a backtick to avoid the issue.

TISNEW-3822