### PR TITLE
feat/handleDuplicateKeyOnProcedure

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.21.1</version>
+  <version>6.21.2</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/resources/db/migration/schema/V4.6__edit_build_person_localoffice_procedure.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.6__edit_build_person_localoffice_procedure.sql
@@ -1,0 +1,17 @@
+delimiter //
+drop procedure if exists build_person_localoffice//
+create procedure build_person_localoffice()
+begin
+
+	truncate table PersonOwner;
+
+	insert into PersonOwner(id,owner,rule)
+	select p.id, get_localoffice(id, 'LO') localoffice, get_localoffice(id, 'R') which_rule
+	from Person p
+	on duplicate key update
+	  id = p.id,
+	  owner = p.owner,
+	  rule = p.rule;
+
+end//
+delimiter ;


### PR DESCRIPTION
TIS21-1517

The procedure used to cause errors if a user tries to update a Placement while it's running (i.e. when the nightly PersonOwnerSyncJob runs) due to a duplicate key.

This should make the procedure more stable and handle a duplicate key as an update rather than an insert with the same primary key.