### PR TITLE
fix: update trainee status when only lapsed PMs

### DIFF
--- a/tcs-service/src/main/resources/db/migration/schema/V4.7__update_person_status_with_lapsed_pms.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.7__update_person_status_with_lapsed_pms.sql
@@ -1,0 +1,6 @@
+UPDATE `Person` p
+SET `status` = 'INACTIVE'
+WHERE
+p.status <> 'INACTIVE' AND
+p.role NOT LIKE '%Leave.Approver.%' AND
+p.id NOT IN (SELECT `personId` FROM `ProgrammeMembership` pm WHERE `programmeEndDate` >= curdate() GROUP BY `personId`);


### PR DESCRIPTION
Assumptions:
1. 'lapsed programme memberships' will have a programmeEndDate before today (e.g. https://stage-apps.tis.nhs.uk/admin/people/person/137890/edit-programme)

2. 'leave approver' roles comprise both Leave.Approver.Administrator and Leave.Approver.NonAdministrator roles.

3. A person with a 'leave approver' role will be excluded from the set of trainees to update, regardless of any other roles they might have.

Note that the converse (setting status=CURRENT when current programme memberships exist) is not considered.

TIS21-1857