### PR TITLE
Fix/check npn update is allowed tweak

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.14</version>
+  <version>6.22.15</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -219,7 +219,7 @@ public class PlacementValidator {
     }
 
     String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
-    String newNpn = placementDetailsDto.getNationalPostNumber();
+    String newNpn = postRepository.findPostById(placementDetailsDto.getPostId()).getNationalPostNumber();
     if (!StringUtils.equals(newNpn, oldNpn) && !dbPlacement.get().getPlacementEsrEvents()
         .isEmpty()) {
       fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidator.java
@@ -219,7 +219,8 @@ public class PlacementValidator {
     }
 
     String oldNpn = dbPlacement.get().getPost().getNationalPostNumber();
-    String newNpn = postRepository.findPostById(placementDetailsDto.getPostId()).getNationalPostNumber();
+    String newNpn = postRepository.findPostById(placementDetailsDto.getPostId())
+        .getNationalPostNumber();
     if (!StringUtils.equals(newNpn, oldNpn) && !dbPlacement.get().getPlacementEsrEvents()
         .isEmpty()) {
       fieldErrors.add(new FieldError(PLACEMENT_DTO_NAME, "nationalPostNumber",

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PlacementValidatorTest.java
@@ -56,6 +56,7 @@ public class PlacementValidatorTest {
   private static final String DEFAULT_PLACEMENT_TYPE = "OOPT";
   private static final BigDecimal DEFAULT_PLACEMENT_WHOLE_TIME_EQUIVALENT = new BigDecimal(1);
   private static final String DEFAULT_NATIONAL_POST_NUMBER = "NATIONAL_POST_NUMBER";
+  private static final String UPDATED_NATIONAL_POST_NUMBER = "UPDATED_NATIONAL_POST_NUMBER";
   private PlacementDetailsDTO placementDTO;
 
   @Mock
@@ -305,26 +306,56 @@ public class PlacementValidatorTest {
   }
 
   @Test(expected = ValidationException.class)
-  public void validateNpnForPlacementExportedToEsr() throws ValidationException {
-    // arrange old Placement already present in DB
-    Post dbPost = new Post();
-    dbPost.setId(DEFAULT_POST);
-    dbPost.setNationalPostNumber(DEFAULT_NATIONAL_POST_NUMBER);
+  public void validateNpnForPlacementExportedToEsrWhenUpdatingViaBulkUpload()
+      throws ValidationException {
+    // when updating a Placement's NPN via bulk-upload, a PlacementDetailsDto is sent to TCS's
+    // updatePlacement() endpoint with a new postId but with the old NPN.
+    placementDTO.setNationalPostNumber(DEFAULT_NATIONAL_POST_NUMBER); // old NPN
+    placementDTO.setPostId(456L); // new PostId
+    placementDTO.setId(PLACEMENT_ID);
 
     PlacementEsrEvent exportedEvent = new PlacementEsrEvent();
     Set<PlacementEsrEvent> esrEvents = new HashSet<>(Arrays.asList(exportedEvent));
-
+    Post post = new Post();
+    post.setId(DEFAULT_POST);
+    post.setNationalPostNumber(DEFAULT_NATIONAL_POST_NUMBER);
     Placement dbPlacement = new Placement();
-    dbPlacement.setId(PLACEMENT_ID);
-    dbPlacement.setPost(dbPost);
     dbPlacement.setPlacementEsrEvents(esrEvents);
+    dbPlacement.setPost(post);
 
-    // arrange new PlacementDetailsDto being passed in by the user
-    placementDTO.setId(PLACEMENT_ID);
-    placementDTO.setNationalPostNumber("NEW_NATIONAL_POST_NUMBER");
-
-    // stubs
     given(placementRepository.findPlacementById(PLACEMENT_ID)).willReturn(Optional.of(dbPlacement));
+
+    OwnerProjection ownerProjection = Mockito.mock(OwnerProjection.class);
+    given(ownerProjection.getNationalPostNumber()).willReturn(UPDATED_NATIONAL_POST_NUMBER);
+    given(postRepository.findPostById(456L)).willReturn(ownerProjection);
+
+    // act
+    placementValidator.validate(placementDTO);
+  }
+
+  @Test(expected = ValidationException.class)
+  public void validateNpnForPlacementExportedToEsrWhenUpdatingViaPlacementPage()
+      throws ValidationException {
+    // when updating a Placement's NPN via its page on the FE, a PlacementDetailsDto is sent to TCS's
+    // updatePlacement() endpoint with a new postId and a new NPN
+    placementDTO.setNationalPostNumber(UPDATED_NATIONAL_POST_NUMBER); // new NPN
+    placementDTO.setPostId(456L); // new PostId
+    placementDTO.setId(PLACEMENT_ID);
+
+    PlacementEsrEvent exportedEvent = new PlacementEsrEvent();
+    Set<PlacementEsrEvent> esrEvents = new HashSet<>(Arrays.asList(exportedEvent));
+    Post post = new Post();
+    post.setId(DEFAULT_POST);
+    post.setNationalPostNumber(DEFAULT_NATIONAL_POST_NUMBER);
+    Placement dbPlacement = new Placement();
+    dbPlacement.setPlacementEsrEvents(esrEvents);
+    dbPlacement.setPost(post);
+
+    given(placementRepository.findPlacementById(PLACEMENT_ID)).willReturn(Optional.of(dbPlacement));
+
+    OwnerProjection ownerProjection = Mockito.mock(OwnerProjection.class);
+    given(ownerProjection.getNationalPostNumber()).willReturn(UPDATED_NATIONAL_POST_NUMBER);
+    given(postRepository.findPostById(456L)).willReturn(ownerProjection);
 
     // act
     placementValidator.validate(placementDTO);


### PR DESCRIPTION
The current validation for NPNs of an updating Placement would only work for placements being updated normally via a Placement's page (which is prevented by the FE anyway).

When Generic Upload tries to update placements, what is being used in a call to the api is:
- the original placementDetailsDto as currently stored in the database
- some other fields, including the **new postId** related to the new NPN entered in the excel file
[[See here]](https://github.com/Health-Education-England/TIS-GENERIC-UPLOAD/blob/0669a2fd9dfc8d4572c29b1b054889b8a410d428/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java#L129)

That's why the PlacementDetailsDto used in a PUT call to TCS at [[this line]](https://github.com/Health-Education-England/TIS-GENERIC-UPLOAD/blob/0669a2fd9dfc8d4572c29b1b054889b8a410d428/generic-upload-service/src/main/java/com/transformuk/hee/tis/genericupload/service/service/PlacementUpdateTransformerService.java#L232) has a **new postId** but an old **NPN**.

Structuring the validation like in this PR makes the validation work regardless whether the update is from bulk-upload or other FE components. The logic is based on using only the PlacementDetailsDto's `id` and `postId`.

- find the **old NPN** by finding the PlacementDetailsDto in the database and extracting it's NPN
- find the **new NPN** by finding a Post in the DB via the `PlacementDetailsDto.postId` (which is new), and extracting its NPN

This way we don't rely on the NPN carried by the PlacementDetailsDto itself, which is the old one when coming from bulk-upload, but the new one when coming from the main FE component.