### PR TITLE
refactor: Remove logging of input via API

### DIFF
--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PersonResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PersonResource.java
@@ -253,11 +253,12 @@ public class PersonResource {
   public ResponseEntity<Collection<PersonLiteDTO>> getPersonsByRoleCategory(
       final Pageable pageable,
       @PathVariable("categoryId") final Long categoryId,
-      @RequestParam(value = "searchQuery", required = false) final String searchQuery) {
+      @RequestParam(value = "searchQuery", required = false) String searchQuery) {
+    searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
     log.info(
         "Received request to search '{}' with RoleCategory ID '{}', searchQuery '{}' and pageable '{}'",
         PersonLiteDTO.class.getSimpleName(), categoryId, searchQuery, pageable);
-    
+
     String searchQuerySanitised = RegExUtils.replaceAll(searchQuery, "[\n\r\t]", "_");
     log.debug("Accessing '{}' to search '{}' with RoleCategory ID '{}' and searchQuery '{}'",
         personService.getClass().getSimpleName(), PersonLiteDTO.class.getSimpleName(), categoryId,
@@ -510,7 +511,8 @@ public class PersonResource {
   @PatchMapping("/bulk-people")
   @PreAuthorize("hasPermission('tis:people::person:', 'Update')")
   public ResponseEntity<List<PersonDTO>> patchPeople(@RequestBody List<PersonDTO> personDtos) {
-    log.debug("REST request to patch People: {}", personDtos);
+    log.debug("REST request to patch People with ids: {}",
+        personDtos.stream().map(PersonDTO::getId).collect(Collectors.toList()));
 
     List<PersonDTO> result = personService.patch(personDtos);
     final List<String> ids = result.stream().map(dto -> dto.getId().toString())

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PlacementResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PlacementResource.java
@@ -2,6 +2,7 @@ package com.transformuk.hee.tis.tcs.service.api;
 
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDetailsDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PlacementEsrEventDto;
 import com.transformuk.hee.tis.tcs.api.dto.validation.Create;
 import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.service.api.decorator.PlacementDetailsDecorator;
@@ -9,7 +10,6 @@ import com.transformuk.hee.tis.tcs.service.api.util.HeaderUtil;
 import com.transformuk.hee.tis.tcs.service.api.util.PaginationUtil;
 import com.transformuk.hee.tis.tcs.service.api.validation.PlacementValidator;
 import com.transformuk.hee.tis.tcs.service.api.validation.ValidationException;
-import com.transformuk.hee.tis.tcs.api.dto.PlacementEsrEventDto;
 import com.transformuk.hee.tis.tcs.service.dto.placementmanager.PlacementsResultDTO;
 import com.transformuk.hee.tis.tcs.service.model.PlacementEsrEvent;
 import com.transformuk.hee.tis.tcs.service.service.PlacementService;
@@ -190,16 +190,16 @@ public class PlacementResource {
   /**
    * PATCH  /placements : Bulk patch Placements.
    *
-   * @param placementDTOS List of the placementDTOS to create
+   * @param placementDtos List of the placementDTOS to create
    * @return the ResponseEntity with status 200 (OK) and with body the new placementDTOS
-   * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PatchMapping("/placements")
   @PreAuthorize("hasAuthority('tcs:add:modify:entities')")
   public ResponseEntity<List<PlacementDTO>> patchPlacements(
-      @RequestBody final List<PlacementDTO> placementDTOS) {
-    log.debug("REST request to bulk save Placement : {}", placementDTOS);
-    final List<PlacementDTO> result = placementService.save(placementDTOS);
+      @RequestBody final List<PlacementDTO> placementDtos) {
+    log.debug("REST request to bulk patch Placements with IDs : {}",
+        placementDtos.stream().map(PlacementDTO::getId).collect(Collectors.toList()));
+    final List<PlacementDTO> result = placementService.save(placementDtos);
     final List<Long> ids = result.stream().map(PlacementDTO::getId).collect(Collectors.toList());
     return ResponseEntity.ok()
         .headers(HeaderUtil.createEntityUpdateAlert(ENTITY_NAME, StringUtils.join(ids, ",")))

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeResource.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -246,19 +247,17 @@ public class ProgrammeResource {
    * @param programmeDTOS List of the programmeDTOS to create
    * @return the ResponseEntity with status 200 (Created) and with body the new programmeDTOS, or
    * with status 400 (Bad Request) if the Programme has already an ID
-   * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/bulk-programmes")
   @PreAuthorize("hasAuthority('programme:bulk:add:modify')")
   public ResponseEntity<List<ProgrammeDTO>> bulkCreateProgrammes(
-      @RequestBody List<ProgrammeDTO> programmeDTOS)
-      throws URISyntaxException, MethodArgumentNotValidException {
-    log.debug("REST request to bulk save Programmes : {}", programmeDTOS);
+      @RequestBody List<ProgrammeDTO> programmeDTOS) {
+    log.debug("REST request to bulk create {} Programmes.", programmeDTOS.size());
     try {
       if (!Collections.isEmpty(programmeDTOS)) {
         List<Long> entityIds = programmeDTOS.stream()
-            .filter(p -> p.getId() != null)
-            .map(p -> p.getId())
+            .map(ProgrammeDTO::getId)
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
         if (!Collections.isEmpty(entityIds)) {
           return ResponseEntity.badRequest().headers(HeaderUtil

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RotationPostResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RotationPostResource.java
@@ -51,7 +51,7 @@ public class RotationPostResource {
   public ResponseEntity<List<RotationPostDTO>> createRotationPost(
       @RequestBody @Validated(Create.class) List<RotationPostDTO> rotationPostDTOs)
       throws URISyntaxException {
-    log.debug("REST request to save RotationPost : {}", rotationPostDTOs);
+    log.debug("REST request to create {} RotationPosts.", rotationPostDTOs.size());
     if (rotationPostDTOs.isEmpty()) {
       return ResponseEntity.badRequest()
           .headers(HeaderUtil.createFailureAlert(ENTITY_NAME, REQUEST_BODY_EMPTY,


### PR DESCRIPTION
Several API resources log user submitted data, which could allow a CRLF
injection attack. Sanitize or rework the logging as necesarry to avoid
such an attack.

TIS21-1900