### PR TITLE
feat: Add validation to PlacementValidator

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>5.13.3</version>
+  <version>5.13.4</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.14.0</version>
+      <version>6.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.13</version>
+  <version>6.22.14</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -59,7 +59,7 @@ public class PlacementValidator {
     // TODO add specialties and clinical supervisors
     //fieldErrors.addAll(checkSpecialties(placementDetailsDTO));
     fieldErrors.addAll(checkPersons(placementDetailsDTO));
-    if (placementDetailsDTO.getEsrEvents().size() > 0) {
+    if (placementDetailsDTO.getEsrEvents() != null) {
       fieldErrors.addAll(checkNpnUpdateIsAllowed(placementDetailsDTO));
     }
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -15,10 +15,10 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -59,9 +59,7 @@ public class PlacementValidator {
     // TODO add specialties and clinical supervisors
     //fieldErrors.addAll(checkSpecialties(placementDetailsDTO));
     fieldErrors.addAll(checkPersons(placementDetailsDTO));
-    if (placementDetailsDTO.getEsrEvents() != null) {
-      fieldErrors.addAll(checkNpnUpdateIsAllowed(placementDetailsDTO));
-    }
+    fieldErrors.addAll(checkNpnUpdateIsAllowed(placementDetailsDTO));
 
     if (!fieldErrors.isEmpty()) {
       final BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
@@ -220,12 +218,15 @@ public class PlacementValidator {
       return fieldErrors;
     }
 
-    String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
-    String newNpn = postRepository.findPostById(placementDetailsDTO.getPostId()).getNationalPostNumber();
-    if (!Objects.equals(newNpn, oldNpn)) {
-      fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
-          "National Post Number can't be edited for Placement exported to ESR"));
+    if (dbPlacement.get().getPlacementEsrEvents() != null) {
+      String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
+      String newNpn = placementDetailsDTO.getNationalPostNumber();
+      if (!StringUtils.equals(newNpn, oldNpn)) {
+        fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
+            "National Post Number can't be edited for Placement exported to ESR"));
+      }
     }
+
     return fieldErrors;
   }
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -208,11 +208,11 @@ public class PlacementValidator {
     }
   }
 
