### PR TITLE
feat: Add DR in Training standardizing feature

### DIFF
--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -236,6 +236,7 @@ public class PersonValidator {
       // Bulk upload uses a ";" separator, account for both that and the default ",".
       List<String> roles = Arrays.stream(roleMultiValue.split("[;,]"))
           .map(String::trim)
+          .map(this::standardizeDRinTraining)
           .collect(Collectors.toList());
 
       personDto.setRole(String.join(",", roles));
@@ -311,5 +312,10 @@ public class PersonValidator {
     }
 
     return fieldErrors;
+  }
+
+  private String standardizeDRinTraining(String role) {
+    String shorthandRole = role.replaceAll("[\\.]?[\\s]","");
+    return shorthandRole.equalsIgnoreCase("DRinTraining") ? "DR in Training" : role;
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -238,6 +238,25 @@ public class PersonValidatorTest {
   }
 
   @Test
+  public void bulkShouldAutofixInaccurateRoleThatExists() {
+    // Given.
+    PersonDTO dto = new PersonDTO();
+    dto.setRole("dr. in training ; role 2,");
+    List<PersonDTO> dtoList = new ArrayList<>();
+    dtoList.add(dto);
+
+    Map<String, Boolean> roleToExists = new HashMap<>();
+    roleToExists.put("DR in Training", true);
+    roleToExists.put("role 2", true);
+    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+
+    // When.
+    testObj.validateForBulk(dtoList);
+    // Then.
+    assertThat("should not contain any errors", dtoList.get(0).getMessageList().size(), is(0));
+  }
+
+  @Test
   public void bulkShouldGetErrorWhenPersonNotExists() {
     // Given.
     PersonDTO dto = new PersonDTO();


### PR DESCRIPTION
**[TIS21-1629](https://hee-tis.atlassian.net/browse/TIS21-1629): Update bulk person create to validate and set the role correctly**

First approach. Allows user to upload Person(s) with an inaccurately spelt role (i.e. 'dr in training' gets fixed and accepted as 'DR in Training').

This approach doesn't disrupt what's already in place too much, but it's a hacky way to add a check in the middle of the process to find if we're passing an inaccurately spelt role of 'DR in Training' (e.g. 'dr in   training ' with wrong casing and spacing) and fix it before it's accepted.

It works, it doesn't require major changes, but it only acts on 'DR in Training' and it introduces something weirdly specific for an algorithm that is meant to deal with all sorts of roles. Kinda "hardcody".

Check out the [second approach (PR753)](https://github.com/Health-Education-England/TIS-TCS/runs/4047327556?check_suite_focus=true) for something not specific to 'DR in Training' and (probably) more desirable as a solution.
