### PR TITLE
chore: split deployments so failures don't cascade

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -126,7 +126,10 @@ jobs:
 
       - name: Publish artifacts
         continue-on-error: true
-        run: mvn --batch-mode deploy -DskipTests
+        run: |
+          mvn --batch-mode deploy -DskipTests --file tcs-api/pom.xml
+          mvn --batch-mode deploy -DskipTests --file tcs-client/pom.xml
+          mvn --batch-mode deploy -DskipTests --file tcs-persistence/pom.xml
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
When deploying all module with the same command a failure in earlier
modules will cause a later failure. This can not be mitigated by
`--fail-at-end` due to dependencies between the modules.

Without this split then it would never be possible to publish a new
version of `tcs-client` or `tcs-persistence` unless `tcs-api` is also
bumped and published.

TIS21-2495