### PR TITLE
feat: check Role mandatory for Person Create/Update

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.5</version>
+  <version>6.22.6</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
1. When creating a Person from UI or bulk upload, check if the Role in the DTO is empty. -- `checkMandatoryFields()`
2. When updating a Person from bulk upload, If the Role in the DTO is empty, check the role of the entity in the DB exists. -- `isUpdatable()`
3. Check if the Role matches Reference data. -- `checkRole()`

TIS21-1752