### PR TITLE
chore: upgrade actions/setup-java to 2.1.0

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
+          distribution: adopt
           java-version: 11
 
       - name: Configure AWS credentials


### PR DESCRIPTION
The PR opened by dependabot to upgrade actions/setup-java from 1 to 2.1.0 got spammed with unrelated commits pulled in by mistake.

I opened a new PR to simply upgrade the dependency manually.
