### PR TITLE
Feat/enhance role validation 2

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.7</version>
+  <version>6.23.0</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.11.0</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -1,6 +1,5 @@
 package com.transformuk.hee.tis.tcs.service.api.validation;
 
-import com.google.common.collect.Streams;
 import com.transformuk.hee.tis.reference.api.dto.RoleDTO;
 import com.transformuk.hee.tis.reference.client.ReferenceService;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
@@ -10,11 +9,7 @@ import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -235,14 +230,8 @@ public class PersonValidator {
 
     String roleMultiValue = personDto.getRole();
 
-    Set<String> allRolesAvailable = referenceService.getAllRoles()
-        .stream()
-        .map(RoleDTO::getCode)
-        .collect(Collectors.toSet());
-
-    Set<String> shorthandsForAllRolesAvailable = allRolesAvailable.stream()
-        .map(String::toLowerCase)
-        .map(this::makeShorthand)
+    Set<String> allExistingRolesShorthands = allRolesSet().stream()
+        .map(this::shorthand)
         .collect(Collectors.toSet());
 
     if (!StringUtils.isEmpty(roleMultiValue)) {
@@ -254,7 +243,7 @@ public class PersonValidator {
       personDto.setRole(String.join(",", roles));
 
       roles.forEach(role -> {
-        if (!shorthandsForAllRolesAvailable.contains(makeShorthand(role))) {
+        if (!allExistingRolesShorthands.contains(shorthand(role))) {
           fieldErrors.add(new FieldError(PERSON_DTO_NAME, "role",
               String.format("Role '%s' did not match a reference value.", role)));
         }
@@ -324,7 +313,14 @@ public class PersonValidator {
     return fieldErrors;
   }
 
-  private String makeShorthand(String role) {
+  private Set<String> allRolesSet() {
+    return referenceService.getAllRoles()
+        .stream()
+        .map(RoleDTO::getCode)
+        .collect(Collectors.toSet());
+  }
+
+  private String shorthand(String role) {
     return role.replaceAll("[\\s]", "").toLowerCase();
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -277,6 +277,10 @@ public class PersonValidatorTest {
     dto.setRole(PERSON_ROLE);
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
+
+    RoleDTO roleDTO = new RoleDTO();
+    roleDTO.setCode(PERSON_ROLE);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDTO));
     when(personRepositoryMock.existsById(1L)).thenReturn(false);
 
     testObj.validateForBulk(dtoList);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -20,6 +20,7 @@ import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainerApprovalDTO;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
+import gherkin.lexer.Ro;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -298,6 +299,10 @@ public class PersonValidatorTest {
     dto.setRole(PERSON_ROLE);
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
+
+    RoleDTO roleDTO = new RoleDTO();
+    roleDTO.setCode(PERSON_ROLE);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDTO));
     when(personRepositoryMock.existsById(1L)).thenReturn(true);
 
     // When.

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,11 +22,16 @@ import com.transformuk.hee.tis.tcs.api.dto.TrainerApprovalDTO;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.assertj.core.util.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +39,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -205,10 +212,9 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", false);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    RoleDTO role1 = new RoleDTO();
+    role1.setCode("role1");
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(role1));
 
     // When.
     testObj.validateForBulk(dtoList);
@@ -219,17 +225,20 @@ public class PersonValidatorTest {
   }
 
   @Test
-  public void bulkShouldNotGetErrorWhenRoleExists() throws MethodArgumentNotValidException {
+  public void bulkShouldNotGetErrorWhenRoleExists() {
     // Given.
     PersonDTO dto = new PersonDTO();
     dto.setRole("role1 ; role2,");
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    RoleDTO role1 = new RoleDTO();
+    role1.setCode("role1");
+    role1.setId(0L);
+    RoleDTO role2 = new RoleDTO();
+    role2.setCode("role2");
+    role2.setId(1L);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(role1, role2));
 
     // When.
     testObj.validateForBulk(dtoList);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -243,6 +243,33 @@ public class PersonValidatorTest {
     // When.
     testObj.validateForBulk(dtoList);
     // Then.
+    assertThat("should not contain any errors",
+        dtoList.get(0).getMessageList().size(), is(0));
+  }
+
+  /**
+   * When role exists but is inaccurately spelt (different casing or spacing), fix it before
+   * accepting the row
+   */
+  @Test
+  public void bulkShouldFixWhenRoleExistsButIsInaccurate() {
+    // Given.
+    PersonDTO dto = new PersonDTO();
+    dto.setRole("role1 ; ROle  2,");
+    List<PersonDTO> dtoList = new ArrayList<>();
+    dtoList.add(dto);
+
+    RoleDTO role1 = new RoleDTO();
+    role1.setCode("role1");
+    role1.setId(0L);
+    RoleDTO role2 = new RoleDTO();
+    role2.setCode("role2");
+    role2.setId(1L);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(role1, role2));
+
+    // When.
+    testObj.validateForBulk(dtoList);
+    // Then.
     assertThat("should not contain any errors", dtoList.get(0).getMessageList().size(), is(0));
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -20,7 +20,6 @@ import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainerApprovalDTO;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
-import gherkin.lexer.Ro;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -131,6 +130,11 @@ public class PersonValidatorTest {
   public void validationSkippedIfPublicHealthNumberIsUnknownOrNA()
       throws MethodArgumentNotValidException {
     when(personDTOMock.getPublicHealthNumber()).thenReturn(UNKNOWN_PUBLIC_HEALTH_NUMBER);
+
+    RoleDTO roleDto = new RoleDTO();
+    roleDto.setCode("VALID_ROLE");
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDto));
+
     testObj.validate(personDTOMock);
     verify(personRepositoryMock, never()).findByPublicHealthNumber(anyString());
   }
@@ -332,15 +336,9 @@ public class PersonValidatorTest {
     when(personRepositoryMock.findByPublicHealthNumber(PUBLIC_HEALTH_NUMBER))
         .thenReturn(Lists.newArrayList(personMock1));
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
-
     RoleDTO roleDto = new RoleDTO();
-    RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();
-    roleCategoryDto.setId(2L);
-    roleDto.setRoleCategory(roleCategoryDto);
-    when(referenceService.findRolesIn("role1")).thenReturn(Lists.newArrayList(roleDto));
+    roleDto.setCode("role1");
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDto));
 
     when(contactDetailsValidatorMock.validateForBulk(any())).thenReturn(Lists.emptyList());
     when(gdcDetailsValidatorMock.validateForBulk(any())).thenReturn(Lists.emptyList());
@@ -399,13 +397,10 @@ public class PersonValidatorTest {
     Person existingPerson = new Person();
     existingPerson.setRole("role1");
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-
     RoleDTO roleDto = new RoleDTO();
-    RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();
-    roleCategoryDto.setId(3L);
-    roleDto.setRoleCategory(roleCategoryDto);
+    roleDto.setCode("VALID_ROLE");
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDto));
+
     TrainerApprovalDTO trainerApprovalDto = new TrainerApprovalDTO();
     when(personDTOMock.getTrainerApprovals()).thenReturn(Sets.newHashSet(trainerApprovalDto));
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -253,10 +253,10 @@ public class PersonValidatorTest {
    * accepting the row
    */
   @Test
-  public void bulkShouldFixWhenRoleExistsButIsInaccurate() {
+  public void bulkShouldFixWhenRoleExistsButCasingIsInaccurate() {
     // Given.
     PersonDTO dto = new PersonDTO();
-    dto.setRole("role1 ; ROle  2,");
+    dto.setRole("role1 ; ROle2,");
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -283,9 +283,9 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    RoleDTO roleDTO = new RoleDTO();
-    roleDTO.setCode(PERSON_ROLE);
-    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDTO));
+    RoleDTO roleDto = new RoleDTO();
+    roleDto.setCode(PERSON_ROLE);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDto));
     when(personRepositoryMock.existsById(1L)).thenReturn(false);
 
     testObj.validateForBulk(dtoList);
@@ -304,9 +304,9 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    RoleDTO roleDTO = new RoleDTO();
-    roleDTO.setCode(PERSON_ROLE);
-    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDTO));
+    RoleDTO roleDto = new RoleDTO();
+    roleDto.setCode(PERSON_ROLE);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(roleDto));
     when(personRepositoryMock.existsById(1L)).thenReturn(true);
 
     // When.

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -431,10 +431,39 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
-    roleToExists.put("role3", true);
+    RoleDTO role1 = new RoleDTO();
+    role1.setCode("role1");
+    role1.setId(0L);
+    RoleDTO role2 = new RoleDTO();
+    role2.setCode("role2");
+    role2.setId(1L);
+    RoleDTO role3 = new RoleDTO();
+    role3.setCode("role3");
+    role3.setId(2L);
+    when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(role1, role2, role3));
+
+    ArgumentCaptor<List<PersonDTO>> personsListCaptor = ArgumentCaptor.forClass(List.class);
+
+    // When.
+    testObj.validateForBulk(dtoList);
+    // Then.
+    assertThat("should not contain any errors",
+        dtoList.get(0).getMessageList().size(), is(0));
+
+    verify(testObj).validateForBulk(personsListCaptor.capture());
+    List<String> splitRoles = Arrays.asList(
+        personsListCaptor.getValue().get(0).getRole().split(","));
+
+    assertThat("Unexpected roles.", splitRoles, hasItems("role1", "role2", "role3"));
+  }
+
+  @Test
+  public void roleCheckShouldHandleSemiColonSeparator() throws MethodArgumentNotValidException {
+    // Given.
+    PersonDTO dto = new PersonDTO();
+    dto.setRole("role1 ; role2;role3;");
+    List<PersonDTO> dtoList = new ArrayList<>();
+    dtoList.add(dto);
 
     RoleDTO role1 = new RoleDTO();
     role1.setCode("role1");
@@ -447,40 +476,18 @@ public class PersonValidatorTest {
     role3.setId(2L);
     when(referenceService.getAllRoles()).thenReturn(Sets.newHashSet(role1, role2, role3));
 
-    ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
-    when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
+    ArgumentCaptor<List<PersonDTO>> personsListCaptor = ArgumentCaptor.forClass(List.class);
 
     // When.
     testObj.validateForBulk(dtoList);
     // Then.
-    assertThat("should not contain any errors", dtoList.get(0).getMessageList().size(), is(0));
+    assertThat("should not contain any errors",
+        dtoList.get(0).getMessageList().size(), is(0));
 
-    List<String> splitRoles = rolesCaptor.getValue();
-    assertThat("Unexpected roles.", splitRoles, hasItems("role1", "role2", "role3"));
-  }
+    verify(testObj).validateForBulk(personsListCaptor.capture());
+    List<String> splitRoles = Arrays.asList(
+        personsListCaptor.getValue().get(0).getRole().split(","));
 
-  @Test
-  public void roleCheckShouldHandleSemiColonSeparator() throws MethodArgumentNotValidException {
-    // Given.
-    PersonDTO dto = new PersonDTO();
-    dto.setRole("role1 ; role2;role3;");
-    List<PersonDTO> dtoList = new ArrayList<>();
-    dtoList.add(dto);
-
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
-    roleToExists.put("role3", true);
-
-    ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
-    when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
-
-    // When.
-    testObj.validateForBulk(dtoList);
-    // Then.
-    assertThat("should not contain any errors", dtoList.get(0).getMessageList().size(), is(0));
-
-    List<String> splitRoles = rolesCaptor.getValue();
     assertThat("Unexpected roles.", splitRoles, hasItems("role1", "role2", "role3"));
   }
 


### PR DESCRIPTION
**[TIS21-1629](https://hee-tis.atlassian.net/browse/TIS21-1629): Update bulk person create to validate and set the role correctly**

Second approach. Allows user to upload Person(s) with an inaccurately spelt role (i.e. `dr in training` gets fixed and accepted as `DR in Training`, but also works on any other role, like `yh education` becomes `YH Education`).

When checking if a role exists, a call was sent to check if the role we were passing existed in the `Role` reference table. If we want to check whether it exists or not regardless of casing and spacing (i.e. `dr in   training` exists because `DR in Training` is in the table), we can't use the `referenceServiceImpl.rolesExist(code)` method, as it'd check for that role exactly (typed as it's typed).

Since there's less than 200 roles, I thought it'd be ok to retrieve them all at one time when a file is uploaded, so we can extrapolate a Set of standardized role codes (i.e. get a set of RoleDtos -> turn it into a Set of their codes -> turn it into a Set of standardized codes that are lowercase and with no spacing). Then we can check if our standardized role value that we're passing is included in the set of standardized role codes. If it isn't, add errors as usual.

This makes use of a new method (`getAllRoles`) in TIS-REFERENCE to retrieve all roles as a `Set<RoleDto>`. So it would require TIS-REFERENCE to be published first, so that TIS-TCS has access to it. Obviously it wouldn't build in the pipeline until the REFERENCE artifact is published. I built it locally and it looks like this:
```
ReferenceServiceImpl

  @Override
  public Set<RoleDTO> getAllRoles() {
    ResponseEntity<Set<RoleDTO>> responseEntity = referenceRestTemplate
        .exchange(serviceUrl + ROLES_ALL_MAPPINGS_ENDPOINT + "?size=3000&page=0", HttpMethod.GET, null, getRolesDto());
    return responseEntity.getBody();
  }
```

Probably better approach than the first one, not specific to 'DR in Training', but obviously more cumbersome in terms of changes to the implementation and previous tests.