### PR TITLE
Feat/get specialties by specialty type tis21 2460

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.16</version>
+  <version>6.22.18</version>
 
   <dependencies>
     <dependency>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.20.3</version>
+      <version>2.20.4</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
@@ -326,6 +326,7 @@
   </prerequisites>
 
   <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
     <argLine>-Djava.security.egd=file:/dev/./urandom -Xmx1g</argLine>
     <assertj.version>3.6.2</assertj.version>
     <commons-io.version>2.9.0</commons-io.version>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.17</version>
+  <version>6.22.16</version>
 
   <dependencies>
     <dependency>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.20.4</version>
+      <version>2.20.3</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
@@ -326,7 +326,6 @@
   </prerequisites>
 
   <properties>
-    <maven.deploy.skip>true</maven.deploy.skip>
     <argLine>-Djava.security.egd=file:/dev/./urandom -Xmx1g</argLine>
     <assertj.version>3.6.2</assertj.version>
     <commons-io.version>2.9.0</commons-io.version>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResource.java
@@ -36,6 +36,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -125,6 +126,7 @@ public class SpecialtyResource {
    */
   @GetMapping("/specialties")
   @PreAuthorize("hasAuthority('specialty:view')")
+  @Transactional
   public ResponseEntity<List<SpecialtyDTO>> getAllSpecialties(
       Pageable pageable,
       @RequestParam(value = "searchQuery", required = false) String searchQuery,

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImpl.java
@@ -121,7 +121,7 @@ public class SpecialtyServiceImpl implements SpecialtyService {
     if (columnFilters != null && !columnFilters.isEmpty()) {
       columnFilters.forEach(cf -> {
         if (StringUtils.equals(cf.getName(), "specialtyTypes")) {
-          List<Object> specialtyTypesValues = cf.getValues().stream()
+          List<SpecialtyType> specialtyTypesValues = cf.getValues().stream()
               .map(value -> SpecialtyType.valueOf((String) value))
               .collect(Collectors.toList());
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImpl.java
@@ -125,7 +125,8 @@ public class SpecialtyServiceImpl implements SpecialtyService {
               .map(value -> SpecialtyType.valueOf((String) value))
               .collect(Collectors.toList());
 
-          specialtyTypesValues.forEach(specialtyTypeValue -> specs.add(isMember(cf.getName(), specialtyTypeValue)));
+          specialtyTypesValues.forEach(specialtyTypeValue ->
+              specs.add(isMember(cf.getName(), specialtyTypeValue)));
         } else {
           specs.add(in(cf.getName(), cf.getValues()));
         }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImpl.java
@@ -2,11 +2,13 @@ package com.transformuk.hee.tis.tcs.service.service.impl;
 
 import static com.transformuk.hee.tis.tcs.service.service.impl.SpecificationFactory.containsLike;
 import static com.transformuk.hee.tis.tcs.service.service.impl.SpecificationFactory.in;
+import static com.transformuk.hee.tis.tcs.service.service.impl.SpecificationFactory.isMember;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtySimpleDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.event.SpecialtyDeletedEvent;
 import com.transformuk.hee.tis.tcs.service.event.SpecialtySavedEvent;
@@ -21,6 +23,7 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.SpecialtySimpleMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,7 +119,17 @@ public class SpecialtyServiceImpl implements SpecialtyService {
     }
     //add the column filters criteria
     if (columnFilters != null && !columnFilters.isEmpty()) {
-      columnFilters.forEach(cf -> specs.add(in(cf.getName(), cf.getValues())));
+      columnFilters.forEach(cf -> {
+        if (StringUtils.equals(cf.getName(), "specialtyTypes")) {
+          List<Object> specialtyTypesValues = cf.getValues().stream()
+              .map(value -> SpecialtyType.valueOf((String) value))
+              .collect(Collectors.toList());
+
+          specialtyTypesValues.forEach(specialtyTypeValue -> specs.add(isMember(cf.getName(), specialtyTypeValue)));
+        } else {
+          specs.add(in(cf.getName(), cf.getValues()));
+        }
+      });
     }
     Specification<Specialty> fullSpec = Specification.where(specs.get(0));
     //add the rest of the specs that made it in

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecificationFactory.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecificationFactory.java
@@ -3,6 +3,7 @@ package com.transformuk.hee.tis.tcs.service.service.impl;
 import java.time.LocalDate;
 import java.util.Collection;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import org.apache.commons.lang3.StringUtils;
@@ -86,6 +87,10 @@ public final class SpecificationFactory {
       });
       return cbi;
     };
+  }
+
+  public static Specification isMember(String attribute, Object value) {
+    return (root, query, cb) -> cb.isMember(value, root.get(attribute));
   }
 
   public static Specification isBetween(String attribute, int min, int max) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecificationFactory.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecificationFactory.java
@@ -3,7 +3,6 @@ package com.transformuk.hee.tis.tcs.service.service.impl;
 import java.time.LocalDate;
 import java.util.Collection;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import org.apache.commons.lang3.StringUtils;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceIntTest.java
@@ -448,30 +448,25 @@ public class SpecialtyResourceIntTest {
     Set<SpecialtyType> subspecialtyAndPlacementAndCurriculum = new HashSet<>(Arrays.asList(SpecialtyType.SUB_SPECIALTY, SpecialtyType.PLACEMENT, SpecialtyType.CURRICULUM));
     specialty.setSpecialtyTypes(subspecialtyAndPlacementAndCurriculum);
     specialty.setStatus(Status.CURRENT);
-    specialty.setId(1L);
 
     Set<SpecialtyType> subspecialtyAndPlacement = new HashSet<>(Arrays.asList(SpecialtyType.SUB_SPECIALTY, SpecialtyType.PLACEMENT));
     Specialty specialty2 = createEntity();
     specialty2.setSpecialtyTypes(subspecialtyAndPlacement);
     specialty2.setStatus(Status.CURRENT);
-    specialty2.setId(2L);
 
     Set<SpecialtyType> subspecialty = new HashSet<>(Arrays.asList(SpecialtyType.SUB_SPECIALTY));
     Specialty specialty3 = createEntity();
     specialty3.setSpecialtyTypes(subspecialty);
     specialty3.setStatus(Status.CURRENT);
-    specialty3.setId(3L);
 
     Set<SpecialtyType> curriculum = new HashSet<>(Arrays.asList(SpecialtyType.CURRICULUM));
     Specialty specialty4 = createEntity();
     specialty4.setSpecialtyTypes(curriculum);
     specialty4.setStatus(Status.CURRENT);
-    specialty4.setId(4L);
 
     Specialty specialty5 = createEntity();
     specialty5.setSpecialtyTypes(subspecialty);
     specialty5.setStatus(Status.INACTIVE);
-    specialty5.setId(5L);
 
     specialtyRepository.saveAll(Arrays.asList(specialty, specialty2, specialty3, specialty4, specialty5));
     specialtyRepository.flush();
@@ -479,13 +474,16 @@ public class SpecialtyResourceIntTest {
     // look to retrieve only the ones that are current && with specialtyTypes SUB_SPECIALTY and PLACEMENT
     String colFilters = new URLCodec().encode("{\"status\":[\"CURRENT\"], \"specialtyTypes\": [\"SUB_SPECIALTY\", \"PLACEMENT\"] }");
 
-    // Get all the specialties that match the columnFilters (i.e. specialty with id 1 and specialty with id 2)
+    // Get all the specialties that match at least the columnFilters. Should retrieve:
+    // specialty2 (with specialtyTypes SUB_SPECIALTY and PLACEMENT)
+    // specialty (with specialtyTypes SUB_SPECIALTY, PLACEMENT and CURRICULUM)
     restSpecialtyMockMvc
         .perform(get("/api/specialties?sort=id,desc&columnFilters=" + colFilters))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.[0].id").value("2"))
-        .andExpect(jsonPath("$.[1].id").value("1"))
+        .andExpect(jsonPath("$.[0].id").value(specialty2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(specialty.getId()))
         .andExpect(jsonPath("$.[2]").doesNotExist());
+    // and nothing else
   }
 
   @Test

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceIntTest.java
@@ -28,8 +28,12 @@ import com.transformuk.hee.tis.tcs.service.repository.SpecialtyGroupRepository;
 import com.transformuk.hee.tis.tcs.service.repository.SpecialtyRepository;
 import com.transformuk.hee.tis.tcs.service.service.SpecialtyService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.SpecialtyMapper;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import org.apache.commons.codec.EncoderException;
 import org.apache.commons.codec.net.URLCodec;
 import org.junit.Before;
 import org.junit.Test;
@@ -436,6 +440,52 @@ public class SpecialtyResourceIntTest {
             colFilters))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.[*].specialtyCode").value("TestSpecialtyCode"));
+  }
+
+  @Test
+  public void shouldGetSpecialtiesFilteredByStatusAndSpecialtyType() throws Exception {
+    // initialize database with 5 specialties with different Statuses and SpecialtyTypes
+    Set<SpecialtyType> subspecialtyAndPlacementAndCurriculum = new HashSet<>(Arrays.asList(SpecialtyType.SUB_SPECIALTY, SpecialtyType.PLACEMENT, SpecialtyType.CURRICULUM));
+    specialty.setSpecialtyTypes(subspecialtyAndPlacementAndCurriculum);
+    specialty.setStatus(Status.CURRENT);
+    specialty.setId(1L);
+
+    Set<SpecialtyType> subspecialtyAndPlacement = new HashSet<>(Arrays.asList(SpecialtyType.SUB_SPECIALTY, SpecialtyType.PLACEMENT));
+    Specialty specialty2 = createEntity();
+    specialty2.setSpecialtyTypes(subspecialtyAndPlacement);
+    specialty2.setStatus(Status.CURRENT);
+    specialty2.setId(2L);
+
+    Set<SpecialtyType> subspecialty = new HashSet<>(Arrays.asList(SpecialtyType.SUB_SPECIALTY));
+    Specialty specialty3 = createEntity();
+    specialty3.setSpecialtyTypes(subspecialty);
+    specialty3.setStatus(Status.CURRENT);
+    specialty3.setId(3L);
+
+    Set<SpecialtyType> curriculum = new HashSet<>(Arrays.asList(SpecialtyType.CURRICULUM));
+    Specialty specialty4 = createEntity();
+    specialty4.setSpecialtyTypes(curriculum);
+    specialty4.setStatus(Status.CURRENT);
+    specialty4.setId(4L);
+
+    Specialty specialty5 = createEntity();
+    specialty5.setSpecialtyTypes(subspecialty);
+    specialty5.setStatus(Status.INACTIVE);
+    specialty5.setId(5L);
+
+    specialtyRepository.saveAll(Arrays.asList(specialty, specialty2, specialty3, specialty4, specialty5));
+    specialtyRepository.flush();
+
+    // look to retrieve only the ones that are current && with specialtyTypes SUB_SPECIALTY and PLACEMENT
+    String colFilters = new URLCodec().encode("{\"status\":[\"CURRENT\"], \"specialtyTypes\": [\"SUB_SPECIALTY\", \"PLACEMENT\"] }");
+
+    // Get all the specialties that match the columnFilters (i.e. specialty with id 1 and specialty with id 2)
+    restSpecialtyMockMvc
+        .perform(get("/api/specialties?sort=id,desc&columnFilters=" + colFilters))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.[0].id").value("2"))
+        .andExpect(jsonPath("$.[1].id").value("1"))
+        .andExpect(jsonPath("$.[2]").doesNotExist());
   }
 
   @Test


### PR DESCRIPTION
In **Posts**, under **ALLOCATION**, the `Sub specialties` field currently displays all specialties instead of showing only specialties whose SpecialtyType is `SUB_SPECIALTY`.

![image](https://user-images.githubusercontent.com/56549133/148246937-4b001d59-9008-4328-b03c-5fc2b459ce5e.png)

The `<tis-dropdown>` element from the frontend is hitting the `getAllSpecialties()` endpoint in TCS. It can already retrieve all specialties according to Status (=CURRENT), but can't yet retrieve all specialties according to SpecialtyType for a number of reasons:
- SpecialtyType in Specialty is lazily instantiated
- Even when made transactional, it still can't cope because it's not a simple field like `Status`, but a `Set<SpecialtyType>`

By transforming each value of the SpecialtyType columnFilter in its own spec that uses the CriteriaBuilder method `isMember` instead of `in`, when given any SpecialtyType in the ColumnFilters, the endpoint can now handle searches by SpecialtyType as well.

In this PR I'm only looking to fix the `getAllSpecialties()` endpoint, which looked like it could handle SpecialtyType columnFilters but actually couldn't. In other PRs I was going to address backend validations.