### PR TITLE
fix: NPE in isEligibleForCurrentTraineeWteChangeNotification method

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.16</version>
+  <version>6.22.17</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementServiceImpl.java
@@ -1010,11 +1010,11 @@ public class PlacementServiceImpl implements PlacementService {
     LocalDate currentDateFrom = latestApprovedLog.getDateFrom();
 
     return
-        ((updatedPlacementDetails.getWholeTimeEquivalent() != null
-            && (currentPlacement.getPlacementWholeTimeEquivalent() == null
-            || updatedPlacementDetails.getWholeTimeEquivalent()
-                .compareTo(currentPlacement.getPlacementWholeTimeEquivalent()) != 0))) &&
-            ((currentDateFrom != null && currentDateFrom
+        (updatedPlacementDetails.getWholeTimeEquivalent() != null && (
+            currentPlacement.getPlacementWholeTimeEquivalent() == null
+                || updatedPlacementDetails.getWholeTimeEquivalent()
+                .compareTo(currentPlacement.getPlacementWholeTimeEquivalent()) != 0))
+            && ((currentDateFrom != null && currentDateFrom
                 .isBefore(LocalDate.now(clock).plusWeeks(13))) ||
                 (updatedPlacementDetails.getDateFrom() != null && updatedPlacementDetails
                     .getDateFrom()

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementServiceImpl.java
@@ -1010,9 +1010,10 @@ public class PlacementServiceImpl implements PlacementService {
     LocalDate currentDateFrom = latestApprovedLog.getDateFrom();
 
     return
-        ((updatedPlacementDetails.getWholeTimeEquivalent() != null && updatedPlacementDetails
-            .getWholeTimeEquivalent()
-            .compareTo(currentPlacement.getPlacementWholeTimeEquivalent()) != 0)) &&
+        ((updatedPlacementDetails.getWholeTimeEquivalent() != null
+            && (currentPlacement.getPlacementWholeTimeEquivalent() == null
+            || updatedPlacementDetails.getWholeTimeEquivalent()
+                .compareTo(currentPlacement.getPlacementWholeTimeEquivalent()) != 0))) &&
             ((currentDateFrom != null && currentDateFrom
                 .isBefore(LocalDate.now(clock).plusWeeks(13))) ||
                 (updatedPlacementDetails.getDateFrom() != null && updatedPlacementDetails

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementServiceImplTest.java
@@ -815,6 +815,39 @@ public class PlacementServiceImplTest {
   }
 
   @Test
+  public void isEligibleForChangedWholeTimeEquivalentShouldDealWithNullCurrentWte() {
+    LocalDate dateFiveMonthsAgo = LocalDate.now().minusMonths(5);
+    Long existingPlacementId = 1L;
+    BigDecimal updatedWholeTimeEquivalent = new BigDecimal(0.5);
+
+    Placement currentPlacement = new Placement();
+    currentPlacement.setId(existingPlacementId);
+    currentPlacement.setDateFrom(dateFiveMonthsAgo);
+    currentPlacement.setLifecycleState(APPROVED);
+    currentPlacement.setPlacementWholeTimeEquivalent(null);
+
+    PlacementDetailsDTO updatedPlacementDetails = new PlacementDetailsDTO();
+    updatedPlacementDetails.setId(existingPlacementId);
+    updatedPlacementDetails.setDateFrom(dateFiveMonthsAgo);
+    updatedPlacementDetails.setDateTo(dateFiveMonthsAgo);
+    updatedPlacementDetails.setWholeTimeEquivalent(updatedWholeTimeEquivalent);
+    updatedPlacementDetails.setWholeTimeEquivalent(updatedWholeTimeEquivalent);
+    updatedPlacementDetails.setLifecycleState(APPROVED);
+
+    PlacementLog placementLog = new PlacementLog();
+    placementLog.setPlacementId(existingPlacementId);
+    placementLog.setLifecycleState(APPROVED);
+    placementLog.setDateFrom(dateFiveMonthsAgo);
+    placementLog.setDateTo(dateFiveMonthsAgo);
+
+    boolean eligibleForCurrentTraineeWteChangeNotification = testObj
+        .isEligibleForCurrentTraineeWteChangeNotification(currentPlacement, updatedPlacementDetails,
+            placementLog);
+
+    Assert.assertTrue(eligibleForCurrentTraineeWteChangeNotification);
+  }
+
+  @Test
   public void markPlacementAsEsrExportedShouldFindPlacementAndCreateNewEventAgainstIt() {
     PlacementEsrEvent placementEsrEventMock = mock(PlacementEsrEvent.class);
     PlacementEsrEventDto placementEsrExportedDtoMock = mock(PlacementEsrEventDto.class);


### PR DESCRIPTION
When updating the `wte` in a placement, backend calls a `isEligibleForCurrentTraineeWteChangeNotification` method which compares if the current `wte` and the new `wte` are the same. If the current `wte` is null, it throws a NPE, which results in a 500 error on the UI.

TIS21-2441