### PR TITLE
chore: Edit dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    rebase-strategy: disabled
     registries:
       - maven-jenkins
     reviewers:
@@ -21,7 +20,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    rebase-strategy: disabled
     reviewers:
       - Health-Education-England/full-stack
       - Health-Education-England/operations


### PR DESCRIPTION
The dependabot config file doesn't need declarations for each modules, just for the root.

TIS21-1356: Roll out new dependabot configs