### PR TITLE
feat: Change PersonValidator

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.11.5</version>
+      <version>4.11.0</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.9</version>
+  <version>6.22.10</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.11.0</version>
+      <version>4.11.6</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -239,11 +239,11 @@ public class PersonValidator {
           .collect(Collectors.toList());
 
       Map<String, String> rolesMatch = referenceService.rolesMatch(roles, true);
-      List<String> correctedRoles = rolesMatch.entrySet().stream()
+      List<String> matchedRoles = rolesMatch.entrySet().stream()
           .map(entry -> entry.getValue().isEmpty() ? entry.getKey() : entry.getValue())
           .collect(Collectors.toList());
 
-      personDto.setRole(String.join(",", correctedRoles));
+      personDto.setRole(String.join(",", matchedRoles));
 
       for (Entry<String, String> roleMatch : rolesMatch.entrySet()) {
         if (roleMatch.getValue().isEmpty()) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -240,13 +240,13 @@ public class PersonValidator {
 
       Map<String, String> rolesMatch = referenceService.rolesMatch(roles, true);
       List<String> matchedRoles = rolesMatch.entrySet().stream()
-          .map(entry -> entry.getValue().isEmpty() ? entry.getKey() : entry.getValue())
+          .map(entry -> StringUtils.isEmpty(entry.getValue()) ? entry.getKey() : entry.getValue())
           .collect(Collectors.toList());
 
       personDto.setRole(String.join(",", matchedRoles));
 
       for (Entry<String, String> roleMatch : rolesMatch.entrySet()) {
-        if (roleMatch.getValue().isEmpty()) {
+        if (StringUtils.isEmpty(roleMatch.getValue())) {
           fieldErrors.add(new FieldError(PERSON_DTO_NAME, "role",
               String.format("Role '%s' did not match a reference value.", roleMatch.getKey())));
         }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -238,17 +238,17 @@ public class PersonValidator {
           .map(String::trim)
           .collect(Collectors.toList());
 
-      Map<String, String> rolesExist = referenceService.rolesMatch(roles, true);
-      List<String> correctedRoles = rolesExist.entrySet().stream()
+      Map<String, String> rolesMatch = referenceService.rolesMatch(roles, true);
+      List<String> correctedRoles = rolesMatch.entrySet().stream()
           .map(entry -> entry.getValue().isEmpty() ? entry.getKey() : entry.getValue())
           .collect(Collectors.toList());
 
       personDto.setRole(String.join(",", correctedRoles));
 
-      for (Entry<String, String> roleExists : rolesExist.entrySet()) {
-        if (roleExists.getValue().isEmpty()) {
+      for (Entry<String, String> roleMatch : rolesMatch.entrySet()) {
+        if (roleMatch.getValue().isEmpty()) {
           fieldErrors.add(new FieldError(PERSON_DTO_NAME, "role",
-              String.format("Role '%s' did not match a reference value.", roleExists.getKey())));
+              String.format("Role '%s' did not match a reference value.", roleMatch.getKey())));
         }
       }
     }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -238,7 +238,7 @@ public class PersonValidator {
           .map(String::trim)
           .collect(Collectors.toList());
 
-      Map<String, String> rolesExist = referenceService.rolesExist(roles, true);
+      Map<String, String> rolesExist = referenceService.rolesMatch(roles, true);
       List<String> correctedRoles = rolesExist.entrySet().stream()
           .map(entry -> entry.getValue().isEmpty() ? entry.getKey() : entry.getValue())
           .collect(Collectors.toList());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidator.java
@@ -238,12 +238,15 @@ public class PersonValidator {
           .map(String::trim)
           .collect(Collectors.toList());
 
-      personDto.setRole(String.join(",", roles));
+      Map<String, String> rolesExist = referenceService.rolesExist(roles, true);
+      List<String> correctedRoles = rolesExist.entrySet().stream()
+          .map(entry -> entry.getValue().isEmpty() ? entry.getKey() : entry.getValue())
+          .collect(Collectors.toList());
 
-      Map<String, Boolean> rolesExist = referenceService.rolesExist(roles, true);
+      personDto.setRole(String.join(",", correctedRoles));
 
-      for (Entry<String, Boolean> roleExists : rolesExist.entrySet()) {
-        if (!roleExists.getValue()) {
+      for (Entry<String, String> roleExists : rolesExist.entrySet()) {
+        if (roleExists.getValue().isEmpty()) {
           fieldErrors.add(new FieldError(PERSON_DTO_NAME, "role",
               String.format("Role '%s' did not match a reference value.", roleExists.getKey())));
         }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PersonResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PersonResourceIntTest.java
@@ -299,9 +299,9 @@ public class PersonResourceIntTest {
     person.setPersonalDetails(personalDetails);
 
     final PersonDTO personDTO = personMapper.toDto(person);
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put(DEFAULT_ROLE, DEFAULT_ROLE);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put(DEFAULT_ROLE, DEFAULT_ROLE);
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     restPersonMockMvc.perform(post("/api/people")
         .contentType(MediaType.APPLICATION_JSON)
@@ -687,9 +687,9 @@ public class PersonResourceIntTest {
     updatedPersonDTO.setPublicHealthNumber(UPDATED_PUBLIC_HEALTH_NUMBER);
     updatedPersonDTO.setRegulator(UPDATED_REGULATOR);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put(UPDATED_ROLE, UPDATED_ROLE);
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     restPersonMockMvc.perform(put("/api/people")
         .contentType(MediaType.APPLICATION_JSON)
@@ -982,9 +982,9 @@ public class PersonResourceIntTest {
 
     updatedPersonDTO.setPublicHealthNumber(" 1111111");
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put(DEFAULT_ROLE, DEFAULT_ROLE);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put(DEFAULT_ROLE, DEFAULT_ROLE);
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     restPersonMockMvc.perform(put("/api/people")
         .contentType(MediaType.APPLICATION_JSON)
@@ -1055,9 +1055,9 @@ public class PersonResourceIntTest {
 
     PersonDTO updatedPersonDto = initialPersonDataForBulk(savedPerson);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put(UPDATED_ROLE, UPDATED_ROLE);
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     restPersonMockMvc.perform(patch("/api/bulk-people")
         .contentType(MediaType.APPLICATION_JSON)
@@ -1079,9 +1079,9 @@ public class PersonResourceIntTest {
     TrainerApproval savedTrainerApproval = trainerApprovalRepository.saveAndFlush(trainerApproval);
     int trainerApprovalAmount = trainerApprovalRepository.findAll().size();
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put(UPDATED_ROLE, UPDATED_ROLE);
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
     RoleDTO roleDto = new RoleDTO();
     roleDto.setCode(UPDATED_ROLE);
     RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();
@@ -1110,9 +1110,9 @@ public class PersonResourceIntTest {
     TrainerApproval savedTrainerApproval = trainerApprovalRepository.saveAndFlush(trainerApproval);
     int trainerApprovalAmount = trainerApprovalRepository.findAll().size();
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put(UPDATED_ROLE, UPDATED_ROLE);
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
     RoleDTO roleDto = new RoleDTO();
     roleDto.setCode(UPDATED_ROLE);
     RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PersonResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PersonResourceIntTest.java
@@ -299,8 +299,8 @@ public class PersonResourceIntTest {
     person.setPersonalDetails(personalDetails);
 
     final PersonDTO personDTO = personMapper.toDto(person);
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put(DEFAULT_ROLE, true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put(DEFAULT_ROLE, DEFAULT_ROLE);
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     restPersonMockMvc.perform(post("/api/people")
@@ -687,8 +687,8 @@ public class PersonResourceIntTest {
     updatedPersonDTO.setPublicHealthNumber(UPDATED_PUBLIC_HEALTH_NUMBER);
     updatedPersonDTO.setRegulator(UPDATED_REGULATOR);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     restPersonMockMvc.perform(put("/api/people")
@@ -982,8 +982,8 @@ public class PersonResourceIntTest {
 
     updatedPersonDTO.setPublicHealthNumber(" 1111111");
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put(DEFAULT_ROLE, true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put(DEFAULT_ROLE, DEFAULT_ROLE);
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     restPersonMockMvc.perform(put("/api/people")
@@ -1055,8 +1055,8 @@ public class PersonResourceIntTest {
 
     PersonDTO updatedPersonDto = initialPersonDataForBulk(savedPerson);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     restPersonMockMvc.perform(patch("/api/bulk-people")
@@ -1079,8 +1079,8 @@ public class PersonResourceIntTest {
     TrainerApproval savedTrainerApproval = trainerApprovalRepository.saveAndFlush(trainerApproval);
     int trainerApprovalAmount = trainerApprovalRepository.findAll().size();
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
     RoleDTO roleDto = new RoleDTO();
     roleDto.setCode(UPDATED_ROLE);
@@ -1110,8 +1110,8 @@ public class PersonResourceIntTest {
     TrainerApproval savedTrainerApproval = trainerApprovalRepository.saveAndFlush(trainerApproval);
     int trainerApprovalAmount = trainerApprovalRepository.findAll().size();
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put(UPDATED_ROLE, true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put(UPDATED_ROLE, UPDATED_ROLE);
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
     RoleDTO roleDto = new RoleDTO();
     roleDto.setCode(UPDATED_ROLE);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -205,10 +205,10 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    roleToExists.put("role2", "");
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    roleToMatches.put("role2", "");
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     // When.
     testObj.validateForBulk(dtoList);
@@ -226,10 +226,10 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    roleToExists.put("role2", "role2");
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    roleToMatches.put("role2", "role2");
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     // When.
     testObj.validateForBulk(dtoList);
@@ -291,9 +291,9 @@ public class PersonValidatorTest {
     when(personRepositoryMock.findByPublicHealthNumber(PUBLIC_HEALTH_NUMBER))
         .thenReturn(Lists.newArrayList(personMock1));
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     RoleDTO roleDto = new RoleDTO();
     RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();
@@ -323,9 +323,9 @@ public class PersonValidatorTest {
     when(personRepositoryMock.findByPublicHealthNumber(PUBLIC_HEALTH_NUMBER))
         .thenReturn(Lists.newArrayList(personMock1, personMock2)); // second error
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    when(referenceService.rolesMatch(any(), eq(true))).thenReturn(roleToMatches);
 
     RoleDTO roleDto = new RoleDTO();
     RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();
@@ -358,8 +358,8 @@ public class PersonValidatorTest {
     Person existingPerson = new Person();
     existingPerson.setRole("role1");
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
+    Map<String, Boolean> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", true);
 
     RoleDTO roleDto = new RoleDTO();
     RoleCategoryDTO roleCategoryDto = new RoleCategoryDTO();
@@ -390,13 +390,13 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    roleToExists.put("role2", "role2");
-    roleToExists.put("role3", "role3");
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    roleToMatches.put("role2", "role2");
+    roleToMatches.put("role3", "role3");
 
     ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
-    when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
+    when(referenceService.rolesMatch(rolesCaptor.capture(), eq(true))).thenReturn(roleToMatches);
 
     // When.
     testObj.validateForBulk(dtoList);
@@ -415,13 +415,13 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    roleToExists.put("role2", "role2");
-    roleToExists.put("role3", "role3");
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    roleToMatches.put("role2", "role2");
+    roleToMatches.put("role3", "role3");
 
     ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
-    when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
+    when(referenceService.rolesMatch(rolesCaptor.capture(), eq(true))).thenReturn(roleToMatches);
 
     // When.
     testObj.validateForBulk(dtoList);
@@ -440,13 +440,13 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, String> roleToExists = new HashMap<>();
-    roleToExists.put("role1", "role1");
-    roleToExists.put("role2", "role2");
-    roleToExists.put("role3", "role3");
+    Map<String, String> roleToMatches = new HashMap<>();
+    roleToMatches.put("role1", "role1");
+    roleToMatches.put("role2", "role2");
+    roleToMatches.put("role3", "role3");
 
     ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
-    when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
+    when(referenceService.rolesMatch(rolesCaptor.capture(), eq(true))).thenReturn(roleToMatches);
 
     // When.
     testObj.validateForBulk(dtoList);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonValidatorTest.java
@@ -205,9 +205,9 @@ public class PersonValidatorTest {
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", false);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
+    roleToExists.put("role2", "");
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     // When.
@@ -219,16 +219,16 @@ public class PersonValidatorTest {
   }
 
   @Test
-  public void bulkShouldNotGetErrorWhenRoleExists() throws MethodArgumentNotValidException {
+  public void bulkShouldNotGetErrorWhenRoleExists() {
     // Given.
     PersonDTO dto = new PersonDTO();
     dto.setRole("role1 ; role2,");
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
+    roleToExists.put("role2", "role2");
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     // When.
@@ -291,8 +291,8 @@ public class PersonValidatorTest {
     when(personRepositoryMock.findByPublicHealthNumber(PUBLIC_HEALTH_NUMBER))
         .thenReturn(Lists.newArrayList(personMock1));
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     RoleDTO roleDto = new RoleDTO();
@@ -323,8 +323,8 @@ public class PersonValidatorTest {
     when(personRepositoryMock.findByPublicHealthNumber(PUBLIC_HEALTH_NUMBER))
         .thenReturn(Lists.newArrayList(personMock1, personMock2)); // second error
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
     when(referenceService.rolesExist(any(), eq(true))).thenReturn(roleToExists);
 
     RoleDTO roleDto = new RoleDTO();
@@ -383,17 +383,17 @@ public class PersonValidatorTest {
   }
 
   @Test
-  public void roleCheckShouldHandleCommaSeparator() throws MethodArgumentNotValidException {
+  public void roleCheckShouldHandleCommaSeparator() {
     // Given.
     PersonDTO dto = new PersonDTO();
     dto.setRole("role1 , role2,role3,");
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
-    roleToExists.put("role3", true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
+    roleToExists.put("role2", "role2");
+    roleToExists.put("role3", "role3");
 
     ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
     when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
@@ -408,17 +408,17 @@ public class PersonValidatorTest {
   }
 
   @Test
-  public void roleCheckShouldHandleSemiColonSeparator() throws MethodArgumentNotValidException {
+  public void roleCheckShouldHandleSemiColonSeparator() {
     // Given.
     PersonDTO dto = new PersonDTO();
     dto.setRole("role1 ; role2;role3;");
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
-    roleToExists.put("role3", true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
+    roleToExists.put("role2", "role2");
+    roleToExists.put("role3", "role3");
 
     ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
     when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);
@@ -433,17 +433,17 @@ public class PersonValidatorTest {
   }
 
   @Test
-  public void roleCheckShouldHandleMixedSeparators() throws MethodArgumentNotValidException {
+  public void roleCheckShouldHandleMixedSeparators() {
     // Given.
     PersonDTO dto = new PersonDTO();
     dto.setRole("role1 ; role2,role3,");
     List<PersonDTO> dtoList = new ArrayList<>();
     dtoList.add(dto);
 
-    Map<String, Boolean> roleToExists = new HashMap<>();
-    roleToExists.put("role1", true);
-    roleToExists.put("role2", true);
-    roleToExists.put("role3", true);
+    Map<String, String> roleToExists = new HashMap<>();
+    roleToExists.put("role1", "role1");
+    roleToExists.put("role2", "role2");
+    roleToExists.put("role3", "role3");
 
     ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
     when(referenceService.rolesExist(rolesCaptor.capture(), eq(true))).thenReturn(roleToExists);


### PR DESCRIPTION
**TIS21-1629: Update bulk person create to validate and set the role correctly**

Make checkRole() in PersonValidator use the new endpoint from REFERENCE that returns a Map<String,String> instead of a
Map<String,Boolean>.

E.G.:
- role `dr in training` is passed in
- the `/roles/matches/` Reference endpoint will return a Map like: { "dr in training" : "DR in Training" }.
- the value (retrieved from the DB, therefore correctly cased) is used to set `personDto.role()`

~~As highlighted in the Reference PR, the naming still needs to be standardized (i.e. we're no longer just checking that a role exists but we're kinda checking for matches, so the method and the collections will have to reflect that)~~ (I think I tracked down all uses of 'exist' terminology and replaced it with 'match')

~~The versions of Reference may still need to be straightened out~~ (I think they're alright now)

~~Dependent on the Reference PR that implements the changes in the endpoint [(REFERENCE PR 202)](https://github.com/Health-Education-England/TIS-REFERENCE/pull/202)~~ (It's merged)
