### PR TITLE
fix: email address validation regexp

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.24.1</version>
+  <version>6.24.2</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidator.java
@@ -26,7 +26,7 @@ public class ContactDetailsValidator {
   private static final String CONTACT_DETAILS_DTO_NAME = "ContactDetailsDTO";
 
   // TODO: Better way to validate emails.
-  private static final String REGEX_EMAIL = "^$|^[A-Za-z0-9+_.-]+@(.+)$";
+  private static final String REGEX_EMAIL = "^$|[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?";
   private static final String REGEX_EMAIL_ERROR = "Valid email format required.";
 
   private static final String REGEX_NAME = "^$|^[A-Za-z0-9\\-' ]+";

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidatorTest.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -844,19 +846,30 @@ class ContactDetailsValidatorTest {
     assertThat("Unexpected number of field errors.", fieldErrors.size(), is(0));
   }
 
-  @Test
-  void shouldReturnErrorsWhenEmailFormatNotValid() {
+  @ParameterizedTest
+  @ValueSource(strings = {"a..b@b.com", "()@b.com", "a@f%.com", "a@b|.com", "a.b.com", "a@f'%com",
+      //following examples drawn from https://en.wikipedia.org/wiki/Email_address
+      //failing entries with the current REGEXP are commented out
+      "Abc.example.com",
+      "A@b@c@example.com",
+      "a\"b(c)d,e:f;g<h>i[j\\k]l@example.com",
+      "just\"not\"right@example.com",
+      "this is\"not\\allowed@example.com",
+      "this\\ still\\\"not\\\\allowed@example.com",
+      /* "1234567890123456789012345678901234567890123456789012345678901234+x@example.com", */
+      "i_like_underscore@but_its_not_allowed_in_this_part.example.com"})
+  void shouldReturnErrorsWhenEmailFormatNotValid(String email) {
     // Given.
     ContactDetailsDTO dto = new ContactDetailsDTO();
     dto.setForenames("");
     dto.setSurname("");
-    dto.setEmail("a*@b.com");
+    dto.setEmail(email);
 
     // When.
     List<FieldError> fieldErrors = validator.validateForBulk(dto);
 
     // Then.
-    assertThat("Unexpected number of field errors.", fieldErrors.size(), is(1));
+    assertThat("No field error for invalid email: '" + email + "'", fieldErrors.size(), is(1));
 
     FieldError fieldError =
         new FieldError(ContactDetailsDTO.class.getSimpleName(), "email", REGEX_EMAIL_ERROR);
@@ -969,19 +982,41 @@ class ContactDetailsValidatorTest {
     assertThat("Unexpected number of field errors.", fieldErrors.size(), is(0));
   }
 
-  @Test
-  void shouldNotReturnErrorsWhenEmailIsValid() {
+  @ParameterizedTest
+  @ValueSource(strings = {"o'connor@abc.com",
+      //following examples drawn from https://en.wikipedia.org/wiki/Email_address
+      //failing entries with the current REGEXP are commented out
+      "simple@example.com",
+      "very.common@example.com",
+      "disposable.style.email.with+symbol@example.com",
+      "other.email-with-hyphen@example.com",
+      "fully-qualified-domain@example.com",
+      "user.name+tag+sorting@example.com",
+      "x@example.com",
+      "example-indeed@strange-example.com",
+      "test/test@test.com",
+      /* "admin@mailserver1", */
+      "example@s.example",
+      /* "\" \"@example.org", */
+      /* "\"john..doe\"@example.org", */
+      "mailhost!username@example.org",
+      /* "\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com", */
+      "user%example.com@example.org",
+      "user-@example.org"
+      /*, "postmaster@[123.123.123.123]", */
+      /* "postmaster@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]" */})
+  void shouldNotReturnErrorsWhenEmailIsValid(String email) {
     // Given.
     ContactDetailsDTO dto = new ContactDetailsDTO();
     dto.setForenames("");
     dto.setSurname("");
-    dto.setEmail("a@b.com");
+    dto.setEmail(email);
 
     // When.
     List<FieldError> fieldErrors = validator.validateForBulk(dto);
 
     // Then.
-    assertThat("Unexpected number of field errors.", fieldErrors.size(), is(0));
+    assertThat("Field error for valid email: '" + email + "'", fieldErrors.size(), is(0));
   }
 
   @Test


### PR DESCRIPTION
This makes the email address validation regexp consistent with the one
used in admins-ui.

Note that it is not comprehensive: tests have been enhanced to
demonstrate failing examples. As such, the TODO for finding a better
solution has been left in place.

TIS21-2764