### PR TITLE
chore: Add auto-caching using setup-java action

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -13,17 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up maven cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Set up JDK
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: maven
           distribution: adopt
           java-version: 11
 
@@ -101,17 +94,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up maven cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Set up JDK
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: maven
           distribution: adopt
           java-version: 11
 

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: maven
           distribution: adopt
           java-version: 11
 


### PR DESCRIPTION
The `setup-java` action now supports automatic caching of maven and
gradle dependencies, update the workflow to use that caching.

TIS21-2078