### PR TITLE
chore: Allow publish artifacts to fail silently

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -125,6 +125,7 @@ jobs:
           cp ./tcs-service/target/tcs-service-*.war ./tcs-service/target/app.jar
 
       - name: Publish artifacts
+        continue-on-error: true
         run: mvn --batch-mode deploy -DskipTests
 
       - name: Configure AWS credentials


### PR DESCRIPTION
As published artifacts cannot be overwritten the publish step will fail
unless the version is bumped for all modules. Until we have an automated
way to do this the safer approach is to allow failures to continue to
stop non-versioned chore type PRs from breaking the build (e.g.
Dependabot, documentation and other non-code changes that don't usually
warrant a manual version bump).

TIS21-2495