### PR TITLE
Feat/overload get specialty by name method

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>5.13.6</version>
+  <version>5.13.5</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>5.13.5</version>
+  <version>5.13.6</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -115,7 +115,8 @@ public class TcsServiceImpl extends AbstractClientService {
       specialtyJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
           .encode("{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"]}");
       specialtyJsonQuerystringAndSpecialtyTypeURLEncoded = new org.apache.commons.codec.net.URLCodec()
-          .encode("{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"],\"specialtyTypes\":[\"PARAMETER_TYPE\"]}");
+          .encode(
+              "{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"],\"specialtyTypes\":[\"PARAMETER_TYPE\"]}");
       placementJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
           .encode("{\"traineeId\":[\"PARAMETER_TRAINEE_ID\"],\"postId\":[\"PARAMETER_POST_ID\"]}");
       rotationJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
@@ -517,15 +518,21 @@ public class TcsServiceImpl extends AbstractClientService {
         .getBody();
   }
 
+  /**
+   * Calls the endpoint to retrieve all specialties filtered by name and SpecialtyType
+   * @param name          the name of the Specialty
+   * @param specialtyType the SpecialtyType to filter specialties by
+   * @return              list of all specialties matching the parameters
+   */
   @Cacheable("specialty")
   public List<SpecialtyDTO> getSpecialtyByName(String name, SpecialtyType specialtyType) {
     log.debug("calling getSpecialtyByName with {}", name);
     return tcsRestTemplate
         .exchange(
-            serviceUrl + API_CURRENT_SPECIALTIES_COLUMN_FILTERS +
-                specialtyJsonQuerystringAndSpecialtyTypeURLEncoded
-                .replace("PARAMETER_NAME", urlEncode(name))
-                .replace("PARAMETER_TYPE", urlEncode(specialtyType.name())), HttpMethod.GET,
+            serviceUrl + API_CURRENT_SPECIALTIES_COLUMN_FILTERS
+                + specialtyJsonQuerystringAndSpecialtyTypeURLEncoded
+                    .replace("PARAMETER_NAME", urlEncode(name))
+                    .replace("PARAMETER_TYPE", urlEncode(specialtyType.name())), HttpMethod.GET,
             null,
             new ParameterizedTypeReference<List<SpecialtyDTO>>() {
             })

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -33,6 +33,7 @@ import com.transformuk.hee.tis.tcs.api.dto.TariffFundingTypeFieldsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TariffRateDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainerApprovalDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.List;
@@ -102,8 +103,8 @@ public class TcsServiceImpl extends AbstractClientService {
   private static final String API_ABSENCE_BY_ABS_ID = API_ABSENCE + "absenceId/";
   private static final Map<Class, ParameterizedTypeReference> classToParamTypeRefMap;
   private static String curriculumJsonQuerystringURLEncoded, programmeJsonQuerystringURLEncoded,
-      specialtyJsonQuerystringURLEncoded, placementJsonQuerystringURLEncoded,
-      rotationJsonQuerystringURLEncoded;
+      specialtyJsonQuerystringURLEncoded, specialtyJsonQuerystringAndSpecialtyTypeURLEncoded,
+      placementJsonQuerystringURLEncoded, rotationJsonQuerystringURLEncoded;
 
   static {
     try {
@@ -113,6 +114,8 @@ public class TcsServiceImpl extends AbstractClientService {
           "{\"programmeName\":[\"PARAMETER_NAME\"],\"programmeNumber\":[\"PARAMETER_NUMBER\"],\"status\":[\"CURRENT\"]}");
       specialtyJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
           .encode("{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"]}");
+      specialtyJsonQuerystringAndSpecialtyTypeURLEncoded = new org.apache.commons.codec.net.URLCodec()
+          .encode("{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"],\"specialtyTypes\":[\"PARAMETER_TYPE\"]}");
       placementJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
           .encode("{\"traineeId\":[\"PARAMETER_TRAINEE_ID\"],\"postId\":[\"PARAMETER_POST_ID\"]}");
       rotationJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
@@ -509,6 +512,21 @@ public class TcsServiceImpl extends AbstractClientService {
         .exchange(
             serviceUrl + API_CURRENT_SPECIALTIES_COLUMN_FILTERS + specialtyJsonQuerystringURLEncoded
                 .replace("PARAMETER_NAME", urlEncode(name)), HttpMethod.GET, null,
+            new ParameterizedTypeReference<List<SpecialtyDTO>>() {
+            })
+        .getBody();
+  }
+
+  @Cacheable("specialty")
+  public List<SpecialtyDTO> getSpecialtyByName(String name, SpecialtyType specialtyType) {
+    log.debug("calling getSpecialtyByName with {}", name);
+    return tcsRestTemplate
+        .exchange(
+            serviceUrl + API_CURRENT_SPECIALTIES_COLUMN_FILTERS +
+                specialtyJsonQuerystringAndSpecialtyTypeURLEncoded
+                .replace("PARAMETER_NAME", urlEncode(name))
+                .replace("PARAMETER_TYPE", urlEncode(specialtyType.name())), HttpMethod.GET,
+            null,
             new ParameterizedTypeReference<List<SpecialtyDTO>>() {
             })
         .getBody();

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.EncoderException;
+import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -108,18 +109,18 @@ public class TcsServiceImpl extends AbstractClientService {
 
   static {
     try {
-      curriculumJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
+      curriculumJsonQuerystringURLEncoded = new URLCodec()
           .encode("{\"name\":[\"PARAMETER_NAME\"]}");
-      programmeJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec().encode(
+      programmeJsonQuerystringURLEncoded = new URLCodec().encode(
           "{\"programmeName\":[\"PARAMETER_NAME\"],\"programmeNumber\":[\"PARAMETER_NUMBER\"],\"status\":[\"CURRENT\"]}");
-      specialtyJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
+      specialtyJsonQuerystringURLEncoded = new URLCodec()
           .encode("{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"]}");
-      specialtyJsonQuerystringAndSpecialtyTypeURLEncoded = new org.apache.commons.codec.net.URLCodec()
-          .encode(
-              "{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"],\"specialtyTypes\":[\"PARAMETER_TYPE\"]}");
-      placementJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
+      specialtyJsonQuerystringAndSpecialtyTypeURLEncoded = new URLCodec().encode(
+              "{\"name\":[\"PARAMETER_NAME\"],\"status\":[\"CURRENT\"],"
+                  + "\"specialtyTypes\":[\"PARAMETER_TYPE\"]}");
+      placementJsonQuerystringURLEncoded = new URLCodec()
           .encode("{\"traineeId\":[\"PARAMETER_TRAINEE_ID\"],\"postId\":[\"PARAMETER_POST_ID\"]}");
-      rotationJsonQuerystringURLEncoded = new org.apache.commons.codec.net.URLCodec()
+      rotationJsonQuerystringURLEncoded = new URLCodec()
           .encode("{\"programmeId\":[\"PARAMETER_PROGRAMME_ID\"],\"status\":[\"CURRENT\"]}");
     } catch (EncoderException e) {
       log.error("URL encoding failed.", e);
@@ -519,7 +520,8 @@ public class TcsServiceImpl extends AbstractClientService {
   }
 
   /**
-   * Calls the endpoint to retrieve all specialties filtered by name and SpecialtyType
+   * Calls the endpoint to retrieve all specialties filtered by name and SpecialtyType.
+   *
    * @param name          the name of the Specialty
    * @param specialtyType the SpecialtyType to filter specialties by
    * @return              list of all specialties matching the parameters


### PR DESCRIPTION
Extra method added so that `tcsServiceImpl.getSpecialtyByName` can take two parameters, not just one.
The second parameter is the `SpecialtyType`, and it'll pass the value as a columnFilter to the endpoint it'll call.

Addition needed in order to retrieve all matching Specialties of type **SpecialtyType.SUB_SPECIALTY** from Generic Upload.
[Here's where it'll be used](https://github.com/Health-Education-England/TIS-GENERIC-UPLOAD/pull/156/files#diff-6256dd397dc350eb0e80fce68b23e6999bb856d18c77e356bc23b841fa588e23R279)

Only thing I wasn't sure about was whether to give the new method the same name and overload the existing method, or to specify a different name (e.g. `getSpecialtiesByNameAndSpecialtyType`)

TIS21-2460: Limit list of specialties to subspecialties