### PR TITLE
Feat/add specialty validation for subspecialties tis21 2460

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.22.18</version>
+  <version>6.22.19</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostValidator.java
@@ -189,8 +189,8 @@ public class PostValidator {
           } else if (PostSpecialtyType.PRIMARY.equals(ps.getPostSpecialtyType())) {
             ++noOfPrimarySpecialtyCount;
           } else if (PostSpecialtyType.SUB_SPECIALTY.equals(ps.getPostSpecialtyType())) {
-            Optional<Specialty> specialty = specialtyRepository.findSpecialtyByIdEagerFetch(ps.getSpecialty().getId());
-            specialty.ifPresent(s -> checkSubspecialtyIsOfTypeSubspecialty(fieldErrors, s));
+            specialtyRepository.findSpecialtyByIdEagerFetch(ps.getSpecialty().getId())
+                .ifPresent(s -> checkSubspecialtyIsOfTypeSubspecialty(fieldErrors, s));
           }
         }
       }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
@@ -497,9 +497,9 @@ public class PostResourceIntTest {
   public void shouldFailToCreatePostIfSubspecialtyIsNotASubspecialty() throws Exception {
     Optional<Post> postBeforeUpdate = postRepository.findById(1L);
 
-    // Attempt to update a Post that has a specialty of specialtyType PLACEMENT as a subspecialty
-    // (i.e. link Post and a Specialty that is SpecialtyType.SUB_SPECIALTY in a PostSpecialty in
-    // a PostSpecialty of PostSpecialtyType.PLACEMENT)
+    // Attempt to save a Post that has a specialty of specialtyType PLACEMENT as a subspecialty
+    // (i.e. link Post and a Specialty that is SpecialtyType.PLACEMENT in a PostSpecialty in
+    // a PostSpecialty of PostSpecialtyType.SUB_SPECIALTY)
     // The update should fail.
 
     Specialty notASubspecialty = createSpecialty();
@@ -508,7 +508,6 @@ public class PostResourceIntTest {
     em.persist(notASubspecialty);
     PostSpecialty postSpecialty = createPostSpecialty(notASubspecialty,
         PostSpecialtyType.SUB_SPECIALTY, post);
-    em.persist(postSpecialty);
     post.setSpecialties(new HashSet<>(Collections.singletonList(postSpecialty)));
     PostDTO postDto = postMapper.postToPostDTO(post);
 


### PR DESCRIPTION
Addition of a validation on Specialties when creating or updating a Post.

When the `createPost()` and `updatePost()` endpoints are hit, the PostDto in question goes through validations concerning sites, grades, specialties etc.

When checking the validity of its specialties, the Post is inspected to make sure of the following:
- check if there's any `PostSpecialty` of PostSpecialtyType `SUB_SPECIALTY` (i.e. check if there's any Specialty that has been indicated as the Post's "subspecialty"
- if there is: check that the Specialty contained in the PostSpecialty is of type `SUB_SPECIALTY` (i.e. check that the Specialty indicated as the Post's "subspecialty" is itself, indeed, a Specialty of SpecialtyType `SUB_SPECIALTY`

I tried to uniform this validation in line with other validations, nevertheless, when trying to create/update a Post via Generic Upload, when Generic Upload receives a response from TCS with the exception, it triggers the writing of an unrelated message on the Excel file. I believe that Generic Upload will need to be amended slightly to capture the exception and parse it, in order to write the correct error on the Excel file (which I think it already does with other datatypes like Placements)