### PR TITLE
fix: Flyway script to fix roles

### DIFF
--- a/tcs-service/src/main/resources/db/migration/data/hee/V4.10__fix_person_roles_with_inaccurate_casing.sql
+++ b/tcs-service/src/main/resources/db/migration/data/hee/V4.10__fix_person_roles_with_inaccurate_casing.sql
@@ -1,0 +1,3 @@
+update Person person
+inner join reference.Role role ON person.role = role.code
+set person.role = role.code;


### PR DESCRIPTION
Update table tcs.Person so that rows have the column 'role' correctly spelt (taken from the reference.Role table, wherever casing is the only difference). It won't fix other errors such as extra dots or typos).

From what I've seen it appears that MySQL automatically does not perform the update if it sees that the value that is being set is the same, which would save us from writing a more elaborate script that checks if the update is necessary or not.

If we discover that our script should indeed have the responsibility to check for this condition itself, an option could be something like:
```
UPDATE tcs.Person person
INNER JOIN reference.Role role ON person.role = role.code
SET person.role = if(binary person.role = binary role.code, role.code, role.code);
```

TIS21-1629