-  private List<FieldError> checkNpnUpdateIsAllowed(final PlacementDetailsDTO placementDetailsDTO) {
+  private List<FieldError> checkNpnUpdateIsAllowed(final PlacementDetailsDTO placementDetailsDto) {
     final List<FieldError> fieldErrors = new ArrayList<>();
 
     Optional<Placement> dbPlacement = placementRepository.findPlacementById(
-        placementDetailsDTO.getId());
+        placementDetailsDto.getId());
 
     if (!dbPlacement.isPresent()) {
       return fieldErrors;
@@ -220,7 +220,7 @@ public class PlacementValidator {
 
     if (!dbPlacement.get().getPlacementEsrEvents().isEmpty()) {
       String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
-      String newNpn = placementDetailsDTO.getNationalPostNumber();
+      String newNpn = placementDetailsDto.getNationalPostNumber();
       if (!StringUtils.equals(newNpn, oldNpn)) {
         fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
             "National Post Number can't be edited for Placement exported to ESR"));

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -59,7 +59,9 @@ public class PlacementValidator {
     // TODO add specialties and clinical supervisors
     //fieldErrors.addAll(checkSpecialties(placementDetailsDTO));
     fieldErrors.addAll(checkPersons(placementDetailsDTO));
-    fieldErrors.addAll(checkPlacementEsrStatusForNpnUpdate(placementDetailsDTO));
+    if (placementDetailsDTO.getEsrEvents().size() > 0) {
+      fieldErrors.addAll(checkNpnUpdateIsAllowed(placementDetailsDTO));
+    }
 
     if (!fieldErrors.isEmpty()) {
       final BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
@@ -208,7 +210,7 @@ public class PlacementValidator {
     }
   }
 
-  private List<FieldError> checkPlacementEsrStatusForNpnUpdate(final PlacementDetailsDTO placementDetailsDTO) {
+  private List<FieldError> checkNpnUpdateIsAllowed(final PlacementDetailsDTO placementDetailsDTO) {
     final List<FieldError> fieldErrors = new ArrayList<>();
 
     Optional<Placement> dbPlacement = placementRepository.findPlacementById(
@@ -217,13 +219,12 @@ public class PlacementValidator {
     if (!dbPlacement.isPresent()) {
       return fieldErrors;
     }
-    if (placementDetailsDTO.getEsrEvents().size() > 0) {
-      String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
-      String newNpn = postRepository.findPostById(placementDetailsDTO.getPostId()).getNationalPostNumber();
-      if (!Objects.equals(newNpn, oldNpn)) {
-        fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
-            "National Post Number can't be edited for Placement exported to ESR"));
-      }
+
+    String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
+    String newNpn = postRepository.findPostById(placementDetailsDTO.getPostId()).getNationalPostNumber();
+    if (!Objects.equals(newNpn, oldNpn)) {
+      fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
+          "National Post Number can't be edited for Placement exported to ESR"));
     }
     return fieldErrors;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -218,7 +218,7 @@ public class PlacementValidator {
       return fieldErrors;
     }
 
-    if (dbPlacement.get().getPlacementEsrEvents() != null) {
+    if (!dbPlacement.get().getPlacementEsrEvents().isEmpty()) {
       String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
       String newNpn = placementDetailsDTO.getNationalPostNumber();
       if (!StringUtils.equals(newNpn, oldNpn)) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -220,7 +220,8 @@ public class PlacementValidator {
 
     String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
     String newNpn = placementDetailsDto.getNationalPostNumber();
-    if (!StringUtils.equals(newNpn, oldNpn) && !dbPlacement.get().getPlacementEsrEvents().isEmpty()) {
+    if (!StringUtils.equals(newNpn, oldNpn) && !dbPlacement.get().getPlacementEsrEvents()
+        .isEmpty()) {
       fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
           "National Post Number can't be edited for Placement exported to ESR"));
     }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -218,13 +218,11 @@ public class PlacementValidator {
       return fieldErrors;
     }
 
-    if (!dbPlacement.get().getPlacementEsrEvents().isEmpty()) {
-      String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
-      String newNpn = placementDetailsDto.getNationalPostNumber();
-      if (!StringUtils.equals(newNpn, oldNpn)) {
-        fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
-            "National Post Number can't be edited for Placement exported to ESR"));
-      }
+    String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
+    String newNpn = placementDetailsDto.getNationalPostNumber();
+    if (!StringUtils.equals(newNpn, oldNpn) && !dbPlacement.get().getPlacementEsrEvents().isEmpty()) {
+      fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",
+          "National Post Number can't be edited for Placement exported to ESR"));
     }
 
     return fieldErrors;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
@@ -324,8 +324,6 @@ public class PlacementValidatorTest {
     placementDTO.setNationalPostNumber("NEW_NATIONAL_POST_NUMBER");
 
     // stubs
-    OwnerProjection ownerProjection = Mockito.mock(OwnerProjection.class);
-    given(ownerProjection.getNationalPostNumber()).willReturn(placementDTO.getNationalPostNumber());
     given(placementRepository.findPlacementById(PLACEMENT_ID)).willReturn(Optional.of(dbPlacement));
 
     // act

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
@@ -319,6 +319,7 @@ public class PlacementValidatorTest {
     dbPlacement.setPost(dbPost);
     dbPlacement.setPlacementEsrEvents(esrEvents);
 
+    // arrange new PlacementDetailsDto being passed in by the user
     placementDTO.setId(PLACEMENT_ID);
     placementDTO.setNationalPostNumber("NEW_NATIONAL_POST_NUMBER");
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
@@ -14,9 +14,7 @@ import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.reference.client.impl.ReferenceServiceImpl;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementCommentDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDetailsDTO;
-import com.transformuk.hee.tis.tcs.api.dto.PlacementEsrEventDto;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementSpecialtyDTO;
-import com.transformuk.hee.tis.tcs.api.enumeration.PlacementEsrEventStatus;
 import com.transformuk.hee.tis.tcs.api.enumeration.PostSpecialtyType;
 import com.transformuk.hee.tis.tcs.service.model.Placement;
 import com.transformuk.hee.tis.tcs.service.model.PlacementEsrEvent;
@@ -26,7 +24,6 @@ import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PlacementRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PostRepository;
 import com.transformuk.hee.tis.tcs.service.repository.SpecialtyRepository;
-import gherkin.lexer.Pl;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -314,22 +311,20 @@ public class PlacementValidatorTest {
     dbPost.setId(DEFAULT_POST);
     dbPost.setNationalPostNumber(DEFAULT_NATIONAL_POST_NUMBER);
 
+    PlacementEsrEvent exportedEvent = new PlacementEsrEvent();
+    Set<PlacementEsrEvent> esrEvents = new HashSet<>(Arrays.asList(exportedEvent));
+
     Placement dbPlacement = new Placement();
     dbPlacement.setId(PLACEMENT_ID);
     dbPlacement.setPost(dbPost);
-
-    // arrange PlacementDto with the fields to be updated (different NPN)
-    PlacementEsrEventDto exportedEvent = new PlacementEsrEventDto();
-    Set<PlacementEsrEventDto> esrEvents = new HashSet<>(Arrays.asList(exportedEvent));
+    dbPlacement.setPlacementEsrEvents(esrEvents);
 
     placementDTO.setId(PLACEMENT_ID);
     placementDTO.setNationalPostNumber("NEW_NATIONAL_POST_NUMBER");
-    placementDTO.setEsrEvents(esrEvents);
 
     // stubs
     OwnerProjection ownerProjection = Mockito.mock(OwnerProjection.class);
     given(ownerProjection.getNationalPostNumber()).willReturn(placementDTO.getNationalPostNumber());
-    given(postRepository.findPostById(DEFAULT_POST)).willReturn(ownerProjection);
     given(placementRepository.findPlacementById(PLACEMENT_ID)).willReturn(Optional.of(dbPlacement));
 
     // act


### PR DESCRIPTION
Make PlacementValidator compare between the new and old NPNs of a Placement in case of Placement update, and return a FieldError in case they're different && EsrEvents are present (i.e. someone's trying to update the NPN of an exported Placement)

**TIS21-174**: Make NPN read-only