### PR TITLE
feat: refactor ProgrammeMembership table

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>6.15.0</version>
+  <version>6.16.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -22,8 +22,13 @@ public class ProgrammeMembershipDTO implements Serializable {
 
   private Long id;
 
-  @Null(groups = {Create.class})
-  private UUID programmeMembershipUuid; //real (database record) UUID
+  /**
+   * This is the real unique (database) identifier for a ProgrammeMembership. Existing clients may
+   * use this DTO to update a {@link CurriculumMembershipDTO}, without this uuid. That means we
+   * can't specify @NotNull(message = "uuid is required", groups = {Update.class})
+   */
+  @Null(message = "ProgrammeMembership ID must be null", groups = {Create.class})
+  private UUID programmeMembershipUuid;
 
   @NotNull(message = "ProgrammeMembershipType is required", groups = {Update.class, Create.class})
   private ProgrammeMembershipType programmeMembershipType;

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -28,7 +28,7 @@ public class ProgrammeMembershipDTO implements Serializable {
    * can't specify @NotNull(message = "uuid is required", groups = {Update.class})
    */
   @Null(message = "ProgrammeMembership ID must be null", groups = {Create.class})
-  private UUID programmeMembershipUuid;
+  private UUID uuid;
 
   @NotNull(message = "ProgrammeMembershipType is required", groups = {Update.class, Create.class})
   private ProgrammeMembershipType programmeMembershipType;

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -23,7 +23,7 @@ public class ProgrammeMembershipDTO implements Serializable {
   private Long id;
 
   @Null(groups = {Create.class})
-  private UUID programmeMembershipId; //real (database record) ID
+  private UUID programmeMembershipUuid; //real (database record) UUID
 
   @NotNull(message = "ProgrammeMembershipType is required", groups = {Update.class, Create.class})
   private ProgrammeMembershipType programmeMembershipType;

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -20,6 +20,8 @@ public class ProgrammeMembershipDTO implements Serializable {
 
   private Long id;
 
+  private Long programmeMembershipId; //real (database record) ID
+
   @NotNull(message = "ProgrammeMembershipType is required", groups = {Update.class, Create.class})
   private ProgrammeMembershipType programmeMembershipType;
 

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -20,7 +21,7 @@ public class ProgrammeMembershipDTO implements Serializable {
 
   private Long id;
 
-  private Long programmeMembershipId; //real (database record) ID
+  private UUID programmeMembershipId; //real (database record) ID
 
   @NotNull(message = "ProgrammeMembershipType is required", groups = {Update.class, Create.class})
   private ProgrammeMembershipType programmeMembershipType;

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
 import lombok.Data;
 
 /**
@@ -21,6 +22,7 @@ public class ProgrammeMembershipDTO implements Serializable {
 
   private Long id;
 
+  @Null(groups = {Create.class})
   private UUID programmeMembershipId; //real (database record) ID
 
   @NotNull(message = "ProgrammeMembershipType is required", groups = {Update.class, Create.class})

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ProgrammeMembershipDTO.java
@@ -5,6 +5,7 @@ import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
@@ -48,6 +49,8 @@ public class ProgrammeMembershipDTO implements Serializable {
   private String trainingPathway;
 
   private TrainingNumberDTO trainingNumber;
+
+  private LocalDateTime amendedDate;
 
   @Valid
   private List<CurriculumMembershipDTO> curriculumMemberships;

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/enumeration/ProgrammeMembershipType.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/enumeration/ProgrammeMembershipType.java
@@ -26,6 +26,7 @@ public enum ProgrammeMembershipType {
     return null;
   }
 
+  @Override
   public String toString() {
     return text;
   }

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.15.0</version>
+      <version>6.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>5.14.0</version>
+  <version>5.15.0</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.15.0</version>
+      <version>6.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.22.0</version>
+  <version>2.23.0</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -33,7 +33,7 @@ public class CurriculumMembership implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(targetEntity = ProgrammeMembership.class, fetch = FetchType.LAZY)
+  @ManyToOne(targetEntity = ProgrammeMembership.class)
   @JoinColumn(name = "programmeMembershipId")
   private ProgrammeMembership programmeMembership;
 
@@ -64,6 +64,7 @@ public class CurriculumMembership implements Serializable {
 
   private String leavingDestination;
 
+  @Deprecated
   private String leavingReason;
 
   @Deprecated

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -38,7 +38,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   @ManyToOne
@@ -48,7 +48,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   @Enumerated(EnumType.STRING)
@@ -63,7 +63,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private LocalDate programmeStartDate;
@@ -73,7 +73,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private LocalDate programmeEndDate;
@@ -81,7 +81,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private String leavingDestination;
@@ -89,7 +89,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private String leavingReason;
@@ -97,7 +97,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   @ManyToOne
@@ -109,7 +109,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   @ManyToOne
@@ -119,7 +119,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   @ManyToOne
@@ -132,7 +132,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private String trainingPathway;
@@ -145,7 +145,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   public CurriculumMembership programmeMembershipType(
@@ -157,7 +157,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   public CurriculumMembership rotation(Rotation rotation) {
@@ -183,7 +183,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   public CurriculumMembership programmeStartDate(LocalDate programmeStartDate) {
@@ -199,7 +199,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   public CurriculumMembership programmeEndDate(LocalDate programmeEndDate) {
@@ -210,7 +210,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   public CurriculumMembership leavingDestination(String leavingDestination) {
@@ -221,7 +221,7 @@ public class CurriculumMembership implements Serializable {
   /**
    * This field is now part of Programme Membership.
    *
-   * @deprecated (to be removed as part of Programme Membership refactoring)
+   * @deprecated 2022-05 (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   public CurriculumMembership leavingReason(String leavingReason) {

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.tcs.service.model;
 
+import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -8,15 +9,16 @@ import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Version;
+import javax.validation.constraints.NotNull;
+
 import lombok.Data;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 /**
  * A CurriculumMembership.
@@ -31,8 +33,7 @@ public class CurriculumMembership implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
-  //@Cascade(CascadeType.SAVE_UPDATE)
+  @ManyToOne(targetEntity = ProgrammeMembership.class, fetch = FetchType.LAZY)
   @JoinColumn(name = "programmeMembershipId")
   private ProgrammeMembership programmeMembership;
 

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -30,7 +30,7 @@ public class CurriculumMembership implements Serializable {
   private Long id;
 
   @ManyToOne(targetEntity = ProgrammeMembership.class)
-  @JoinColumn(name = "programmeMembershipId")
+  @JoinColumn(name = "programmeMembershipUuid")
   private ProgrammeMembership programmeMembership;
 
   private String intrepidId;

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -29,12 +29,18 @@ public class CurriculumMembership implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @ManyToOne
+  @JoinColumn(name = "programmeMembershipId")
+  private ProgrammeMembership programmeMembership;
+
   private String intrepidId;
 
+  @Deprecated
   @ManyToOne
   @JoinColumn(name = "personId")
   private Person person;
 
+  @Deprecated
   @Enumerated(EnumType.STRING)
   private ProgrammeMembershipType programmeMembershipType;
 
@@ -44,26 +50,31 @@ public class CurriculumMembership implements Serializable {
 
   private Integer periodOfGrace;
 
+  @Deprecated
   private LocalDate programmeStartDate;
 
   private LocalDate curriculumCompletionDate;
 
+  @Deprecated
   private LocalDate programmeEndDate;
 
   private String leavingDestination;
 
   private String leavingReason;
 
+  @Deprecated
   @ManyToOne
   @JoinColumn(name = "programmeId")
   private Programme programme;
 
   private Long curriculumId;
 
+  @Deprecated
   @ManyToOne
   @JoinColumn(name = "rotationId")
   private Rotation rotation;
 
+  @Deprecated
   @ManyToOne
   @JoinColumn(name = "trainingNumberId")
   private TrainingNumber trainingNumber;
@@ -71,6 +82,7 @@ public class CurriculumMembership implements Serializable {
   @Version
   private LocalDateTime amendedDate;
 
+  @Deprecated
   private String trainingPathway;
 
   public CurriculumMembership intrepidId(String intrepidId) {

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -35,11 +35,17 @@ public class CurriculumMembership implements Serializable {
 
   private String intrepidId;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   @ManyToOne
   @JoinColumn(name = "personId")
   private Person person;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   @Enumerated(EnumType.STRING)
   private ProgrammeMembershipType programmeMembershipType;
@@ -50,20 +56,35 @@ public class CurriculumMembership implements Serializable {
 
   private Integer periodOfGrace;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   private LocalDate programmeStartDate;
 
   private LocalDate curriculumCompletionDate;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   private LocalDate programmeEndDate;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   private String leavingDestination;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   private String leavingReason;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   @ManyToOne
   @JoinColumn(name = "programmeId")
@@ -71,11 +92,17 @@ public class CurriculumMembership implements Serializable {
 
   private Long curriculumId;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   @ManyToOne
   @JoinColumn(name = "rotationId")
   private Rotation rotation;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   @ManyToOne
   @JoinColumn(name = "trainingNumberId")
@@ -84,6 +111,9 @@ public class CurriculumMembership implements Serializable {
   @Version
   private LocalDateTime amendedDate;
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
   @Deprecated
   private String trainingPathway;
 
@@ -92,12 +122,20 @@ public class CurriculumMembership implements Serializable {
     return this;
   }
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
+  @Deprecated
   public CurriculumMembership programmeMembershipType(
       ProgrammeMembershipType programmeMembershipType) {
     this.programmeMembershipType = programmeMembershipType;
     return this;
   }
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
+  @Deprecated
   public CurriculumMembership rotation(Rotation rotation) {
     this.rotation = rotation;
     return this;
@@ -118,6 +156,10 @@ public class CurriculumMembership implements Serializable {
     return this;
   }
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
+  @Deprecated
   public CurriculumMembership programmeStartDate(LocalDate programmeStartDate) {
     this.programmeStartDate = programmeStartDate;
     return this;
@@ -128,16 +170,28 @@ public class CurriculumMembership implements Serializable {
     return this;
   }
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
+  @Deprecated
   public CurriculumMembership programmeEndDate(LocalDate programmeEndDate) {
     this.programmeEndDate = programmeEndDate;
     return this;
   }
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
+  @Deprecated
   public CurriculumMembership leavingDestination(String leavingDestination) {
     this.leavingDestination = leavingDestination;
     return this;
   }
 
+  /**
+   * @deprecated (to be removed as part of Programme Membership refactoring)
+   */
+  @Deprecated
   public CurriculumMembership leavingReason(String leavingReason) {
     this.leavingReason = leavingReason;
     return this;

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -58,6 +58,7 @@ public class CurriculumMembership implements Serializable {
   @Deprecated
   private LocalDate programmeEndDate;
 
+  @Deprecated
   private String leavingDestination;
 
   @Deprecated

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -1,6 +1,5 @@
 package com.transformuk.hee.tis.tcs.service.model;
 
-import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -9,15 +8,12 @@ import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Version;
-import javax.validation.constraints.NotNull;
-
 import lombok.Data;
 
 /**

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -15,6 +15,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Version;
 import lombok.Data;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 /**
  * A CurriculumMembership.
@@ -30,6 +32,7 @@ public class CurriculumMembership implements Serializable {
   private Long id;
 
   @ManyToOne
+  //@Cascade(CascadeType.SAVE_UPDATE)
   @JoinColumn(name = "programmeMembershipId")
   private ProgrammeMembership programmeMembership;
 

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembership.java
@@ -36,6 +36,8 @@ public class CurriculumMembership implements Serializable {
   private String intrepidId;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -44,6 +46,8 @@ public class CurriculumMembership implements Serializable {
   private Person person;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -57,6 +61,8 @@ public class CurriculumMembership implements Serializable {
   private Integer periodOfGrace;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -65,24 +71,32 @@ public class CurriculumMembership implements Serializable {
   private LocalDate curriculumCompletionDate;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private LocalDate programmeEndDate;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private String leavingDestination;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
   private String leavingReason;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -93,6 +107,8 @@ public class CurriculumMembership implements Serializable {
   private Long curriculumId;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -101,6 +117,8 @@ public class CurriculumMembership implements Serializable {
   private Rotation rotation;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -112,6 +130,8 @@ public class CurriculumMembership implements Serializable {
   private LocalDateTime amendedDate;
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -123,6 +143,8 @@ public class CurriculumMembership implements Serializable {
   }
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -133,6 +155,8 @@ public class CurriculumMembership implements Serializable {
   }
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -157,6 +181,8 @@ public class CurriculumMembership implements Serializable {
   }
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -171,6 +197,8 @@ public class CurriculumMembership implements Serializable {
   }
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -180,6 +208,8 @@ public class CurriculumMembership implements Serializable {
   }
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated
@@ -189,6 +219,8 @@ public class CurriculumMembership implements Serializable {
   }
 
   /**
+   * This field is now part of Programme Membership.
+   *
    * @deprecated (to be removed as part of Programme Membership refactoring)
    */
   @Deprecated

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Person.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Person.java
@@ -94,7 +94,7 @@ public class Person implements Serializable {
 
   @OneToMany(mappedBy = "person", cascade = {CascadeType.REMOVE,
       CascadeType.REFRESH}, orphanRemoval = true)
-  private Set<CurriculumMembership> curriculumMemberships = new HashSet<>();
+  private Set<ProgrammeMembership> programmeMemberships = new HashSet<>();
 
   @OneToOne
   @JoinColumn(unique = true, name = "id")
@@ -132,11 +132,11 @@ public class Person implements Serializable {
   }
 
   public Status programmeMembershipsStatus() {
-    if (CollectionUtils.isEmpty(this.getCurriculumMemberships())) {
+    if (CollectionUtils.isEmpty(this.getProgrammeMemberships())) {
       return Status.INACTIVE;
     }
     LocalDate today = LocalDate.now();
-    return this.getCurriculumMemberships().parallelStream()
+    return this.getProgrammeMemberships().parallelStream()
         .filter(pm -> pm.getProgrammeStartDate() != null && pm.getProgrammeEndDate() != null)
         .anyMatch(pm -> !today.isBefore(pm.getProgrammeStartDate())
             && !today.isAfter(pm.getProgrammeEndDate()))
@@ -197,8 +197,8 @@ public class Person implements Serializable {
     return this;
   }
 
-  public Person programmeMemberships(Set<CurriculumMembership> curriculumMemberships) {
-    this.curriculumMemberships = curriculumMemberships;
+  public Person programmeMemberships(Set<ProgrammeMembership> programmeMemberships) {
+    this.programmeMemberships = programmeMemberships;
     return this;
   }
 

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -58,9 +58,9 @@ public class ProgrammeMembership implements Serializable {
   @JoinColumn(name = "trainingNumberId")
   private TrainingNumber trainingNumber;
 
-  //@OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.ALL}, orphanRemoval = true)
-  @OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.REMOVE,
-      CascadeType.REFRESH}, orphanRemoval = true)
+  @OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.ALL}, orphanRemoval = true)
+  //@OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.REMOVE,
+  //    CascadeType.REFRESH}, orphanRemoval = true)
   private Set<CurriculumMembership> curriculumMemberships = new HashSet<>();
 
   @Version

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -19,6 +20,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Version;
 import lombok.Data;
+import org.hibernate.annotations.GenericGenerator;
 
 /**
  * A ProgrammeMembership.
@@ -30,8 +32,12 @@ public class ProgrammeMembership implements Serializable {
   private static final long serialVersionUID = 1L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  @GeneratedValue(generator = "UUID")
+  @GenericGenerator(
+      name = "UUID",
+      strategy = "org.hibernate.id.UUIDGenerator"
+  )
+  private UUID id;
 
   @ManyToOne
   @JoinColumn(name = "personId")
@@ -45,6 +51,8 @@ public class ProgrammeMembership implements Serializable {
   private LocalDate programmeEndDate;
 
   private String leavingReason;
+
+  private String leavingDestination;
 
   @ManyToOne
   @JoinColumn(name = "programmeId")
@@ -89,6 +97,11 @@ public class ProgrammeMembership implements Serializable {
 
   public ProgrammeMembership leavingReason(String leavingReason) {
     this.leavingReason = leavingReason;
+    return this;
+  }
+
+  public ProgrammeMembership leavingDestination(String leavingDestination) {
+    this.leavingDestination = leavingDestination;
     return this;
   }
 

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -1,6 +1,5 @@
 package com.transformuk.hee.tis.tcs.service.model;
 
-import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -12,7 +11,6 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -20,8 +18,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Version;
-import javax.validation.constraints.NotNull;
-
 import lombok.Data;
 
 /**
@@ -62,8 +58,7 @@ public class ProgrammeMembership implements Serializable {
   @JoinColumn(name = "trainingNumberId")
   private TrainingNumber trainingNumber;
 
-  @OneToMany(mappedBy = "programmeMembership", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY,
-      orphanRemoval = true)
+  @OneToMany(mappedBy = "programmeMembership", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<CurriculumMembership> curriculumMemberships = new HashSet<>();
 
   @Version

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -38,7 +38,7 @@ public class ProgrammeMembership implements Serializable {
       strategy = "org.hibernate.id.UUIDGenerator"
   )
   @Type(type = "org.hibernate.type.UUIDCharType")
-  private UUID id;
+  private UUID uuid;
 
   @ManyToOne
   @JoinColumn(name = "personId")
@@ -115,14 +115,14 @@ public class ProgrammeMembership implements Serializable {
       return false;
     }
     ProgrammeMembership programmeMembership = (ProgrammeMembership) o;
-    if (programmeMembership.id == null || id == null) {
+    if (programmeMembership.uuid == null || uuid == null) {
       return false;
     }
-    return Objects.equals(id, programmeMembership.id);
+    return Objects.equals(uuid, programmeMembership.uuid);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id);
+    return Objects.hashCode(uuid);
   }
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -37,7 +37,7 @@ public class ProgrammeMembership implements Serializable {
       name = "UUID",
       strategy = "org.hibernate.id.UUIDGenerator"
   )
-  @Type(type="org.hibernate.type.UUIDCharType")
+  @Type(type = "org.hibernate.type.UUIDCharType")
   private UUID id;
 
   @ManyToOne

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.tcs.service.model;
 
+import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -11,6 +12,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -18,6 +20,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Version;
+import javax.validation.constraints.NotNull;
+
 import lombok.Data;
 
 /**
@@ -58,9 +62,8 @@ public class ProgrammeMembership implements Serializable {
   @JoinColumn(name = "trainingNumberId")
   private TrainingNumber trainingNumber;
 
-  @OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.ALL}, orphanRemoval = true)
-  //@OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.REMOVE,
-  //    CascadeType.REFRESH}, orphanRemoval = true)
+  @OneToMany(mappedBy = "programmeMembership", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY,
+      orphanRemoval = true)
   private Set<CurriculumMembership> curriculumMemberships = new HashSet<>();
 
   @Version

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -4,7 +4,10 @@ import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -13,6 +16,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Version;
 import lombok.Data;
 
@@ -29,8 +33,6 @@ public class ProgrammeMembership implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private String intrepidId;
-
   @ManyToOne
   @JoinColumn(name = "personId")
   private Person person;
@@ -38,27 +40,15 @@ public class ProgrammeMembership implements Serializable {
   @Enumerated(EnumType.STRING)
   private ProgrammeMembershipType programmeMembershipType;
 
-  private LocalDate curriculumStartDate;
-
-  private LocalDate curriculumEndDate;
-
-  private Integer periodOfGrace;
-
   private LocalDate programmeStartDate;
 
-  private LocalDate curriculumCompletionDate;
-
   private LocalDate programmeEndDate;
-
-  private String leavingDestination;
 
   private String leavingReason;
 
   @ManyToOne
   @JoinColumn(name = "programmeId")
   private Programme programme;
-
-  private Long curriculumId;
 
   @ManyToOne
   @JoinColumn(name = "rotationId")
@@ -68,15 +58,15 @@ public class ProgrammeMembership implements Serializable {
   @JoinColumn(name = "trainingNumberId")
   private TrainingNumber trainingNumber;
 
+  //@OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.ALL}, orphanRemoval = true)
+  @OneToMany(mappedBy = "programmeMembership", cascade = {CascadeType.REMOVE,
+      CascadeType.REFRESH}, orphanRemoval = true)
+  private Set<CurriculumMembership> curriculumMemberships = new HashSet<>();
+
   @Version
   private LocalDateTime amendedDate;
 
   private String trainingPathway;
-
-  public ProgrammeMembership intrepidId(String intrepidId) {
-    this.intrepidId = intrepidId;
-    return this;
-  }
 
   public ProgrammeMembership programmeMembershipType(
       ProgrammeMembershipType programmeMembershipType) {
@@ -89,38 +79,13 @@ public class ProgrammeMembership implements Serializable {
     return this;
   }
 
-  public ProgrammeMembership curriculumStartDate(LocalDate curriculumStartDate) {
-    this.curriculumStartDate = curriculumStartDate;
-    return this;
-  }
-
-  public ProgrammeMembership curriculumEndDate(LocalDate curriculumEndDate) {
-    this.curriculumEndDate = curriculumEndDate;
-    return this;
-  }
-
-  public ProgrammeMembership periodOfGrace(Integer periodOfGrace) {
-    this.periodOfGrace = periodOfGrace;
-    return this;
-  }
-
   public ProgrammeMembership programmeStartDate(LocalDate programmeStartDate) {
     this.programmeStartDate = programmeStartDate;
     return this;
   }
 
-  public ProgrammeMembership curriculumCompletionDate(LocalDate curriculumCompletionDate) {
-    this.curriculumCompletionDate = curriculumCompletionDate;
-    return this;
-  }
-
   public ProgrammeMembership programmeEndDate(LocalDate programmeEndDate) {
     this.programmeEndDate = programmeEndDate;
-    return this;
-  }
-
-  public ProgrammeMembership leavingDestination(String leavingDestination) {
-    this.leavingDestination = leavingDestination;
     return this;
   }
 

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -13,7 +13,6 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -21,6 +20,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Version;
 import lombok.Data;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
 
 /**
  * A ProgrammeMembership.
@@ -37,6 +37,7 @@ public class ProgrammeMembership implements Serializable {
       name = "UUID",
       strategy = "org.hibernate.id.UUIDGenerator"
   )
+  @Type(type="org.hibernate.type.UUIDCharType")
   private UUID id;
 
   @ManyToOne

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
@@ -13,7 +13,10 @@ import org.springframework.data.repository.query.Param;
 @SuppressWarnings("unused")
 public interface CurriculumMembershipRepository extends JpaRepository<CurriculumMembership, Long> {
   //Note: personId, programme, programmeEndDate etc. are now only updated in the
-  //programmeMembership table, and may be null in the curriculumMembership table.
+  //programmeMembership table, and may be NULL in the CurriculumMembership table.
+
+  //TODO: the CurriculumMemberships that are returned may have NULL values in the fields above (the deprecated fields)
+  // - these need to be resolved
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
@@ -12,36 +12,32 @@ import org.springframework.data.repository.query.Param;
  */
 @SuppressWarnings("unused")
 public interface CurriculumMembershipRepository extends JpaRepository<CurriculumMembership, Long> {
-  //Note: personId, programme, programmeEndDate etc. are now only updated in the
-  //programmeMembership table, and may be NULL in the CurriculumMembership table.
-
-  //TODO: the CurriculumMemberships that are returned may have NULL values in the fields above (the deprecated fields)
-  // - these need to be resolved
+  //Note: personId, programme, programmeEndDate etc. should be updated in the
+  //programmeMembership table, and removed from the CurriculumMembership table.
+  //See commit 43657e57f8068704ed5ad81f8b9d66090845d025 for initial work to refactor this
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE cm.programmeMembership.person.id = :traineeId "
-      + "AND cm.programmeMembership.programme.id = :programmeId")
+      + "WHERE personId = :traineeId "
+      + "AND cm.programme.id = :programmeId")
   List<CurriculumMembership> findByTraineeIdAndProgrammeId(@Param("traineeId") Long traineeId,
                                                           @Param("programmeId") Long programmeId);
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE cm.programmeMembership.person.id = :traineeId")
+      + "WHERE personId = :traineeId")
   List<CurriculumMembership> findByTraineeId(@Param("traineeId") Long traineeId);
 
   //Find latest curriculum membership of a trainee
   @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipId = pm.id "
-      + "WHERE pm.personId = :traineeId ORDER BY pm.programmeEndDate DESC LIMIT 1",
+      + "WHERE cm.personId = :traineeId ORDER BY cm.programmeEndDate DESC LIMIT 1",
       nativeQuery = true)
   CurriculumMembership findLatestCurriculumMembershipByTraineeId(@Param("traineeId")
                                                                      Long traineeId);
 
   @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipId = pm.id "
-      + "WHERE pm.personId = :traineeId "
-      + "ORDER BY pm.programmeEndDate DESC", nativeQuery = true)
+      + "WHERE cm.personId = :traineeId "
+      + "ORDER BY cm.programmeEndDate DESC", nativeQuery = true)
   List<CurriculumMembership> findAllCurriculumMembershipInDescOrderByTraineeId(
       @Param("traineeId") Long traineeId);
 
@@ -54,8 +50,7 @@ public interface CurriculumMembershipRepository extends JpaRepository<Curriculum
 
   //Find latest curriculum membership of a trainee order by curriculum end date
   @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipId = pm.id "
-      + "WHERE pm.personId = :traineeId ORDER BY cm.curriculumEndDate DESC LIMIT 1",
+      + "WHERE cm.personId = :traineeId ORDER BY cm.curriculumEndDate DESC LIMIT 1",
       nativeQuery = true)
   CurriculumMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
@@ -43,7 +43,7 @@ public interface CurriculumMembershipRepository extends JpaRepository<Curriculum
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE cm.programmeMembership.programme.id = :programmeId")
+      + "WHERE cm.programme.id = :programmeId")
   List<CurriculumMembership> findByProgrammeId(@Param("programmeId") Long programmeId);
 
   List<CurriculumMembership> findByIdIn(Set<Long> ids);

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
@@ -12,42 +12,47 @@ import org.springframework.data.repository.query.Param;
  */
 @SuppressWarnings("unused")
 public interface CurriculumMembershipRepository extends JpaRepository<CurriculumMembership, Long> {
+  //Note: personId, programme, programmeEndDate etc. are now only updated in the
+  //programmeMembership table, and may be null in the curriculumMembership table.
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE personId = :traineeId "
-      + "AND cm.programme.id = :programmeId")
+      + "WHERE cm.programmeMembership.person.id = :traineeId "
+      + "AND cm.programmeMembership.programme.id = :programmeId")
   List<CurriculumMembership> findByTraineeIdAndProgrammeId(@Param("traineeId") Long traineeId,
                                                           @Param("programmeId") Long programmeId);
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE personId = :traineeId")
+      + "WHERE cm.programmeMembership.person.id = :traineeId")
   List<CurriculumMembership> findByTraineeId(@Param("traineeId") Long traineeId);
 
   //Find latest curriculum membership of a trainee
   @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "WHERE cm.personId = :traineeId ORDER BY cm.programmeEndDate DESC LIMIT 1",
+      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipId = pm.id "
+      + "WHERE pm.personId = :traineeId ORDER BY pm.programmeEndDate DESC LIMIT 1",
       nativeQuery = true)
   CurriculumMembership findLatestCurriculumMembershipByTraineeId(@Param("traineeId")
                                                                      Long traineeId);
 
   @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "WHERE cm.personId = :traineeId "
-      + "ORDER BY cm.programmeEndDate DESC", nativeQuery = true)
+      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipId = pm.id "
+      + "WHERE pm.personId = :traineeId "
+      + "ORDER BY pm.programmeEndDate DESC", nativeQuery = true)
   List<CurriculumMembership> findAllCurriculumMembershipInDescOrderByTraineeId(
       @Param("traineeId") Long traineeId);
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE cm.programme.id = :programmeId")
+      + "WHERE cm.programmeMembership.programme.id = :programmeId")
   List<CurriculumMembership> findByProgrammeId(@Param("programmeId") Long programmeId);
 
   List<CurriculumMembership> findByIdIn(Set<Long> ids);
 
   //Find latest curriculum membership of a trainee order by curriculum end date
   @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "WHERE cm.personId = :traineeId ORDER BY cm.curriculumEndDate DESC LIMIT 1",
+      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipId = pm.id "
+      + "WHERE pm.personId = :traineeId ORDER BY cm.curriculumEndDate DESC LIMIT 1",
       nativeQuery = true)
   CurriculumMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.repository.query.Param;
  * Spring Data JPA repository for the ProgrammeMembership entity.
  */
 @SuppressWarnings("unused")
-public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMembership, Long> {
+public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMembership, UUID> {
 
   @Query(value = "SELECT pm "
       + "FROM ProgrammeMembership pm "
@@ -44,8 +44,6 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
   List<ProgrammeMembership> findByProgrammeId(@Param("programmeId") Long programmeId);
 
   List<ProgrammeMembership> findByIdIn(Set<UUID> ids);
-
-  Optional<ProgrammeMembership> findById(UUID id);
 
   //Find latest programme membership of a trainee order by curriculum end date
   //this won't work with the new structure: there is no curriculumEndDate

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -43,7 +43,9 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
       + "WHERE pm.programme.id = :programmeId")
   List<ProgrammeMembership> findByProgrammeId(@Param("programmeId") Long programmeId);
 
-  List<ProgrammeMembership> findByIdIn(Set<UUID> ids);
+  List<ProgrammeMembership> findByUuidIn(Set<UUID> ids);
+
+  Optional<ProgrammeMembership> findByUuid(UUID id);
 
   //Find latest programme membership of a trainee order by curriculum end date
   //this won't work with the new structure: there is no curriculumEndDate

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -46,11 +46,4 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
   List<ProgrammeMembership> findByUuidIn(Set<UUID> ids);
 
   Optional<ProgrammeMembership> findByUuid(UUID id);
-
-  //Find latest programme membership of a trainee order by curriculum end date
-  //this won't work with the new structure: there is no curriculumEndDate
-  //  @Query(value = "SELECT pm.* FROM ProgrammeMembership pm "
-  //      + "WHERE pm.personId = :traineeId ORDER BY pm.curriculumEndDate DESC LIMIT 1",
-  //      nativeQuery = true)
-  //  ProgrammeMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -47,8 +47,8 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
 
   //Find latest programme membership of a trainee order by curriculum end date
   //this won't work with the new structure: there is no curriculumEndDate
-//  @Query(value = "SELECT pm.* FROM ProgrammeMembership pm "
-//      + "WHERE pm.personId = :traineeId ORDER BY pm.curriculumEndDate DESC LIMIT 1",
-//      nativeQuery = true)
-//  ProgrammeMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
+  //  @Query(value = "SELECT pm.* FROM ProgrammeMembership pm "
+  //      + "WHERE pm.personId = :traineeId ORDER BY pm.curriculumEndDate DESC LIMIT 1",
+  //      nativeQuery = true)
+  //  ProgrammeMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -44,8 +44,9 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
   List<ProgrammeMembership> findByIdIn(Set<Long> ids);
 
   //Find latest programme membership of a trainee order by curriculum end date
-  @Query(value = "SELECT pm.* FROM ProgrammeMembership pm "
-      + "WHERE pm.personId = :traineeId ORDER BY pm.curriculumEndDate DESC LIMIT 1",
-      nativeQuery = true)
-  ProgrammeMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
+  //this won't work with the new structure: there is no curriculumEndDate
+//  @Query(value = "SELECT pm.* FROM ProgrammeMembership pm "
+//      + "WHERE pm.personId = :traineeId ORDER BY pm.curriculumEndDate DESC LIMIT 1",
+//      nativeQuery = true)
+//  ProgrammeMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -2,7 +2,9 @@ package com.transformuk.hee.tis.tcs.service.repository;
 
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -41,7 +43,9 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
       + "WHERE pm.programme.id = :programmeId")
   List<ProgrammeMembership> findByProgrammeId(@Param("programmeId") Long programmeId);
 
-  List<ProgrammeMembership> findByIdIn(Set<Long> ids);
+  List<ProgrammeMembership> findByIdIn(Set<UUID> ids);
+
+  Optional<ProgrammeMembership> findById(UUID id);
 
   //Find latest programme membership of a trainee order by curriculum end date
   //this won't work with the new structure: there is no curriculumEndDate

--- a/tcs-persistence/src/main/resources/queries/personView.sql
+++ b/tcs-persistence/src/main/resources/queries/personView.sql
@@ -27,7 +27,7 @@ from (
   join ContactDetails cd on (cd.id = p.id)
   left join GmcDetails gmc on (gmc.id = p.id)
   left join GdcDetails gdc on (gdc.id = p.id)
-  left join CurriculumMembership pm on (pm.personId = p.id) and curdate() between pm.programmeStartDate and pm.programmeEndDate
+  left join ProgrammeMembership pm on (pm.personId = p.id) and curdate() between pm.programmeStartDate and pm.programmeEndDate
   left join Programme prg on (prg.id = pm.programmeId)
   left join TrainingNumber tn on tn.id = pm.trainingNumberId
   left join Placement pl on (pl.traineeId = p.id) and curdate() between pl.dateFrom and pl.dateTo

--- a/tcs-persistence/src/main/resources/queries/programmeMembership.sql
+++ b/tcs-persistence/src/main/resources/queries/programmeMembership.sql
@@ -9,13 +9,13 @@ select distinct
 from
   (
   select
-    id,
-    personId,
-    programmeId,
-    trainingNumberId,
-    get_programmeMembershipStatus(programmeStartDate, programmeEndDate) as programmeMembershipStatus
+    cmem.id,
+    pmem.personId,
+    pmem.programmeId,
+    pmem.trainingNumberId,
+    get_programmeMembershipStatus(pmem.programmeStartDate, pmem.programmeEndDate) as programmeMembershipStatus
   from
-    CurriculumMembership WHERECLAUSE
+    CurriculumMembership cmem JOIN ProgrammeMembership pmem ON cmem.programmeMembershipId = pmem.id WHERECLAUSE
   ) as pm
 left join Programme prg on (prg.id = pm.programmeId)
 left join TrainingNumber tn on (tn.id = pm.trainingNumberId);

--- a/tcs-persistence/src/main/resources/queries/programmeMembership.sql
+++ b/tcs-persistence/src/main/resources/queries/programmeMembership.sql
@@ -15,7 +15,7 @@ from
     pmem.trainingNumberId,
     get_programmeMembershipStatus(pmem.programmeStartDate, pmem.programmeEndDate) as programmeMembershipStatus
   from
-    CurriculumMembership cmem JOIN ProgrammeMembership pmem ON cmem.programmeMembershipId = pmem.id WHERECLAUSE
+    CurriculumMembership cmem JOIN ProgrammeMembership pmem ON cmem.programmeMembershipUuid = pmem.uuid WHERECLAUSE
   ) as pm
 left join Programme prg on (prg.id = pm.programmeId)
 left join TrainingNumber tn on (tn.id = pm.trainingNumberId);

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -15,13 +15,14 @@ from (
     Person p
   join ContactDetails cd on (cd.id = p.id)
   left join GmcDetails gmc on (gmc.id = p.id)
-  left join (select distinct cm.personId, cm.programmeStartDate, cm.programmeEndDate,
-          cm.programmeId, cm.programmeMembershipType, cm.curriculumId, cm.curriculumEndDate
+  left join (select distinct pm.personId, pm.programmeStartDate, pm.programmeEndDate,
+          pm.programmeId, pm.programmeMembershipType, cm.curriculumId, cm.curriculumEndDate
           from CurriculumMembership cm
+          inner join ProgrammeMembership pm ON cm.programmeMembershipId = pm.id
           inner join (select personId, MAX(programmeEndDate) as latestEndDate
-              from CurriculumMembership
-              group by personId) latest on cm.personId = latest.personId
-              and cm.programmeEndDate = latest.latestEndDate
+              from ProgrammeMembership
+              group by personId) latest on pm.personId = latest.personId
+              and pm.programmeEndDate = latest.latestEndDate
           ) latestPm on (latestPm.personId = p.id)
   left join Programme prg on (prg.id = latestPm.programmeId)
   ) as ot

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -18,7 +18,7 @@ from (
   left join (select distinct pm.personId, pm.programmeStartDate, pm.programmeEndDate,
           pm.programmeId, pm.programmeMembershipType, cm.curriculumId, cm.curriculumEndDate
           from CurriculumMembership cm
-          inner join ProgrammeMembership pm ON cm.programmeMembershipId = pm.id
+          inner join ProgrammeMembership pm ON cm.programmeMembershipUuid = pm.uuid
           inner join (select personId, MAX(programmeEndDate) as latestEndDate
               from ProgrammeMembership
               group by personId) latest on pm.personId = latest.personId

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembershipTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembershipTest.java
@@ -6,14 +6,14 @@ import org.junit.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class CurriculumMembershipTest extends CurriculumMembership {
+public class CurriculumMembershipTest {
   private static final String LEAVING_REASON = "leaving reason";
   private static final String LEAVING_DESTINATION = "leaving destination";
   private static final String ROTATION_NAME = "rotation";
   private static final LocalDate START_DATE = LocalDate.of(2020, 1, 1);
   private static final LocalDate END_DATE = LocalDate.of(2020, 2, 1);
 
-  private CurriculumMembership curriculumMembership;
+  private final CurriculumMembership curriculumMembership;
 
   public CurriculumMembershipTest() {
     Rotation rotation = new Rotation();

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembershipTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/model/CurriculumMembershipTest.java
@@ -1,0 +1,63 @@
+package com.transformuk.hee.tis.tcs.service.model;
+
+import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
+import java.time.LocalDate;
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class CurriculumMembershipTest extends CurriculumMembership {
+  private static final String LEAVING_REASON = "leaving reason";
+  private static final String LEAVING_DESTINATION = "leaving destination";
+  private static final String ROTATION_NAME = "rotation";
+  private static final LocalDate START_DATE = LocalDate.of(2020, 1, 1);
+  private static final LocalDate END_DATE = LocalDate.of(2020, 2, 1);
+
+  private CurriculumMembership curriculumMembership;
+
+  public CurriculumMembershipTest() {
+    Rotation rotation = new Rotation();
+    rotation.setName(ROTATION_NAME);
+
+    curriculumMembership = new CurriculumMembership();
+
+    //The non-deprecated field get/setters are tested elsewhere; this just covers the deprecated ones
+    curriculumMembership
+        .programmeMembershipType(ProgrammeMembershipType.SUBSTANTIVE)
+        .rotation(rotation)
+        .programmeStartDate(START_DATE)
+        .programmeEndDate(END_DATE)
+        .leavingDestination(LEAVING_DESTINATION)
+        .leavingReason(LEAVING_REASON);
+  }
+
+  @Test
+  public void testDeprecatedProgrammeMembershipType() {
+    assertThat(curriculumMembership.getProgrammeMembershipType()).isEqualTo(ProgrammeMembershipType.SUBSTANTIVE);
+  }
+
+  @Test
+  public void testDeprecatedRotation() {
+    assertThat(curriculumMembership.getRotation().getName()).isEqualTo(ROTATION_NAME);
+  }
+
+  @Test
+  public void testDeprecatedProgrammeStartDate() {
+    assertThat(curriculumMembership.getProgrammeStartDate()).isEqualTo(START_DATE);
+  }
+
+  @Test
+  public void testDeprecatedProgrammeEndDate() {
+    assertThat(curriculumMembership.getProgrammeEndDate()).isEqualTo(END_DATE);
+  }
+
+  @Test
+  public void testDeprecatedLeavingDestination() {
+    assertThat(curriculumMembership.getLeavingDestination()).isEqualTo(LEAVING_DESTINATION);
+  }
+
+  @Test
+  public void testDeprecatedLeavingReason() {
+    assertThat(curriculumMembership.getLeavingReason()).isEqualTo(LEAVING_REASON);
+  }
+}

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/model/PersonTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/model/PersonTest.java
@@ -11,9 +11,9 @@ import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 
 public class PersonTest extends Person {
 
-  private CurriculumMembership pastMembership;
-  private CurriculumMembership futureMembership;
-  private CurriculumMembership currentMembership;
+  private ProgrammeMembership pastMembership;
+  private ProgrammeMembership futureMembership;
+  private ProgrammeMembership currentMembership;
 
   private LocalDate today = LocalDate.now();
   private LocalDate yesterday = today.minusDays(1);
@@ -25,15 +25,15 @@ public class PersonTest extends Person {
 
   public PersonTest() {
 
-    pastMembership = new CurriculumMembership();
+    pastMembership = new ProgrammeMembership();
     pastMembership.setProgrammeEndDate(yesterday);
     pastMembership.setProgrammeStartDate(lastYear);
 
-    futureMembership = new CurriculumMembership();
+    futureMembership = new ProgrammeMembership();
     futureMembership.setProgrammeEndDate(nextYear);
     futureMembership.setProgrammeStartDate(tomorrow);
 
-    currentMembership = new CurriculumMembership();
+    currentMembership = new ProgrammeMembership();
     currentMembership.setProgrammeEndDate(nextMonth);
     currentMembership.setProgrammeStartDate(lastMonth);
   }
@@ -42,7 +42,7 @@ public class PersonTest extends Person {
   public void testCalculateTrainingStatusWithNoProgrammes() {
     assertPersonRecordStatusEquals(Status.INACTIVE, null);
     assertPersonRecordStatusEquals(Status.INACTIVE,
-        Collections.<CurriculumMembership>emptySet());
+        Collections.emptySet());
   }
 
   @Test
@@ -58,14 +58,14 @@ public class PersonTest extends Person {
   @Test
   public void testCalculateTrainingStatusWithCurrentProgramme() {
     assertPersonRecordStatusEquals(Status.CURRENT, Collections.singleton(currentMembership));
-    Set<CurriculumMembership> allMemberships = new HashSet<CurriculumMembership>();
+    Set<ProgrammeMembership> allMemberships = new HashSet<>();
     allMemberships.addAll(Arrays.asList(pastMembership, currentMembership, futureMembership));
     assertPersonRecordStatusEquals(Status.CURRENT, allMemberships);
   }
 
   private void assertPersonRecordStatusEquals(Status expected,
-      Set<CurriculumMembership> curriculumMemberships) {
-    Person person = new Person().programmeMemberships(curriculumMemberships);
+      Set<ProgrammeMembership> programmeMemberships) {
+    Person person = new Person().programmeMemberships(programmeMemberships);
     Status actual = person.programmeMembershipsStatus();
     assertEquals(expected, actual);
   }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeRepositoryIntTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeRepositoryIntTest.java
@@ -63,6 +63,7 @@ public class ProgrammeRepositoryIntTest {
     personRepository.saveAll(Lists.newArrayList(person1, person2));
     personRepository.flush();
 
+    //TODO: rewrite with new data structure
     CurriculumMembership pm1 = new CurriculumMembership(), pm2 = new CurriculumMembership(), pm3 = new CurriculumMembership(),
         pmWithSameProgramme = new CurriculumMembership();
 

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeRepositoryIntTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeRepositoryIntTest.java
@@ -49,6 +49,8 @@ public class ProgrammeRepositoryIntTest {
   @Transactional
   @Test
   public void findByCurriculumMembershipPersonIdShouldReturnAUniqueCollectionOfProgrammesThePersonIsEnrolledOn() {
+    //TODO: rewrite this test when curriculum memberships
+    // do not duplicate programme membership fields (e.g. programme)
     Programme programme1 = new Programme(), programme2 = new Programme(), programme3 = new Programme();
 
     programme1.setProgrammeName("Programme 1");
@@ -63,7 +65,6 @@ public class ProgrammeRepositoryIntTest {
     personRepository.saveAll(Lists.newArrayList(person1, person2));
     personRepository.flush();
 
-    //TODO: rewrite with new data structure
     CurriculumMembership pm1 = new CurriculumMembership(), pm2 = new CurriculumMembership(), pm3 = new CurriculumMembership(),
         pmWithSameProgramme = new CurriculumMembership();
 

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.22.0</version>
+      <version>2.23.0</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.25.0</version>
+  <version>6.26.0</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -94,7 +94,8 @@ public class ProgrammeMembershipResource {
   }
 
   /**
-   * PUT /programme-memberships : Updates an existing programmeMembership.
+   * PUT /programme-memberships : Updates an existing programmeMembership, or creates it if it
+   * does not exist.
    *
    * @param programmeMembershipDto the programmeMembershipDTO to update
    * @return the ResponseEntity with status 200 (OK) and with body the updated

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -77,7 +77,8 @@ public class ProgrammeMembershipResource {
     log.debug("REST request to save ProgrammeMembership : {}", programmeMembershipDTO);
     programmeMembershipValidator.validate(programmeMembershipDTO);
     if (programmeMembershipDTO.getCurriculumMemberships().get(0).getId() != null) { //TODO: this seems wrong,
-      // but might need to be left as-is to avoid changing the contract for this API call
+      // but might need to be left as-is to avoid changing the contract for this API call. As it stands, it insists
+      // that the first curriculumMembership is new, but doesn't check the programmeMembership's id.
       return ResponseEntity.badRequest().headers(HeaderUtil
           .createFailureAlert(ENTITY_NAME, "idexists",
               "A new programmeMembership cannot already have an ID")).body(null);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -76,7 +76,8 @@ public class ProgrammeMembershipResource {
       throws URISyntaxException, MethodArgumentNotValidException {
     log.debug("REST request to save ProgrammeMembership : {}", programmeMembershipDTO);
     programmeMembershipValidator.validate(programmeMembershipDTO);
-    if (programmeMembershipDTO.getCurriculumMemberships().get(0).getId() != null) {
+    if (programmeMembershipDTO.getCurriculumMemberships().get(0).getId() != null) { //TODO: this seems wrong,
+      // but might need to be left as-is to avoid changing the contract for this API call
       return ResponseEntity.badRequest().headers(HeaderUtil
           .createFailureAlert(ENTITY_NAME, "idexists",
               "A new programmeMembership cannot already have an ID")).body(null);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -76,9 +76,11 @@ public class ProgrammeMembershipResource {
       throws URISyntaxException, MethodArgumentNotValidException {
     log.debug("REST request to save ProgrammeMembership : {}", programmeMembershipDTO);
     programmeMembershipValidator.validate(programmeMembershipDTO);
-    if (programmeMembershipDTO.getCurriculumMemberships().get(0).getId() != null) { //TODO: this seems wrong,
-      // but might need to be left as-is to avoid changing the contract for this API call. As it stands, it insists
-      // that the first curriculumMembership is new, but doesn't check the programmeMembership's id.
+    if (programmeMembershipDTO.getCurriculumMemberships().get(0).getId() != null) {
+      // this seems wrong,
+      // but should be left as-is to avoid changing the contract for this API call.
+      // As it stands, it insists that the first curriculumMembership is new, but doesn't
+      // check the programmeMembership's id.
       return ResponseEntity.badRequest().headers(HeaderUtil
           .createFailureAlert(ENTITY_NAME, "idexists",
               "A new programmeMembership cannot already have an ID")).body(null);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
@@ -334,7 +334,7 @@ public class PersonElasticSearchService {
   public void updatePersonDocumentForProgramme(Long programmeId) {
     String programmeMembershipQuery = sqlQuerySupplier
         .getQuery(SqlQuerySupplier.PROGRAMME_MEMBERSHIP_VIEW)
-        .replace("WHERECLAUSE", "where programmeId=:programmeId");
+        .replace("WHERECLAUSE", "where pmem.programmeId=:programmeId");
 
     MapSqlParameterSource paramSource = new MapSqlParameterSource();
     paramSource.addValue("programmeId", programmeId);
@@ -397,7 +397,7 @@ public class PersonElasticSearchService {
 
       String programmeMembershipQuery = sqlQuerySupplier
           .getQuery(SqlQuerySupplier.PROGRAMME_MEMBERSHIP_VIEW)
-          .replace("WHERECLAUSE", "where personId IN (:personIds)");
+          .replace("WHERECLAUSE", "where pmem.personId IN (:personIds)");
 
       List<ProgrammeMembershipDto> programmeMembershipDtos = namedParameterJdbcTemplate
           .query(programmeMembershipQuery,

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -56,7 +56,6 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   private final CurriculumMembershipMapper curriculumMembershipMapper;
   private final CurriculumRepository curriculumRepository;
   private final CurriculumMapper curriculumMapper;
-  private final ProgrammeRepository programmeRepository;
   private final ApplicationEventPublisher applicationEventPublisher;
   private final PersonRepository personRepository;
 
@@ -69,7 +68,6 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
    * @param curriculumMembershipMapper      the CurriculumMembershipMapper
    * @param curriculumRepository            the CurriculumRepository
    * @param curriculumMapper                the CurriculumMapper
-   * @param programmeRepository             the ProgrammeRepository
    * @param applicationEventPublisher       the ApplicationEventPublisher
    * @param personRepository                the PersonRepository
    */
@@ -79,7 +77,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
       ProgrammeMembershipMapper programmeMembershipMapper,
       CurriculumMembershipMapper curriculumMembershipMapper,
       CurriculumRepository curriculumRepository, CurriculumMapper curriculumMapper,
-      ProgrammeRepository programmeRepository, ApplicationEventPublisher applicationEventPublisher,
+      ApplicationEventPublisher applicationEventPublisher,
       PersonRepository personRepository) {
     this.programmeMembershipRepository = programmeMembershipRepository;
     this.curriculumMembershipRepository = curriculumMembershipRepository;
@@ -87,7 +85,6 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     this.curriculumMembershipMapper = curriculumMembershipMapper;
     this.curriculumRepository = curriculumRepository;
     this.curriculumMapper = curriculumMapper;
-    this.programmeRepository = programmeRepository;
     this.applicationEventPublisher = applicationEventPublisher;
     this.personRepository = personRepository;
   }
@@ -102,15 +99,18 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   public ProgrammeMembershipDTO save(ProgrammeMembershipDTO programmeMembershipDto) {
     log.debug("Request to save ProgrammeMembership : {}", programmeMembershipDto);
 
-    ProgrammeMembership programmeMembership = programmeMembershipMapper.toEntity(programmeMembershipDto);
+    ProgrammeMembership programmeMembership
+        = programmeMembershipMapper.toEntity(programmeMembershipDto);
 
     programmeMembership = programmeMembershipRepository.save(programmeMembership);
 
-    ProgrammeMembershipDTO programmeMembershipSavedDto = programmeMembershipMapper.toDto(programmeMembership);
+    ProgrammeMembershipDTO programmeMembershipSavedDto
+        = programmeMembershipMapper.toDto(programmeMembership);
 
     //emit events
     updatePersonWhenStatusIsStale(programmeMembershipSavedDto.getPerson().getId());
-    List<ProgrammeMembershipDTO> resultDtos = Collections.singletonList(programmeMembershipSavedDto);
+    List<ProgrammeMembershipDTO> resultDtos
+        = Collections.singletonList(programmeMembershipSavedDto);
     emitProgrammeMembershipSavedEvents(resultDtos);
     return CollectionUtils.isNotEmpty(resultDtos) ? resultDtos.get(0) : null;
   }
@@ -126,7 +126,8 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     log.debug("Request to save ProgrammeMembership : {}", programmeMembershipDto);
 
     List<ProgrammeMembership> programmeMemberships =
-        programmeMembershipMapper.programmeMembershipDTOsToProgrammeMemberships(programmeMembershipDto);
+        programmeMembershipMapper
+            .programmeMembershipDTOsToProgrammeMemberships(programmeMembershipDto);
     programmeMemberships.forEach(programmeMembership -> {
       programmeMembership = programmeMembershipRepository.save(programmeMembership);
       updatePersonWhenStatusIsStale(programmeMembership.getPerson().getId());
@@ -134,7 +135,8 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
 
     //emit events
     List<ProgrammeMembershipDTO> resultDtos =
-        programmeMembershipMapper.programmeMembershipsToProgrammeMembershipDTOs(programmeMemberships);
+        programmeMembershipMapper
+            .programmeMembershipsToProgrammeMembershipDTOs(programmeMemberships);
     emitProgrammeMembershipSavedEvents(resultDtos);
     return resultDtos;
   }
@@ -315,9 +317,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     if (CollectionUtils.isNotEmpty(foundProgrammeMemberships)) {
       List<ProgrammeMembershipDTO> programmeMembershipDtos = programmeMembershipMapper
           .allEntityToDto(foundProgrammeMemberships);
-      List<ProgrammeMembershipCurriculaDTO> result = attachCurricula(programmeMembershipDtos);
-
-      return result;
+      return attachCurricula(programmeMembershipDtos);
     }
     return Collections.emptyList();
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -105,7 +105,6 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     ProgrammeMembership programmeMembership = programmeMembershipMapper.toEntity(programmeMembershipDto);
 
     programmeMembership = programmeMembershipRepository.save(programmeMembership);
-    //curriculumMembershipRepository.saveAll(programmeMembership.getCurriculumMemberships());
 
     ProgrammeMembershipDTO programmeMembershipSavedDto = programmeMembershipMapper.toDto(programmeMembership);
 
@@ -129,7 +128,6 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     List<ProgrammeMembership> programmeMemberships =
         programmeMembershipMapper.programmeMembershipDTOsToProgrammeMemberships(programmeMembershipDto);
     programmeMemberships.forEach(programmeMembership -> {
-      //curriculumMembershipRepository.saveAll(programmeMembership.getCurriculumMemberships());
       programmeMembership = programmeMembershipRepository.save(programmeMembership);
       updatePersonWhenStatusIsStale(programmeMembership.getPerson().getId());
     });

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -195,10 +195,9 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
 
     programmeMembership.getCurriculumMemberships().removeIf(cm -> cm.getId().equals(id));
 
-    if (programmeMembership.getCurriculumMemberships().size() > 0) {
+    if (!programmeMembership.getCurriculumMemberships().isEmpty()) {
       programmeMembershipRepository.save(programmeMembership);
     } else {
-      //TODO: confirm - if PM now has no CMs, do we delete it as well?
       programmeMembershipRepository.delete(programmeMembership);
     }
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -12,7 +12,6 @@ import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipSavedEvent;
 import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
-import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumRepository;
@@ -105,9 +104,9 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     log.debug("Request to save ProgrammeMembership : {}", programmeMembershipDto);
 
     ProgrammeMembership programmeMembership = programmeMembershipMapper.toEntity(programmeMembershipDto);
-    curriculumMembershipRepository.saveAll(programmeMembership.getCurriculumMemberships());
-    programmeMembership = programmeMembershipRepository.save(programmeMembership);
 
+    programmeMembership = programmeMembershipRepository.save(programmeMembership);
+    //curriculumMembershipRepository.saveAll(programmeMembership.getCurriculumMemberships());
 
     ProgrammeMembershipDTO programmeMembershipSavedDto = programmeMembershipMapper.toDto(programmeMembership);
 
@@ -131,7 +130,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     List<ProgrammeMembership> programmeMemberships =
         programmeMembershipMapper.programmeMembershipDTOsToProgrammeMemberships(programmeMembershipDto);
     programmeMemberships.forEach(programmeMembership -> {
-      curriculumMembershipRepository.saveAll(programmeMembership.getCurriculumMemberships());
+      //curriculumMembershipRepository.saveAll(programmeMembership.getCurriculumMemberships());
       programmeMembership = programmeMembershipRepository.save(programmeMembership);
       updatePersonWhenStatusIsStale(programmeMembership.getPerson().getId());
     });

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -193,7 +193,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
         .getProgrammeMembership();
     Long personId = programmeMembership.getPerson().getId();
 
-    programmeMembership.getCurriculumMemberships().removeIf(cm -> cm.getId() == id);
+    programmeMembership.getCurriculumMemberships().removeIf(cm -> cm.getId().equals(id));
 
     if (programmeMembership.getCurriculumMemberships().size() > 0) {
       programmeMembershipRepository.save(programmeMembership);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -17,7 +17,6 @@ import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipReposi
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
 import com.transformuk.hee.tis.tcs.service.repository.ProgrammeMembershipRepository;
-import com.transformuk.hee.tis.tcs.service.repository.ProgrammeRepository;
 import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -189,11 +189,18 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     log.debug("Request to delete CurriculumMembership : {}", id);
 
     //Get the person id from the programme membership before deleting it
-    Long personId = curriculumMembershipRepository.getOne(id)
-        .getProgrammeMembership().getPerson().getId();
+    ProgrammeMembership programmeMembership = curriculumMembershipRepository.getOne(id)
+        .getProgrammeMembership();
+    Long personId = programmeMembership.getPerson().getId();
 
-    curriculumMembershipRepository.deleteById(id);
-    curriculumRepository.flush();
+    programmeMembership.getCurriculumMemberships().removeIf(cm -> cm.getId() == id);
+
+    if (programmeMembership.getCurriculumMemberships().size() > 0) {
+      programmeMembershipRepository.save(programmeMembership);
+    } else {
+      //TODO: confirm - if PM now has no CMs, do we delete it as well?
+      programmeMembershipRepository.delete(programmeMembership);
+    }
 
     updatePersonWhenStatusIsStale(personId);
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -21,6 +21,7 @@ import com.transformuk.hee.tis.tcs.service.repository.ProgrammeRepository;
 import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -30,8 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -367,11 +367,11 @@ public class RevalidationServiceImpl implements RevalidationService {
       return true;
     }
     ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
-    return Objects.isNull(programmeMembership) ||
-        Objects.isNull(programmeMembership.getProgrammeStartDate()) ||
-        Objects.isNull(programmeMembership.getProgrammeEndDate()) ||
-        programmeMembership.getProgrammeStartDate().isAfter(currentDate) ||
-        programmeMembership.getProgrammeEndDate().isBefore(currentDate);
+    return Objects.isNull(programmeMembership)
+        || Objects.isNull(programmeMembership.getProgrammeStartDate())
+        || Objects.isNull(programmeMembership.getProgrammeEndDate())
+        || programmeMembership.getProgrammeStartDate().isAfter(currentDate)
+        || programmeMembership.getProgrammeEndDate().isBefore(currentDate);
   }
 
   private RevalidationRecordDto buildRevalidationRecord(GmcDetails gmcDetails) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -23,6 +23,7 @@ import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.GmcDetails;
 import com.transformuk.hee.tis.tcs.service.model.Placement;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.GmcDetailsRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
@@ -341,19 +342,20 @@ public class RevalidationServiceImpl implements RevalidationService {
       if (!isDisconnected(currentDate, curriculumMembership)) {
         connectionRecordDto.setConnectionStatus("Yes");
       }
+      ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
       final String programmeMemberShipType =
-          Objects.nonNull(curriculumMembership.getProgrammeMembershipType()) ? curriculumMembership
+          Objects.nonNull(programmeMembership.getProgrammeMembershipType()) ? programmeMembership
               .getProgrammeMembershipType().toString() : null;
       connectionRecordDto.setProgrammeMembershipType(programmeMemberShipType);
       connectionRecordDto
-          .setProgrammeMembershipStartDate(curriculumMembership.getProgrammeStartDate());
-      connectionRecordDto.setProgrammeMembershipEndDate(curriculumMembership.getProgrammeEndDate());
-      if (Objects.nonNull(curriculumMembership.getProgramme())) {
-        String programmeOwner = curriculumMembership.getProgramme().getOwner();
+          .setProgrammeMembershipStartDate(programmeMembership.getProgrammeStartDate());
+      connectionRecordDto.setProgrammeMembershipEndDate(programmeMembership.getProgrammeEndDate());
+      if (Objects.nonNull(programmeMembership.getProgramme())) {
+        String programmeOwner = programmeMembership.getProgramme().getOwner();
         connectionRecordDto.setProgrammeOwner(programmeOwner);
         connectionRecordDto
             .setDesignatedBodyCode(DesignatedBodyMapper.getDbcByOwner(programmeOwner));
-        connectionRecordDto.setProgrammeName(curriculumMembership.getProgramme().getProgrammeName());
+        connectionRecordDto.setProgrammeName(programmeMembership.getProgramme().getProgrammeName());
       }
     }
 
@@ -361,11 +363,15 @@ public class RevalidationServiceImpl implements RevalidationService {
   }
 
   private boolean isDisconnected(LocalDate currentDate, CurriculumMembership curriculumMembership) {
-    return Objects.isNull(curriculumMembership) ||
-        Objects.isNull(curriculumMembership.getProgrammeStartDate()) ||
-        Objects.isNull(curriculumMembership.getProgrammeEndDate()) ||
-        curriculumMembership.getProgrammeStartDate().isAfter(currentDate) ||
-        curriculumMembership.getProgrammeEndDate().isBefore(currentDate);
+    if (Objects.isNull(curriculumMembership)) {
+      return true;
+    }
+    ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
+    return Objects.isNull(programmeMembership) ||
+        Objects.isNull(programmeMembership.getProgrammeStartDate()) ||
+        Objects.isNull(programmeMembership.getProgrammeEndDate()) ||
+        programmeMembership.getProgrammeStartDate().isAfter(currentDate) ||
+        programmeMembership.getProgrammeEndDate().isBefore(currentDate);
   }
 
   private RevalidationRecordDto buildRevalidationRecord(GmcDetails gmcDetails) {
@@ -386,11 +392,12 @@ public class RevalidationServiceImpl implements RevalidationService {
     CurriculumMembership curriculumMembership = curriculumMembershipRepository
         .findLatestCurriculumByTraineeId(personId);
     if (Objects.nonNull(curriculumMembership)) {
-      LOG.debug("Curriculum Membership End Date : {}", curriculumMembership.getProgrammeEndDate());
+      ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
+      LOG.debug("Curriculum Membership End Date : {}", programmeMembership.getProgrammeEndDate());
       revalidationRecordDto.setCurriculumEndDate(curriculumMembership.getCurriculumEndDate());
-      revalidationRecordDto.setProgrammeMembershipType(curriculumMembership
+      revalidationRecordDto.setProgrammeMembershipType(programmeMembership
           .getProgrammeMembershipType().toString());
-      revalidationRecordDto.setProgrammeName(curriculumMembership.getProgramme().getProgrammeName());
+      revalidationRecordDto.setProgrammeName(programmeMembership.getProgramme().getProgrammeName());
     }
     //Placement
     List<Placement> currentPlacementsForTrainee = placementRepository

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -209,9 +209,8 @@ public class CurriculumMembershipMapper {
    *
    * @param programmeMembershipDto the ProgrammeMembershipDTO object to convert
    * @return a CurriculumMembership object
-   *
-   *  @deprecated 2022-05 as part of the programme membership refactoring,
-   *  a curriculum membership should not duplicate programme membership fields.
+   * @deprecated 2022-05 as part of the programme membership refactoring, a curriculum membership
+   *     should not duplicate programme membership fields.
    */
   @Deprecated
   private CurriculumMembership programmeMembershipDtoToCurriculumMembership(

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -313,9 +313,9 @@ public class CurriculumMembershipMapper {
   }
 
   /**
-   * Convert a trainingNumberDTO to a trainingNumber object.
+   * Convert a TrainingNumberDTO to a TrainingNumber object.
    *
-   * @param trainingNumberDTO the TrainingNumberDTO object to convert
+   * @param trainingNumberDto the TrainingNumberDTO object to convert
    * @return a TrainingNumber object
    */
   private TrainingNumber trainingNumberDtoToTrainingNumber(TrainingNumberDTO trainingNumberDto) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -165,7 +165,7 @@ public class CurriculumMembershipMapper {
    * @param curriculumMembership the CurriculumMembership object to convert
    * @return a CurriculumMembershipDTO object
    */
-  private CurriculumMembershipDTO curriculumMembershipToCurriculumMembershipDto(
+  public CurriculumMembershipDTO curriculumMembershipToCurriculumMembershipDto(
       CurriculumMembership curriculumMembership) {
     CurriculumMembershipDTO result = new CurriculumMembershipDTO();
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -209,14 +209,15 @@ public class CurriculumMembershipMapper {
    *
    * @param programmeMembershipDto the ProgrammeMembershipDTO object to convert
    * @return a CurriculumMembership object
+   *
+   *  @deprecated 2022-05 as part of the programme membership refactoring,
+   *  a curriculum membership should not duplicate programme membership fields.
    */
+  @Deprecated
   private CurriculumMembership programmeMembershipDtoToCurriculumMembership(
       ProgrammeMembershipDTO programmeMembershipDto) {
     CurriculumMembership result = new CurriculumMembership();
 
-    //TODO: the following should be removed in future
-    // once e.g. the tcs-persistence repository queries are refactored
-    // to allow CurriculumMembership to not duplicate ProgrammeMembership data
     result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembershipDto.getProgrammeEndDate());
@@ -240,7 +241,6 @@ public class CurriculumMembershipMapper {
       result.setPerson(personDtoToPerson(programmeMembershipDto.getPerson()));
     }
     result.setTrainingPathway(programmeMembershipDto.getTrainingPathway());
-    //end remove block
 
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -214,10 +214,6 @@ public class CurriculumMembershipMapper {
       ProgrammeMembershipDTO programmeMembershipDto) {
     CurriculumMembership result = new CurriculumMembership();
 
-    //leavingReason is held at PM level,
-    //CHECK: can leavingDestination be omitted as legacy field?
-    //result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
-
     //TODO: the following should be removed in future once e.g. the tcs-persistence repository queries are refactored
     // to allow CurriculumMembership to not duplicate ProgrammeMembership data
     result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -318,13 +318,13 @@ public class CurriculumMembershipMapper {
    * @param trainingNumberDTO the TrainingNumberDTO object to convert
    * @return a TrainingNumber object
    */
-  private TrainingNumber trainingNumberDtoToTrainingNumber(TrainingNumberDTO trainingNumberDTO) {
+  private TrainingNumber trainingNumberDtoToTrainingNumber(TrainingNumberDTO trainingNumberDto) {
     TrainingNumber result = null;
-    if (trainingNumberDTO != null) {
+    if (trainingNumberDto != null) {
       result = new TrainingNumber();
-      result.setId(trainingNumberDTO.getId());
-      result.setIntrepidId(trainingNumberDTO.getIntrepidId());
-      result.setTrainingNumber(trainingNumberDTO.getTrainingNumber());
+      result.setId(trainingNumberDto.getId());
+      result.setIntrepidId(trainingNumberDto.getIntrepidId());
+      result.setTrainingNumber(trainingNumberDto.getTrainingNumber());
     }
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -13,7 +13,6 @@ import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.Rotation;
 import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -214,7 +214,8 @@ public class CurriculumMembershipMapper {
       ProgrammeMembershipDTO programmeMembershipDto) {
     CurriculumMembership result = new CurriculumMembership();
 
-    //TODO: the following should be removed in future once e.g. the tcs-persistence repository queries are refactored
+    //TODO: the following should be removed in future
+    // once e.g. the tcs-persistence repository queries are refactored
     // to allow CurriculumMembership to not duplicate ProgrammeMembership data
     result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -97,8 +97,8 @@ public class CurriculumMembershipMapper {
   }
 
   /**
-   * Convert a ProgrammeMembershipDTO to a CurriculumMembership object, enriched with all
-   * curriculum membership details from the ProgrammeMembershipDTO.
+   * Convert a ProgrammeMembershipDTO to a CurriculumMembership object, enriched with all curriculum
+   * membership details from the ProgrammeMembershipDTO.
    *
    * @param programmeMembershipDto the ProgrammeMembershipDTO object to convert
    * @return a CurriculumMembership object
@@ -128,7 +128,7 @@ public class CurriculumMembershipMapper {
     ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
 
     result.setId(curriculumMembership.getId()); //use CM ID
-    result.setProgrammeMembershipUuid(programmeMembership.getUuid());
+    result.setUuid(programmeMembership.getUuid());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());
@@ -186,7 +186,7 @@ public class CurriculumMembershipMapper {
    * Amend a CurriculumMembership object with details from a CurriculumMembershipDTO.
    *
    * @param curriculumMembershipDto the CurriculumMembershipDTO to use
-   * @param curriculumMembership the CurriculumMembership object to amend
+   * @param curriculumMembership    the CurriculumMembership object to amend
    * @return the amended (enriched) CurriculumMembership object
    */
   private CurriculumMembership curriculumMembershipDtoToCurriculumMembership(
@@ -333,7 +333,7 @@ public class CurriculumMembershipMapper {
   /**
    * Convert a Rotation to a RotationDTO object.
    *
-   * @param rotation the Rotation object to convert
+   * @param rotation  the Rotation object to convert
    * @param programme the rotation Programme
    * @return a RotationDTO object
    */

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -132,7 +132,7 @@ public class CurriculumMembershipMapper {
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());
-    result.setLeavingDestination(null);
+    result.setLeavingDestination(programmeMembership.getLeavingDestination());
     result.setLeavingReason(programmeMembership.getLeavingReason());
     Programme programme = programmeMembership.getProgramme();
     if (programme != null) {
@@ -231,7 +231,7 @@ public class CurriculumMembershipMapper {
       result.setRotation(rotationDtoToRotation(programmeMembershipDto.getRotation()));
     }
     result.setTrainingNumber(
-        trainingNumberDTOToTrainingNumber(programmeMembershipDto.getTrainingNumber()));
+        trainingNumberDtoToTrainingNumber(programmeMembershipDto.getTrainingNumber()));
 
     if (programmeMembershipDto.getPerson() == null) {
       result.setPerson(null);
@@ -313,6 +313,23 @@ public class CurriculumMembershipMapper {
   }
 
   /**
+   * Convert a trainingNumberDTO to a trainingNumber object.
+   *
+   * @param trainingNumberDTO the TrainingNumberDTO object to convert
+   * @return a TrainingNumber object
+   */
+  private TrainingNumber trainingNumberDtoToTrainingNumber(TrainingNumberDTO trainingNumberDTO) {
+    TrainingNumber result = null;
+    if (trainingNumberDTO != null) {
+      result = new TrainingNumber();
+      result.setId(trainingNumberDTO.getId());
+      result.setIntrepidId(trainingNumberDTO.getIntrepidId());
+      result.setTrainingNumber(trainingNumberDTO.getTrainingNumber());
+    }
+    return result;
+  }
+
+  /**
    * Convert a Rotation to a RotationDTO object.
    *
    * @param rotation the Rotation object to convert
@@ -347,23 +364,6 @@ public class CurriculumMembershipMapper {
       result.setProgrammeId(rotationDto.getProgrammeId());
       result.setName(rotationDto.getName());
       result.setStatus(rotationDto.getStatus());
-    }
-    return result;
-  }
-
-  /**
-   * Convert a trainingNumberDTO to a trainingNumber object.
-   *
-   * @param trainingNumberDTO the TrainingNumberDTO object to convert
-   * @return a TrainingNumber object
-   */
-  private TrainingNumber trainingNumberDTOToTrainingNumber(TrainingNumberDTO trainingNumberDTO) {
-    TrainingNumber result = null;
-    if (trainingNumberDTO != null) {
-      result = new TrainingNumber();
-      result.setId(trainingNumberDTO.getId());
-      result.setIntrepidId(trainingNumberDTO.getIntrepidId());
-      result.setTrainingNumber(trainingNumberDTO.getTrainingNumber());
     }
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -169,7 +169,7 @@ public class CurriculumMembershipMapper {
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());
-    result.setLeavingDestination(curriculumMembership.getLeavingDestination());
+    result.setLeavingDestination(null);
     result.setLeavingReason(programmeMembership.getLeavingReason());
     Programme programme = programmeMembership.getProgramme();
     if (programme != null) {
@@ -251,9 +251,9 @@ public class CurriculumMembershipMapper {
       ProgrammeMembershipDTO programmeMembershipDto) {
     CurriculumMembership result = new CurriculumMembership();
 
-    //this is a legacy field (leavingReason is held at PM level),
-    //but technically this should be held at CM level not set for all CMs at PM level
-    result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
+    //leavingReason is held at PM level,
+    //CHECK: can leavingDestination be omitted as legacy field?
+    //result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
 
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -128,7 +128,7 @@ public class CurriculumMembershipMapper {
     ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
 
     result.setId(curriculumMembership.getId()); //use CM ID
-    result.setProgrammeMembershipId(programmeMembership.getId());
+    result.setProgrammeMembershipUuid(programmeMembership.getUuid());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -127,7 +127,8 @@ public class CurriculumMembershipMapper {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
     ProgrammeMembership programmeMembership = curriculumMembership.getProgrammeMembership();
 
-    result.setId(programmeMembership.getId());
+    result.setId(curriculumMembership.getId()); //use CM ID
+    result.setProgrammeMembershipId(programmeMembership.getId());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -171,7 +171,7 @@ public class CurriculumMembershipMapper {
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());
     result.setLeavingDestination(curriculumMembership.getLeavingDestination());
-    result.setLeavingReason(curriculumMembership.getLeavingReason());
+    result.setLeavingReason(programmeMembership.getLeavingReason());
     Programme programme = programmeMembership.getProgramme();
     if (programme != null) {
       result.setProgrammeId(programme.getId());
@@ -252,13 +252,9 @@ public class CurriculumMembershipMapper {
       ProgrammeMembershipDTO programmeMembershipDto) {
     CurriculumMembership result = new CurriculumMembership();
 
-    //TODO: this is not very elegant
-//    ProgrammeMembership programmeMembership = new ProgrammeMembership();
-//    programmeMembership.setId(programmeMembershipDto.getId());
-//    result.setProgrammeMembership(programmeMembership);
-    //FIXME: these fields should be held at the level of curriculum membership not programme membership
+    //this is a legacy field (leavingReason is held at PM level),
+    //but technically this should be held at CM level not set for all CMs at PM level
     result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
-    result.setLeavingReason(programmeMembershipDto.getLeavingReason());
 
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -178,7 +178,11 @@ public class CurriculumMembershipMapper {
       result.setProgrammeOwner(programme.getOwner());
       result.setProgrammeName(programme.getProgrammeName());
       result.setProgrammeNumber(programme.getProgrammeNumber());
-      result.setRotation(rotationToRotationDto(programmeMembership.getRotation(), programme));
+      if (programmeMembership.getRotation() == null) {
+        result.setRotation(null);
+      } else {
+        result.setRotation(rotationToRotationDto(programmeMembership.getRotation(), programme));
+      }
     }
     result.setTrainingNumber(
         trainingNumberToTrainingNumberDto(programmeMembership.getTrainingNumber()));
@@ -188,6 +192,7 @@ public class CurriculumMembershipMapper {
     } else {
       result.setPerson(personToPersonDto(programmeMembership.getPerson()));
     }
+
     result.setTrainingPathway(programmeMembership.getTrainingPathway());
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -13,7 +13,6 @@ import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.Rotation;
 import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -98,27 +97,6 @@ public class CurriculumMembershipMapper {
   }
 
   /**
-   * Convert a list of CurriculumMemberships to a list of distinct CurriculumMembershipDTOs.
-   *
-   * @param curriculumMemberships the list of CurriculumMembership objects to convert
-   * @return a list of distinct CurriculumMembershipDTO objects
-   */
-  public List<CurriculumMembershipDTO> curriculumMembershipsToCurriculumMembershipDtos(
-      List<CurriculumMembership> curriculumMemberships) {
-    Map<CurriculumMembershipDTO, CurriculumMembershipDTO> listMap = Maps.newHashMap();
-
-    for (CurriculumMembership curriculumMembership : curriculumMemberships) {
-      CurriculumMembershipDTO curriculumMembershipDto = curriculumMembershipToCurriculumMembershipDto(
-          curriculumMembership);
-      if (!listMap.containsKey(curriculumMembershipDto)) {
-        listMap.put(curriculumMembershipDto, curriculumMembershipDto);
-      }
-    }
-
-    return new ArrayList<>(listMap.keySet());
-  }
-
-  /**
    * Convert a ProgrammeMembershipDTO to a CurriculumMembership object, enriched with all
    * curriculum membership details from the ProgrammeMembershipDTO.
    *
@@ -136,22 +114,6 @@ public class CurriculumMembershipMapper {
       curriculumMembershipList.add(curriculumMembership);
     }
     return curriculumMembershipList;
-  }
-
-  /**
-   * Convert a list of ProgrammeMembershipDTOs to a list of CurriculumMembership objects.
-   *
-   * @param programmeMembershipDtos the list of ProgrammeMembershipDTO objects to convert
-   * @return a list of CurriculumMembership objects
-   */
-  public List<CurriculumMembership> programmeMembershipDtosToCurriculumMemberships(
-      List<ProgrammeMembershipDTO> programmeMembershipDtos) {
-    List<CurriculumMembership> result = Lists.newArrayList();
-
-    for (ProgrammeMembershipDTO programmeMembershipDto : programmeMembershipDtos) {
-      result.addAll(toEntity(programmeMembershipDto));
-    }
-    return result;
   }
 
   /**
@@ -349,23 +311,6 @@ public class CurriculumMembershipMapper {
       result.setId(trainingNumber.getId());
       result.setIntrepidId(trainingNumber.getIntrepidId());
       result.setTrainingNumber(trainingNumber.getTrainingNumber());
-    }
-    return result;
-  }
-
-  /**
-   * Convert a TrainingNumberDTO to a TrainingNumber object.
-   *
-   * @param trainingNumberDto the TrainingNumberDTO object to convert
-   * @return a TrainingNumber object
-   */
-  private TrainingNumber trainingNumberDtoToTrainingNumber(TrainingNumberDTO trainingNumberDto) {
-    TrainingNumber result = null;
-    if (trainingNumberDto != null) {
-      result = new TrainingNumber();
-      result.setId(trainingNumberDto.getId());
-      result.setIntrepidId(trainingNumberDto.getIntrepidId());
-      result.setTrainingNumber(trainingNumberDto.getTrainingNumber());
     }
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -248,9 +248,9 @@ public class CurriculumMembershipMapper {
     CurriculumMembership result = new CurriculumMembership();
 
     //TODO: this is not very elegant
-    ProgrammeMembership programmeMembership = new ProgrammeMembership();
-    programmeMembership.setId(programmeMembershipDto.getId());
-    result.setProgrammeMembership(programmeMembership);
+//    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+//    programmeMembership.setId(programmeMembershipDto.getId());
+//    result.setProgrammeMembership(programmeMembership);
     //FIXME: these fields should be held at the level of curriculum membership not programme membership
     result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
     result.setLeavingReason(programmeMembershipDto.getLeavingReason());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/CurriculumMembershipMapper.java
@@ -255,6 +255,33 @@ public class CurriculumMembershipMapper {
     //CHECK: can leavingDestination be omitted as legacy field?
     //result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
 
+    //TODO: the following should be removed in future once e.g. the tcs-persistence repository queries are refactored
+    // to allow CurriculumMembership to not duplicate ProgrammeMembership data
+    result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
+    result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());
+    result.setProgrammeEndDate(programmeMembershipDto.getProgrammeEndDate());
+    result.setLeavingReason(programmeMembershipDto.getLeavingReason());
+    result.setLeavingDestination(programmeMembershipDto.getLeavingDestination());
+    if (programmeMembershipDto.getProgrammeId() != null) {
+      Programme programme = new Programme();
+      programme.setId(programmeMembershipDto.getProgrammeId());
+      programme.setProgrammeName(programmeMembershipDto.getProgrammeName());
+      programme.setOwner(programmeMembershipDto.getProgrammeOwner());
+      programme.setProgrammeNumber(programmeMembershipDto.getProgrammeNumber());
+      result.setProgramme(programme);
+      result.setRotation(rotationDtoToRotation(programmeMembershipDto.getRotation()));
+    }
+    result.setTrainingNumber(
+        trainingNumberDTOToTrainingNumber(programmeMembershipDto.getTrainingNumber()));
+
+    if (programmeMembershipDto.getPerson() == null) {
+      result.setPerson(null);
+    } else {
+      result.setPerson(personDtoToPerson(programmeMembershipDto.getPerson()));
+    }
+    result.setTrainingPathway(programmeMembershipDto.getTrainingPathway());
+    //end remove block
+
     return result;
   }
 
@@ -378,6 +405,23 @@ public class CurriculumMembershipMapper {
       result.setProgrammeId(rotationDto.getProgrammeId());
       result.setName(rotationDto.getName());
       result.setStatus(rotationDto.getStatus());
+    }
+    return result;
+  }
+
+  /**
+   * Convert a trainingNumberDTO to a trainingNumber object.
+   *
+   * @param trainingNumberDTO the TrainingNumberDTO object to convert
+   * @return a TrainingNumber object
+   */
+  private TrainingNumber trainingNumberDTOToTrainingNumber(TrainingNumberDTO trainingNumberDTO) {
+    TrainingNumber result = null;
+    if (trainingNumberDTO != null) {
+      result = new TrainingNumber();
+      result.setId(trainingNumberDTO.getId());
+      result.setIntrepidId(trainingNumberDTO.getIntrepidId());
+      result.setTrainingNumber(trainingNumberDTO.getTrainingNumber());
     }
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PersonMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PersonMapper.java
@@ -34,7 +34,7 @@ public class PersonMapper {
   private RightToWorkMapper rightToWorkMapper;
 
   @Autowired
-  private CurriculumMembershipMapper curriculumMembershipMapper;
+  private ProgrammeMembershipMapper programmeMembershipMapper;
 
   @Autowired
   private TrainerApprovalMapper trainerApprovalMapper;
@@ -65,8 +65,8 @@ public class PersonMapper {
     }
 
     if (dto.getProgrammeMemberships() != null) {
-      person.setCurriculumMemberships(new HashSet<>(curriculumMembershipMapper
-          .programmeMembershipDtosToCurriculumMemberships(
+      person.setProgrammeMemberships(new HashSet<>(programmeMembershipMapper
+          .programmeMembershipDTOsToProgrammeMemberships(
               new ArrayList<>(dto.getProgrammeMemberships()))));
     }
 
@@ -113,10 +113,10 @@ public class PersonMapper {
     personDTO.setRightToWork(rightToWorkMapper.toDto(entity.getRightToWork()));
     personDTO.setRegulator(entity.getRegulator());
 
-    if (entity.getCurriculumMemberships() != null) {
-      personDTO.setProgrammeMemberships(new HashSet<>(curriculumMembershipMapper
-          .curriculumMembershipsToProgrammeMembershipDtos(
-              new ArrayList<>(entity.getCurriculumMemberships()))));
+    if (entity.getProgrammeMemberships() != null) {
+      personDTO.setProgrammeMemberships(new HashSet<>(programmeMembershipMapper
+          .programmeMembershipsToProgrammeMembershipDTOs(
+              new ArrayList<>(entity.getProgrammeMemberships()))));
     }
 
     if (entity.getTrainerApprovals() != null) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -114,7 +114,7 @@ public class ProgrammeMembershipMapper {
   public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDto) {
     ProgrammeMembership result = new ProgrammeMembership();
 
-    result.setId(programmeMembershipDto.getProgrammeMembershipId()); //use real (database) ID
+    result.setUuid(programmeMembershipDto.getProgrammeMembershipUuid()); //use real (database) ID
     result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembershipDto.getProgrammeEndDate());
@@ -159,7 +159,7 @@ public class ProgrammeMembershipMapper {
       ProgrammeMembership programmeMembership) {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
 
-    result.setProgrammeMembershipId(programmeMembership.getId());
+    result.setProgrammeMembershipUuid(programmeMembership.getUuid());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -94,6 +94,7 @@ public class ProgrammeMembershipMapper {
     result.setProgrammeEndDate(programmeMembershipDTO.getProgrammeEndDate());
     result.setLeavingReason(programmeMembershipDTO.getLeavingReason());
     result.setTrainingPathway(programmeMembershipDTO.getTrainingPathway());
+    result.setAmendedDate(programmeMembershipDTO.getAmendedDate());
     Programme programme = null;
     if (programmeMembershipDTO.getProgrammeId() != null) {
       programme = new Programme();
@@ -136,6 +137,7 @@ public class ProgrammeMembershipMapper {
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());
     result.setLeavingReason(programmeMembership.getLeavingReason());
+    result.setAmendedDate(programmeMembership.getAmendedDate());
     Programme programme = programmeMembership.getProgramme();
     if (programme != null) {
       result.setProgrammeId(programme.getId());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -42,6 +42,10 @@ public class ProgrammeMembershipMapper {
       }
       result.getCurriculumMemberships()
           .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
+      if (!result.getCurriculumMemberships().isEmpty()) {
+        //set ID from curriculumMembership
+        result.setId(result.getCurriculumMemberships().iterator().next().getId());
+      }
     }
     return result;
   }
@@ -58,6 +62,10 @@ public class ProgrammeMembershipMapper {
       }
       programmeMembershipDTO.getCurriculumMemberships()
           .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
+      if (!programmeMembershipDTO.getCurriculumMemberships().isEmpty()) {
+        //set ID from curriculumMembership
+        programmeMembershipDTO.setId(programmeMembershipDTO.getCurriculumMemberships().iterator().next().getId());
+      }
       result.add(programmeMembershipDTO);
     }
 
@@ -79,6 +87,10 @@ public class ProgrammeMembershipMapper {
       }
       programmeMembershipDTO.getCurriculumMemberships()
           .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
+      if (!programmeMembershipDTO.getCurriculumMemberships().isEmpty()) {
+        //set ID from curriculumMembership
+        programmeMembershipDTO.setId(programmeMembershipDTO.getCurriculumMemberships().iterator().next().getId());
+      }
       listMap.put(programmeMembershipDTO, programmeMembershipDTO);
     }
 
@@ -88,7 +100,7 @@ public class ProgrammeMembershipMapper {
   public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDTO) {
     ProgrammeMembership result = new ProgrammeMembership();
 
-    result.setId(programmeMembershipDTO.getId());
+    result.setId(programmeMembershipDTO.getProgrammeMembershipId()); //use real (database) ID
     result.setProgrammeMembershipType(programmeMembershipDTO.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembershipDTO.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembershipDTO.getProgrammeEndDate());
@@ -132,7 +144,8 @@ public class ProgrammeMembershipMapper {
       ProgrammeMembership programmeMembership) {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
 
-    result.setId(programmeMembership.getId());
+    //result.setId(programmeMembership.getId());
+    result.setProgrammeMembershipId(programmeMembership.getId());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -62,11 +62,11 @@ public class ProgrammeMembershipMapper {
         if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
           programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
         }
-        CurriculumMembershipDTO curriculumMembershipDTO
+        CurriculumMembershipDTO curriculumMembershipDto
             = curriculumMembershipMapper
             .curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
         programmeMembershipDto.getCurriculumMemberships()
-            .add(curriculumMembershipDTO);
+            .add(curriculumMembershipDto);
         if (!programmeMembershipDto.getCurriculumMemberships().isEmpty()) {
           //set ID from curriculumMembership
           programmeMembershipDto.setId(
@@ -105,35 +105,41 @@ public class ProgrammeMembershipMapper {
     return new ArrayList<>(listMap.keySet());
   }
 
-  public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDTO) {
+  /**
+   * Covert a ProgrammeMembershipDTO to a ProgrammeMembership, including its CurriculumMemberships.
+   *
+   * @param programmeMembershipDto
+   * @return
+   */
+  public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDto) {
     ProgrammeMembership result = new ProgrammeMembership();
 
-    result.setId(programmeMembershipDTO.getProgrammeMembershipId()); //use real (database) ID
-    result.setProgrammeMembershipType(programmeMembershipDTO.getProgrammeMembershipType());
-    result.setProgrammeStartDate(programmeMembershipDTO.getProgrammeStartDate());
-    result.setProgrammeEndDate(programmeMembershipDTO.getProgrammeEndDate());
-    result.setLeavingReason(programmeMembershipDTO.getLeavingReason());
-    result.setTrainingPathway(programmeMembershipDTO.getTrainingPathway());
-    result.setAmendedDate(programmeMembershipDTO.getAmendedDate());
+    result.setId(programmeMembershipDto.getProgrammeMembershipId()); //use real (database) ID
+    result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
+    result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());
+    result.setProgrammeEndDate(programmeMembershipDto.getProgrammeEndDate());
+    result.setLeavingReason(programmeMembershipDto.getLeavingReason());
+    result.setTrainingPathway(programmeMembershipDto.getTrainingPathway());
+    result.setAmendedDate(programmeMembershipDto.getAmendedDate());
     Programme programme = null;
-    if (programmeMembershipDTO.getProgrammeId() != null) {
+    if (programmeMembershipDto.getProgrammeId() != null) {
       programme = new Programme();
-      programme.setId(programmeMembershipDTO.getProgrammeId());
-      programme.setProgrammeName(programmeMembershipDTO.getProgrammeName());
-      programme.setOwner(programmeMembershipDTO.getProgrammeOwner());
-      programme.setProgrammeNumber(programmeMembershipDTO.getProgrammeNumber());
-      result.setRotation(rotationDTOToRotation(programmeMembershipDTO.getRotation()));
+      programme.setId(programmeMembershipDto.getProgrammeId());
+      programme.setProgrammeName(programmeMembershipDto.getProgrammeName());
+      programme.setOwner(programmeMembershipDto.getProgrammeOwner());
+      programme.setProgrammeNumber(programmeMembershipDto.getProgrammeNumber());
+      result.setRotation(rotationDTOToRotation(programmeMembershipDto.getRotation()));
     }
     result.setProgramme(programme);
     result.setTrainingNumber(
-        trainingNumberDTOToTrainingNumber(programmeMembershipDTO.getTrainingNumber()));
-    result.setPerson(personDTOToPerson(programmeMembershipDTO.getPerson()));
+        trainingNumberDTOToTrainingNumber(programmeMembershipDto.getTrainingNumber()));
+    result.setPerson(personDTOToPerson(programmeMembershipDto.getPerson()));
 
-    if (CollectionUtils.isEmpty(programmeMembershipDTO.getCurriculumMemberships())) {
+    if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
       result.setCurriculumMemberships(new HashSet<>());
     }
     result.getCurriculumMemberships()
-        .addAll(curriculumMembershipMapper.toEntity(programmeMembershipDTO));
+        .addAll(curriculumMembershipMapper.toEntity(programmeMembershipDto));
     result.getCurriculumMemberships().forEach(cm -> cm.setProgrammeMembership(result));
     return result;
   }
@@ -153,7 +159,7 @@ public class ProgrammeMembershipMapper {
       ProgrammeMembership programmeMembership) {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
 
-    //result.setId(programmeMembership.getId());
+    //Note - do not use PM ID: result.setId(programmeMembership.getId());
     result.setProgrammeMembershipId(programmeMembership.getId());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
@@ -183,7 +189,7 @@ public class ProgrammeMembershipMapper {
 
   private List<CurriculumMembershipDTO> programmeMembershipToCurriculumMembershipDTOs(
       ProgrammeMembership programmeMembership) {
-    List<CurriculumMembershipDTO> curriculumMembershipDTOs = Lists.newArrayList();
+    List<CurriculumMembershipDTO> curriculumMembershipDtos = Lists.newArrayList();
     Set<CurriculumMembership> curriculumMemberships
         = programmeMembership.getCurriculumMemberships();
 
@@ -199,10 +205,10 @@ public class ProgrammeMembershipMapper {
       cmDto.setCurriculumId(cm.getCurriculumId());
       cmDto.setAmendedDate(cm.getAmendedDate());
 
-      curriculumMembershipDTOs.add(cmDto);
+      curriculumMembershipDtos.add(cmDto);
     });
 
-    return curriculumMembershipDTOs;
+    return curriculumMembershipDtos;
   }
 
   private PersonDTO personToPersonDTO(Person person) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -59,9 +59,7 @@ public class ProgrammeMembershipMapper {
           : programmeMembership.getCurriculumMemberships()) {
         ProgrammeMembershipDTO programmeMembershipDto
             = programmeMembershipToProgrammeMembershipDTO(programmeMembership);
-        if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
-          programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
-        }
+        programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
         CurriculumMembershipDTO curriculumMembershipDto
             = curriculumMembershipMapper
             .curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
@@ -135,7 +133,7 @@ public class ProgrammeMembershipMapper {
         trainingNumberDTOToTrainingNumber(programmeMembershipDto.getTrainingNumber()));
     result.setPerson(personDTOToPerson(programmeMembershipDto.getPerson()));
 
-    if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
+    if (programmeMembershipDto.getCurriculumMemberships() == null) {
       result.setCurriculumMemberships(new HashSet<>());
     }
     result.getCurriculumMemberships()

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -55,21 +55,24 @@ public class ProgrammeMembershipMapper {
     List<ProgrammeMembershipDTO> result = Lists.newArrayList();
 
     for (ProgrammeMembership programmeMembership : programmeMemberships) {
-      for (CurriculumMembership curriculumMembership : programmeMembership.getCurriculumMemberships()) {
-        ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipToProgrammeMembershipDTO(
-            programmeMembership);
-        if (CollectionUtils.isEmpty(programmeMembershipDTO.getCurriculumMemberships())) {
-          programmeMembershipDTO.setCurriculumMemberships(Lists.newArrayList());
+      for (CurriculumMembership curriculumMembership
+          : programmeMembership.getCurriculumMemberships()) {
+        ProgrammeMembershipDTO programmeMembershipDto
+            = programmeMembershipToProgrammeMembershipDTO(programmeMembership);
+        if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
+          programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
         }
         CurriculumMembershipDTO curriculumMembershipDTO
-            = curriculumMembershipMapper.curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
-        programmeMembershipDTO.getCurriculumMemberships()
+            = curriculumMembershipMapper
+            .curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
+        programmeMembershipDto.getCurriculumMemberships()
             .add(curriculumMembershipDTO);
-        if (!programmeMembershipDTO.getCurriculumMemberships().isEmpty()) {
+        if (!programmeMembershipDto.getCurriculumMemberships().isEmpty()) {
           //set ID from curriculumMembership
-          programmeMembershipDTO.setId(programmeMembershipDTO.getCurriculumMemberships().iterator().next().getId());
+          programmeMembershipDto.setId(
+              programmeMembershipDto.getCurriculumMemberships().iterator().next().getId());
         }
-        result.add(programmeMembershipDTO);
+        result.add(programmeMembershipDto);
       }
     }
 
@@ -81,21 +84,22 @@ public class ProgrammeMembershipMapper {
     Map<ProgrammeMembershipDTO, ProgrammeMembershipDTO> listMap = Maps.newHashMap();
 
     for (ProgrammeMembership programmeMembership : programmeMemberships) {
-      ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipToProgrammeMembershipDTO(
-          programmeMembership);
-      if (listMap.containsKey(programmeMembershipDTO)) {
-        programmeMembershipDTO = listMap.get(programmeMembershipDTO);
+      ProgrammeMembershipDTO programmeMembershipDto
+          = programmeMembershipToProgrammeMembershipDTO(programmeMembership);
+      if (listMap.containsKey(programmeMembershipDto)) {
+        programmeMembershipDto = listMap.get(programmeMembershipDto);
       }
-      if (CollectionUtils.isEmpty(programmeMembershipDTO.getCurriculumMemberships())) {
-        programmeMembershipDTO.setCurriculumMemberships(Lists.newArrayList());
+      if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
+        programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
       }
-      programmeMembershipDTO.getCurriculumMemberships()
+      programmeMembershipDto.getCurriculumMemberships()
           .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
-      if (!programmeMembershipDTO.getCurriculumMemberships().isEmpty()) {
+      if (!programmeMembershipDto.getCurriculumMemberships().isEmpty()) {
         //set ID from curriculumMembership
-        programmeMembershipDTO.setId(programmeMembershipDTO.getCurriculumMemberships().iterator().next().getId());
+        programmeMembershipDto.setId(
+            programmeMembershipDto.getCurriculumMemberships().iterator().next().getId());
       }
-      listMap.put(programmeMembershipDTO, programmeMembershipDTO);
+      listMap.put(programmeMembershipDto, programmeMembershipDto);
     }
 
     return new ArrayList<>(listMap.keySet());
@@ -121,7 +125,8 @@ public class ProgrammeMembershipMapper {
       result.setRotation(rotationDTOToRotation(programmeMembershipDTO.getRotation()));
     }
     result.setProgramme(programme);
-    result.setTrainingNumber(trainingNumberDTOToTrainingNumber(programmeMembershipDTO.getTrainingNumber()));
+    result.setTrainingNumber(
+        trainingNumberDTOToTrainingNumber(programmeMembershipDTO.getTrainingNumber()));
     result.setPerson(personDTOToPerson(programmeMembershipDTO.getPerson()));
 
     if (CollectionUtils.isEmpty(programmeMembershipDTO.getCurriculumMemberships())) {
@@ -137,8 +142,8 @@ public class ProgrammeMembershipMapper {
       List<ProgrammeMembershipDTO> programmeMembershipDTOs) {
     List<ProgrammeMembership> result = Lists.newArrayList();
 
-    for (ProgrammeMembershipDTO programmeMembershipDTO : programmeMembershipDTOs) {
-      result.add(toEntity(programmeMembershipDTO));
+    for (ProgrammeMembershipDTO programmeMembershipDto : programmeMembershipDTOs) {
+      result.add(toEntity(programmeMembershipDto));
     }
 
     return result;
@@ -179,21 +184,22 @@ public class ProgrammeMembershipMapper {
   private List<CurriculumMembershipDTO> programmeMembershipToCurriculumMembershipDTOs(
       ProgrammeMembership programmeMembership) {
     List<CurriculumMembershipDTO> curriculumMembershipDTOs = Lists.newArrayList();
-    Set<CurriculumMembership> curriculumMemberships = programmeMembership.getCurriculumMemberships();
+    Set<CurriculumMembership> curriculumMemberships
+        = programmeMembership.getCurriculumMemberships();
 
     curriculumMemberships.forEach(cm -> {
-      CurriculumMembershipDTO cmDTO = new CurriculumMembershipDTO();
+      CurriculumMembershipDTO cmDto = new CurriculumMembershipDTO();
 
-      cmDTO.setId(cm.getId());
-      cmDTO.setIntrepidId(cm.getIntrepidId());
-      cmDTO.setCurriculumStartDate(cm.getCurriculumStartDate());
-      cmDTO.setCurriculumEndDate(cm.getCurriculumEndDate());
-      cmDTO.setPeriodOfGrace(cm.getPeriodOfGrace());
-      cmDTO.setCurriculumCompletionDate(cm.getCurriculumCompletionDate());
-      cmDTO.setCurriculumId(cm.getCurriculumId());
-      cmDTO.setAmendedDate(cm.getAmendedDate());
+      cmDto.setId(cm.getId());
+      cmDto.setIntrepidId(cm.getIntrepidId());
+      cmDto.setCurriculumStartDate(cm.getCurriculumStartDate());
+      cmDto.setCurriculumEndDate(cm.getCurriculumEndDate());
+      cmDto.setPeriodOfGrace(cm.getPeriodOfGrace());
+      cmDto.setCurriculumCompletionDate(cm.getCurriculumCompletionDate());
+      cmDto.setCurriculumId(cm.getCurriculumId());
+      cmDto.setAmendedDate(cm.getAmendedDate());
 
-      curriculumMembershipDTOs.add(cmDTO);
+      curriculumMembershipDTOs.add(cmDto);
     });
 
     return curriculumMembershipDTOs;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -113,7 +113,7 @@ public class ProgrammeMembershipMapper {
     }
     result.getCurriculumMemberships()
         .addAll(curriculumMembershipMapper.toEntity(programmeMembershipDTO));
-
+    result.getCurriculumMemberships().forEach(cm -> cm.setProgrammeMembership(result));
     return result;
   }
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -55,18 +55,11 @@ public class ProgrammeMembershipMapper {
     List<ProgrammeMembershipDTO> result = Lists.newArrayList();
 
     for (ProgrammeMembership programmeMembership : programmeMemberships) {
-      ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipToProgrammeMembershipDTO(
-          programmeMembership);
-      if (CollectionUtils.isEmpty(programmeMembershipDTO.getCurriculumMemberships())) {
-        programmeMembershipDTO.setCurriculumMemberships(Lists.newArrayList());
+      for (CurriculumMembership curriculumMembership : programmeMembership.getCurriculumMemberships()) {
+        ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper.toDto(
+            curriculumMembership);
+        result.add(programmeMembershipDTO);
       }
-      programmeMembershipDTO.getCurriculumMemberships()
-          .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
-      if (!programmeMembershipDTO.getCurriculumMemberships().isEmpty()) {
-        //set ID from curriculumMembership
-        programmeMembershipDTO.setId(programmeMembershipDTO.getCurriculumMemberships().iterator().next().getId());
-      }
-      result.add(programmeMembershipDTO);
     }
 
     return result;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -42,10 +42,6 @@ public class ProgrammeMembershipMapper {
       }
       result.getCurriculumMemberships()
           .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
-      if (!result.getCurriculumMemberships().isEmpty()) {
-        //set ID from curriculumMembership
-        result.setId(result.getCurriculumMemberships().iterator().next().getId());
-      }
     }
     return result;
   }
@@ -65,11 +61,6 @@ public class ProgrammeMembershipMapper {
             .curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
         programmeMembershipDto.getCurriculumMemberships()
             .add(curriculumMembershipDto);
-        if (!programmeMembershipDto.getCurriculumMemberships().isEmpty()) {
-          //set ID from curriculumMembership
-          programmeMembershipDto.setId(
-              programmeMembershipDto.getCurriculumMemberships().iterator().next().getId());
-        }
         result.add(programmeMembershipDto);
       }
     }
@@ -92,11 +83,6 @@ public class ProgrammeMembershipMapper {
       }
       programmeMembershipDto.getCurriculumMemberships()
           .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
-      if (!programmeMembershipDto.getCurriculumMemberships().isEmpty()) {
-        //set ID from curriculumMembership
-        programmeMembershipDto.setId(
-            programmeMembershipDto.getCurriculumMemberships().iterator().next().getId());
-      }
       listMap.put(programmeMembershipDto, programmeMembershipDto);
     }
 
@@ -157,6 +143,10 @@ public class ProgrammeMembershipMapper {
       ProgrammeMembership programmeMembership) {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
 
+    if (!programmeMembership.getCurriculumMemberships().isEmpty()) {
+      //Preserve backward-compatibility
+      result.setId(programmeMembership.getCurriculumMemberships().iterator().next().getId());
+    }
     result.setUuid(programmeMembership.getUuid());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -13,7 +13,6 @@ import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.Rotation;
 import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -108,8 +108,8 @@ public class ProgrammeMembershipMapper {
   /**
    * Covert a ProgrammeMembershipDTO to a ProgrammeMembership, including its CurriculumMemberships.
    *
-   * @param programmeMembershipDto
-   * @return
+   * @param programmeMembershipDto the ProgrammeMembershipDTO to convert
+   * @return the ProgrammeMembership entity
    */
   public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDto) {
     ProgrammeMembership result = new ProgrammeMembership();
@@ -159,7 +159,6 @@ public class ProgrammeMembershipMapper {
       ProgrammeMembership programmeMembership) {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
 
-    //Note - do not use PM ID: result.setId(programmeMembership.getId());
     result.setProgrammeMembershipId(programmeMembership.getId());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -114,7 +114,7 @@ public class ProgrammeMembershipMapper {
   public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDto) {
     ProgrammeMembership result = new ProgrammeMembership();
 
-    result.setUuid(programmeMembershipDto.getProgrammeMembershipUuid()); //use real (database) ID
+    result.setUuid(programmeMembershipDto.getUuid()); //use real (database) ID
     result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembershipDto.getProgrammeEndDate());
@@ -159,7 +159,7 @@ public class ProgrammeMembershipMapper {
       ProgrammeMembership programmeMembership) {
     ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
 
-    result.setProgrammeMembershipUuid(programmeMembership.getUuid());
+    result.setUuid(programmeMembership.getUuid());
     result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
     result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
     result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -56,8 +56,19 @@ public class ProgrammeMembershipMapper {
 
     for (ProgrammeMembership programmeMembership : programmeMemberships) {
       for (CurriculumMembership curriculumMembership : programmeMembership.getCurriculumMemberships()) {
-        ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper.toDto(
-            curriculumMembership);
+        ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipToProgrammeMembershipDTO(
+            programmeMembership);
+        if (CollectionUtils.isEmpty(programmeMembershipDTO.getCurriculumMemberships())) {
+          programmeMembershipDTO.setCurriculumMemberships(Lists.newArrayList());
+        }
+        CurriculumMembershipDTO curriculumMembershipDTO
+            = curriculumMembershipMapper.curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
+        programmeMembershipDTO.getCurriculumMemberships()
+            .add(curriculumMembershipDTO);
+        if (!programmeMembershipDTO.getCurriculumMemberships().isEmpty()) {
+          //set ID from curriculumMembership
+          programmeMembershipDTO.setId(programmeMembershipDTO.getCurriculumMemberships().iterator().next().getId());
+        }
         result.add(programmeMembershipDTO);
       }
     }

--- a/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
@@ -1,6 +1,6 @@
 DROP TABLE `ProgrammeMembership`;
 CREATE TABLE `ProgrammeMembership` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` varchar(36) NOT NULL, -- for UUID
   `programmeMembershipType` varchar(255) DEFAULT NULL,
   `programmeStartDate` date DEFAULT NULL,
   `programmeEndDate` date DEFAULT NULL,
@@ -11,6 +11,7 @@ CREATE TABLE `ProgrammeMembership` (
   `rotationId` bigint(20) DEFAULT NULL,
   `trainingPathway` varchar(255) DEFAULT NULL,
   `leavingReason` varchar(255) DEFAULT NULL,
+  `leavingDestination` varchar(255) DEFAULT NULL,
   `amendedDate` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
   PRIMARY KEY (`id`),
   KEY `fk_ProgrammeMembership_person_id` (`personId`),
@@ -23,16 +24,16 @@ CREATE TABLE `ProgrammeMembership` (
   CONSTRAINT `fk_ProgrammeMembership_rotation_id` FOREIGN KEY (`rotationId`) REFERENCES `Rotation` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
 
-INSERT INTO ProgrammeMembership (personId, programmeId, rotationId, rotation, programmeStartDate, programmeEndDate,
-programmeMembershipType, trainingPathway, leavingReason)
+INSERT INTO ProgrammeMembership (id, personId, programmeId, rotationId, rotation, programmeStartDate, programmeEndDate,
+programmeMembershipType, trainingPathway, trainingNumberId, leavingReason, leavingDestination)
 SELECT
-personId, programmeId, rotationId, max(rotation), programmeStartDate, programmeEndDate,
-programmeMembershipType, max(trainingPathway), max(leavingReason)
+uuid(), personId, programmeId, rotationId, max(rotation), programmeStartDate, programmeEndDate,
+programmeMembershipType, max(trainingPathway), max(trainingNumberId), max(leavingReason), max(leavingDestination)
 FROM CurriculumMembership
 GROUP BY
 personId, programmeId, rotationId, programmeStartDate, programmeEndDate, programmeMembershipType;
 
-ALTER TABLE CurriculumMembership ADD COLUMN `programmeMembershipId` bigint(20) DEFAULT NULL;
+ALTER TABLE CurriculumMembership ADD COLUMN `programmeMembershipId` varchar(36) DEFAULT NULL;
 
 UPDATE tcs.CurriculumMembership cm
 SET programmeMembershipId = (SELECT id FROM tcs.ProgrammeMembership pm
@@ -43,7 +44,7 @@ pm.programmeStartDate = cm.programmeStartDate AND
 pm.programmeEndDate = cm.programmeEndDate AND
 IFNULL(pm.programmeMembershipType,'') = IFNULL(cm.programmeMembershipType,''));
 
-ALTER TABLE CurriculumMembership MODIFY COLUMN `programmeMembershipId` bigint(20) NOT NULL;
+ALTER TABLE CurriculumMembership MODIFY COLUMN `programmeMembershipId` varchar(36) NOT NULL;
 ALTER TABLE CurriculumMembership ADD INDEX `fk_ProgrammeMembership_programme_membership_id` (`programmeMembershipId`);
 ALTER TABLE CurriculumMembership ADD FOREIGN KEY (`programmeMembershipId`) REFERENCES `ProgrammeMembership` (`id`);
 ALTER TABLE CurriculumMembership CHANGE COLUMN `programmeId` `programmeId` BIGINT(20) NULL,

--- a/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
@@ -1,6 +1,6 @@
 DROP TABLE `ProgrammeMembership`;
 CREATE TABLE `ProgrammeMembership` (
-  `id` varchar(36) NOT NULL, -- for UUID
+  `uuid` varchar(36) NOT NULL,
   `programmeMembershipType` varchar(255) DEFAULT NULL,
   `programmeStartDate` date DEFAULT NULL,
   `programmeEndDate` date DEFAULT NULL,
@@ -13,7 +13,7 @@ CREATE TABLE `ProgrammeMembership` (
   `leavingReason` varchar(255) DEFAULT NULL,
   `leavingDestination` varchar(255) DEFAULT NULL,
   `amendedDate` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  PRIMARY KEY (`id`),
+  PRIMARY KEY (`uuid`),
   KEY `fk_ProgrammeMembership_person_id` (`personId`),
   KEY `fk_ProgrammeMembership_programme_id` (`programmeId`),
   KEY `fk_ProgrammeMembership_training_number_id` (`trainingNumberId`),
@@ -24,7 +24,7 @@ CREATE TABLE `ProgrammeMembership` (
   CONSTRAINT `fk_ProgrammeMembership_rotation_id` FOREIGN KEY (`rotationId`) REFERENCES `Rotation` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
 
-INSERT INTO ProgrammeMembership (id, personId, programmeId, rotationId, rotation, programmeStartDate, programmeEndDate,
+INSERT INTO ProgrammeMembership (uuid, personId, programmeId, rotationId, rotation, programmeStartDate, programmeEndDate,
 programmeMembershipType, trainingPathway, trainingNumberId, leavingReason, leavingDestination)
 SELECT
 uuid(), personId, programmeId, rotationId, max(rotation), programmeStartDate, programmeEndDate,
@@ -33,10 +33,10 @@ FROM CurriculumMembership
 GROUP BY
 personId, programmeId, rotationId, programmeStartDate, programmeEndDate, programmeMembershipType;
 
-ALTER TABLE CurriculumMembership ADD COLUMN `programmeMembershipId` varchar(36) DEFAULT NULL;
+ALTER TABLE CurriculumMembership ADD COLUMN `programmeMembershipUuid` varchar(36) DEFAULT NULL;
 
 UPDATE tcs.CurriculumMembership cm
-SET programmeMembershipId = (SELECT id FROM tcs.ProgrammeMembership pm
+SET programmeMembershipUuid = (SELECT uuid FROM tcs.ProgrammeMembership pm
 WHERE pm.personId = cm.personId AND
 pm.programmeId = cm.programmeId AND
 IFNULL(pm.rotationId,0) = IFNULL(cm.rotationId,0) AND
@@ -44,9 +44,9 @@ pm.programmeStartDate = cm.programmeStartDate AND
 pm.programmeEndDate = cm.programmeEndDate AND
 IFNULL(pm.programmeMembershipType,'') = IFNULL(cm.programmeMembershipType,''));
 
-ALTER TABLE CurriculumMembership MODIFY COLUMN `programmeMembershipId` varchar(36) NOT NULL;
-ALTER TABLE CurriculumMembership ADD INDEX `fk_ProgrammeMembership_programme_membership_id` (`programmeMembershipId`);
-ALTER TABLE CurriculumMembership ADD FOREIGN KEY (`programmeMembershipId`) REFERENCES `ProgrammeMembership` (`id`);
+ALTER TABLE CurriculumMembership MODIFY COLUMN `programmeMembershipUuid` varchar(36) NOT NULL;
+ALTER TABLE CurriculumMembership ADD INDEX `fk_ProgrammeMembership_programme_membership_id` (`programmeMembershipUuid`);
+ALTER TABLE CurriculumMembership ADD FOREIGN KEY (`programmeMembershipUuid`) REFERENCES `ProgrammeMembership` (`uuid`);
 ALTER TABLE CurriculumMembership CHANGE COLUMN `programmeId` `programmeId` BIGINT(20) NULL,
                                  CHANGE COLUMN `personId` `personId` BIGINT(20) NULL;
 

--- a/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
@@ -1,0 +1,49 @@
+DROP TABLE `ProgrammeMembership`;
+CREATE TABLE `ProgrammeMembership` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `programmeMembershipType` varchar(255) DEFAULT NULL,
+  `programmeStartDate` date DEFAULT NULL,
+  `programmeEndDate` date DEFAULT NULL,
+  `periodOfGrace` int(11) DEFAULT NULL,
+  `programmeId` bigint(20) NOT NULL,
+  `trainingNumberId` bigint(20) DEFAULT NULL,
+  `personId` bigint(20) NOT NULL,
+  `rotation` varchar(255) DEFAULT NULL,
+  `rotationId` bigint(20) DEFAULT NULL,
+  `trainingPathway` varchar(255) DEFAULT NULL,
+  `amendedDate` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  KEY `fk_ProgrammeMembership_person_id` (`personId`),
+  KEY `fk_ProgrammeMembership_programme_id` (`programmeId`),
+  KEY `fk_ProgrammeMembership_training_number_id` (`trainingNumberId`),
+  KEY `fk_ProgrammeMembership_rotation_id` (`rotationId`),
+  CONSTRAINT `fk_ProgrammeMembership_person_id` FOREIGN KEY (`personId`) REFERENCES `Person` (`id`),
+  CONSTRAINT `fk_ProgrammeMembership_programme_id` FOREIGN KEY (`programmeId`) REFERENCES `Programme` (`id`),
+  CONSTRAINT `fk_ProgrammeMembership_training_number_id` FOREIGN KEY (`trainingNumberId`) REFERENCES `TrainingNumber` (`id`),
+  CONSTRAINT `fk_ProgrammeMembership_rotation_id` FOREIGN KEY (`rotationId`) REFERENCES `Rotation` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+
+INSERT INTO ProgrammeMembership (personId, programmeId, rotationId, rotation, programmeStartDate, programmeEndDate,
+programmeMembershipType, trainingPathway, periodOfGrace)
+SELECT
+personId, programmeId, rotationId, max(rotation), programmeStartDate, programmeEndDate,
+programmeMembershipType, max(trainingPathway), max(periodOfGrace)
+FROM CurriculumMembership
+GROUP BY
+personId, programmeId, rotationId, programmeStartDate, programmeEndDate, programmeMembershipType;
+
+ALTER TABLE CurriculumMembership ADD COLUMN `programmeMembershipId` bigint(20) DEFAULT NULL;
+
+UPDATE tcs.CurriculumMembership cm
+SET programmeMembershipId = (SELECT id FROM tcs.ProgrammeMembership pm
+WHERE pm.personId = cm.personId AND
+pm.programmeId = cm.programmeId AND
+IFNULL(pm.rotationId,0) = IFNULL(cm.rotationId,0) AND
+pm.programmeStartDate = cm.programmeStartDate AND
+pm.programmeEndDate = cm.programmeEndDate AND
+IFNULL(pm.programmeMembershipType,'') = IFNULL(cm.programmeMembershipType,''));
+
+ALTER TABLE CurriculumMembership MODIFY COLUMN `programmeMembershipId` bigint(20) NOT NULL;
+ALTER TABLE CurriculumMembership ADD INDEX `fk_ProgrammeMembership_programme_membership_id` (`programmeMembershipId`);
+ALTER TABLE CurriculumMembership ADD FOREIGN KEY (`programmeMembershipId`) REFERENCES `ProgrammeMembership` (`id`);
+

--- a/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
@@ -4,13 +4,13 @@ CREATE TABLE `ProgrammeMembership` (
   `programmeMembershipType` varchar(255) DEFAULT NULL,
   `programmeStartDate` date DEFAULT NULL,
   `programmeEndDate` date DEFAULT NULL,
-  `periodOfGrace` int(11) DEFAULT NULL,
   `programmeId` bigint(20) NOT NULL,
   `trainingNumberId` bigint(20) DEFAULT NULL,
   `personId` bigint(20) NOT NULL,
   `rotation` varchar(255) DEFAULT NULL,
   `rotationId` bigint(20) DEFAULT NULL,
   `trainingPathway` varchar(255) DEFAULT NULL,
+  `leavingReason` varchar(255) DEFAULT NULL,
   `amendedDate` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
   PRIMARY KEY (`id`),
   KEY `fk_ProgrammeMembership_person_id` (`personId`),
@@ -24,10 +24,10 @@ CREATE TABLE `ProgrammeMembership` (
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
 
 INSERT INTO ProgrammeMembership (personId, programmeId, rotationId, rotation, programmeStartDate, programmeEndDate,
-programmeMembershipType, trainingPathway, periodOfGrace)
+programmeMembershipType, trainingPathway, leavingReason)
 SELECT
 personId, programmeId, rotationId, max(rotation), programmeStartDate, programmeEndDate,
-programmeMembershipType, max(trainingPathway), max(periodOfGrace)
+programmeMembershipType, max(trainingPathway), max(leavingReason)
 FROM CurriculumMembership
 GROUP BY
 personId, programmeId, rotationId, programmeStartDate, programmeEndDate, programmeMembershipType;

--- a/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
@@ -46,4 +46,6 @@ IFNULL(pm.programmeMembershipType,'') = IFNULL(cm.programmeMembershipType,''));
 ALTER TABLE CurriculumMembership MODIFY COLUMN `programmeMembershipId` bigint(20) NOT NULL;
 ALTER TABLE CurriculumMembership ADD INDEX `fk_ProgrammeMembership_programme_membership_id` (`programmeMembershipId`);
 ALTER TABLE CurriculumMembership ADD FOREIGN KEY (`programmeMembershipId`) REFERENCES `ProgrammeMembership` (`id`);
+ALTER TABLE CurriculumMembership CHANGE COLUMN `programmeId` `programmeId` BIGINT(20) NULL,
+                                 CHANGE COLUMN `personId` `personId` BIGINT(20) NULL;
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ContactDetailsResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ContactDetailsResourceIntTest.java
@@ -26,9 +26,8 @@ import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +35,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,9 +44,9 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @see ContactDetailsResource
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-public class ContactDetailsResourceIntTest {
+public
+class ContactDetailsResourceIntTest {
 
   private static final String DEFAULT_SURNAME = "AAAAAAAAAA";
   private static final String UPDATED_SURNAME = "BBBBBBBBBB";
@@ -152,8 +150,8 @@ public class ContactDetailsResourceIntTest {
     return contactDetails;
   }
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     MockitoAnnotations.initMocks(this);
     ContactDetailsResource contactDetailsResource = new ContactDetailsResource(
         contactDetailsService, contactDetailsValidator);
@@ -163,14 +161,14 @@ public class ContactDetailsResourceIntTest {
         .setMessageConverters(jacksonMessageConverter).build();
   }
 
-  @Before
-  public void initTest() {
+  @BeforeEach
+  void initTest() {
     contactDetails = createEntity(em);
   }
 
   @Test
   @Transactional
-  public void createContactDetails() throws Exception {
+  void createContactDetails() throws Exception {
     Query nativeQuery = em.createNativeQuery("select * from information_schema.indexes;");
     List<Object[]> authors = nativeQuery.getResultList();
 
@@ -209,7 +207,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateMandatoryFieldsWhenCreating() throws Exception {
+  void shouldValidateMandatoryFieldsWhenCreating() throws Exception {
     //given
     ContactDetailsDTO contactDetailsDTO = new ContactDetailsDTO();
 
@@ -225,7 +223,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateMandatoryFieldsWhenUpdating() throws Exception {
+  void shouldValidateMandatoryFieldsWhenUpdating() throws Exception {
     //given
     ContactDetailsDTO contactDetailsDTO = new ContactDetailsDTO();
 
@@ -241,7 +239,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateValidEmailField() throws Exception {
+  void shouldValidateValidEmailField() throws Exception {
     //given
     ContactDetailsDTO contactDetailsDTO = contactDetailsMapper.toDto(contactDetails);
     contactDetailsDTO.setEmail("test");
@@ -258,7 +256,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void createContactDetailsWithExistingId() throws Exception {
+  void createContactDetailsWithExistingId() throws Exception {
     int databaseSizeBeforeCreate = contactDetailsRepository.findAll().size();
 
     // Create the ContactDetails with an existing ID
@@ -278,7 +276,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void getAllContactDetails() throws Exception {
+  void getAllContactDetails() throws Exception {
     // Initialize the database
     contactDetailsRepository.saveAndFlush(contactDetails);
 
@@ -287,28 +285,28 @@ public class ContactDetailsResourceIntTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$.[*].id").value(hasItem(contactDetails.getId().intValue())))
-        .andExpect(jsonPath("$.[*].surname").value(hasItem(DEFAULT_SURNAME.toString())))
-        .andExpect(jsonPath("$.[*].forenames").value(hasItem(DEFAULT_FORENAMES.toString())))
-        .andExpect(jsonPath("$.[*].knownAs").value(hasItem(DEFAULT_KNOWN_AS.toString())))
-        .andExpect(jsonPath("$.[*].maidenName").value(hasItem(DEFAULT_MAIDEN_NAME.toString())))
-        .andExpect(jsonPath("$.[*].initials").value(hasItem(DEFAULT_INITIALS.toString())))
-        .andExpect(jsonPath("$.[*].title").value(hasItem(DEFAULT_TITLE.toString())))
+        .andExpect(jsonPath("$.[*].surname").value(hasItem(DEFAULT_SURNAME)))
+        .andExpect(jsonPath("$.[*].forenames").value(hasItem(DEFAULT_FORENAMES)))
+        .andExpect(jsonPath("$.[*].knownAs").value(hasItem(DEFAULT_KNOWN_AS)))
+        .andExpect(jsonPath("$.[*].maidenName").value(hasItem(DEFAULT_MAIDEN_NAME)))
+        .andExpect(jsonPath("$.[*].initials").value(hasItem(DEFAULT_INITIALS)))
+        .andExpect(jsonPath("$.[*].title").value(hasItem(DEFAULT_TITLE)))
         .andExpect(
-            jsonPath("$.[*].telephoneNumber").value(hasItem(DEFAULT_CONTACT_PHONE_NR_1.toString())))
+            jsonPath("$.[*].telephoneNumber").value(hasItem(DEFAULT_CONTACT_PHONE_NR_1)))
         .andExpect(
-            jsonPath("$.[*].mobileNumber").value(hasItem(DEFAULT_CONTACT_PHONE_NR_2.toString())))
-        .andExpect(jsonPath("$.[*].email").value(hasItem(DEFAULT_EMAIL.toString())))
-        .andExpect(jsonPath("$.[*].address1").value(hasItem(DEFAULT_ADDRESS.toString())))
-        .andExpect(jsonPath("$.[*].postCode").value(hasItem(DEFAULT_POST_CODE.toString())))
-        .andExpect(jsonPath("$.[*].legalSurname").value(hasItem(DEFAULT_LEGAL_SURNAME.toString())))
+            jsonPath("$.[*].mobileNumber").value(hasItem(DEFAULT_CONTACT_PHONE_NR_2)))
+        .andExpect(jsonPath("$.[*].email").value(hasItem(DEFAULT_EMAIL)))
+        .andExpect(jsonPath("$.[*].address1").value(hasItem(DEFAULT_ADDRESS)))
+        .andExpect(jsonPath("$.[*].postCode").value(hasItem(DEFAULT_POST_CODE)))
+        .andExpect(jsonPath("$.[*].legalSurname").value(hasItem(DEFAULT_LEGAL_SURNAME)))
         .andExpect(
-            jsonPath("$.[*].legalForenames").value(hasItem(DEFAULT_LEGAL_FORENAMES.toString())))
+            jsonPath("$.[*].legalForenames").value(hasItem(DEFAULT_LEGAL_FORENAMES)))
         .andExpect(jsonPath("$.[*].amendedDate").isNotEmpty());
   }
 
   @Test
   @Transactional
-  public void getContactDetails() throws Exception {
+  void getContactDetails() throws Exception {
     // Initialize the database
     contactDetailsRepository.saveAndFlush(contactDetails);
 
@@ -317,26 +315,26 @@ public class ContactDetailsResourceIntTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$.id").value(contactDetails.getId().intValue()))
-        .andExpect(jsonPath("$.surname").value(DEFAULT_SURNAME.toString()))
-        .andExpect(jsonPath("$.forenames").value(DEFAULT_FORENAMES.toString()))
-        .andExpect(jsonPath("$.knownAs").value(DEFAULT_KNOWN_AS.toString()))
-        .andExpect(jsonPath("$.maidenName").value(DEFAULT_MAIDEN_NAME.toString()))
-        .andExpect(jsonPath("$.initials").value(DEFAULT_INITIALS.toString()))
-        .andExpect(jsonPath("$.title").value(DEFAULT_TITLE.toString()))
-        .andExpect(jsonPath("$.telephoneNumber").value(DEFAULT_CONTACT_PHONE_NR_1.toString()))
-        .andExpect(jsonPath("$.mobileNumber").value(DEFAULT_CONTACT_PHONE_NR_2.toString()))
-        .andExpect(jsonPath("$.email").value(DEFAULT_EMAIL.toString()))
-        .andExpect(jsonPath("$.address1").value(DEFAULT_ADDRESS.toString()))
-        .andExpect(jsonPath("$.postCode").value(DEFAULT_POST_CODE.toString()))
-        .andExpect(jsonPath("$.legalSurname").value(DEFAULT_LEGAL_SURNAME.toString()))
-        .andExpect(jsonPath("$.legalForenames").value(DEFAULT_LEGAL_FORENAMES.toString()))
+        .andExpect(jsonPath("$.surname").value(DEFAULT_SURNAME))
+        .andExpect(jsonPath("$.forenames").value(DEFAULT_FORENAMES))
+        .andExpect(jsonPath("$.knownAs").value(DEFAULT_KNOWN_AS))
+        .andExpect(jsonPath("$.maidenName").value(DEFAULT_MAIDEN_NAME))
+        .andExpect(jsonPath("$.initials").value(DEFAULT_INITIALS))
+        .andExpect(jsonPath("$.title").value(DEFAULT_TITLE))
+        .andExpect(jsonPath("$.telephoneNumber").value(DEFAULT_CONTACT_PHONE_NR_1))
+        .andExpect(jsonPath("$.mobileNumber").value(DEFAULT_CONTACT_PHONE_NR_2))
+        .andExpect(jsonPath("$.email").value(DEFAULT_EMAIL))
+        .andExpect(jsonPath("$.address1").value(DEFAULT_ADDRESS))
+        .andExpect(jsonPath("$.postCode").value(DEFAULT_POST_CODE))
+        .andExpect(jsonPath("$.legalSurname").value(DEFAULT_LEGAL_SURNAME))
+        .andExpect(jsonPath("$.legalForenames").value(DEFAULT_LEGAL_FORENAMES))
         .andExpect(jsonPath("$.amendedDate").isNotEmpty());
 
   }
 
   @Test
   @Transactional
-  public void getNonExistingContactDetails() throws Exception {
+  void getNonExistingContactDetails() throws Exception {
     // Get the contactDetails
     restContactDetailsMockMvc.perform(get("/api/contact-details/{id}", Long.MAX_VALUE))
         .andExpect(status().isNotFound());
@@ -344,7 +342,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void updateContactDetails() throws Exception {
+  void updateContactDetails() throws Exception {
     // Initialize the database
     contactDetailsRepository.saveAndFlush(contactDetails);
     int databaseSizeBeforeUpdate = contactDetailsRepository.findAll().size();
@@ -395,7 +393,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void updateNonExistingContactDetails() throws Exception {
+  void updateNonExistingContactDetails() throws Exception {
     int databaseSizeBeforeUpdate = contactDetailsRepository.findAll().size();
 
     // Create the ContactDetails
@@ -415,7 +413,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void deleteContactDetails() throws Exception {
+  void deleteContactDetails() throws Exception {
     // Initialize the database
     contactDetailsRepository.saveAndFlush(contactDetails);
     int databaseSizeBeforeDelete = contactDetailsRepository.findAll().size();
@@ -432,7 +430,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void equalsVerifier() throws Exception {
+  void equalsVerifier() throws Exception {
     TestUtil.equalsVerifier(ContactDetails.class);
     ContactDetails contactDetails1 = new ContactDetails();
     contactDetails1.setId(1L);
@@ -447,7 +445,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void dtoEqualsVerifier() throws Exception {
+  void dtoEqualsVerifier() throws Exception {
     TestUtil.equalsVerifier(ContactDetailsDTO.class);
     ContactDetailsDTO contactDetailsDTO1 = new ContactDetailsDTO();
     contactDetailsDTO1.setId(1L);
@@ -463,7 +461,7 @@ public class ContactDetailsResourceIntTest {
 
   @Test
   @Transactional
-  public void patchContactDetails() throws Exception {
+  void patchContactDetails() throws Exception {
     // Initialize the database
     contactDetailsRepository.saveAndFlush(contactDetails);
     ContactDetails updatedContactDetails = contactDetailsRepository.findById(contactDetails.getId())

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -692,12 +692,14 @@ public class ProgrammeMembershipResourceIntTest {
 
     programmeMembership.setPerson(person);
     programmeMembership.setProgramme(programme);
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
+    programmeMembership.setCurriculumMemberships(Sets.newLinkedHashSet(curriculumMembership));
 
     curriculumMembership.setProgrammeMembership(programmeMembership);
     curriculumMembership
         .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
-    curriculumMembershipRepository.saveAndFlush(curriculumMembership);
+    //curriculumMembershipRepository.saveAndFlush(curriculumMembership);
+
+    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     int databaseSizeBeforeUpdate = curriculumMembershipRepository.findAll().size();
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -959,17 +959,19 @@ public class ProgrammeMembershipResourceIntTest {
     ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
         .findById(programmeMembership.getId()).orElse(null);
 
-    updatedProgrammeMembership.setProgrammeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
-    updatedProgrammeMembership.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
-
-    CurriculumMembership updatedCurriculumMembership = updatedProgrammeMembership.getCurriculumMemberships().iterator().next();
-    updatedCurriculumMembership
-        .intrepidId(UPDATED_INTREPID_ID)
-        .curriculumStartDate(UPDATED_CURRICULUM_START_DATE)
-        .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
-        .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
-        .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
+
+    programmeMembershipDTO.setProgrammeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
+    programmeMembershipDTO.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
+
+    CurriculumMembershipDTO curriculumMembershipDTO
+        = programmeMembershipDTO.getCurriculumMemberships().iterator().next();
+
+    curriculumMembershipDTO.setIntrepidId(UPDATED_INTREPID_ID);
+    curriculumMembershipDTO.setCurriculumStartDate(UPDATED_CURRICULUM_START_DATE);
+    curriculumMembershipDTO.setCurriculumEndDate(UPDATED_CURRICULUM_END_DATE);
+    curriculumMembershipDTO.setCurriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
+    curriculumMembershipDTO.setPeriodOfGrace(UPDATED_PERIOD_OF_GRACE);
 
     //when
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
@@ -1052,7 +1054,7 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembership.setPerson(person);
 
     CurriculumMembership curriculumMembership1 = new CurriculumMembership()
-        .intrepidId("XXX")
+        .intrepidId(DEFAULT_INTREPID_ID)
         .curriculumStartDate(DEFAULT_CURRICULUM_START_DATE)
         .curriculumEndDate(DEFAULT_CURRICULUM_END_DATE)
         .periodOfGrace(DEFAULT_PERIOD_OF_GRACE)
@@ -1080,7 +1082,7 @@ public class ProgrammeMembershipResourceIntTest {
     assertThat(pmSize).isEqualTo(databasePmSizeBeforeDelete);
   }
 
-  @Test //(expected = JpaObjectRetrievalFailureException.class)
+  @Test
   @Transactional
   @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
   public void deleteLastCurriculumMembershipShouldDeleteContainingProgrammeMembership()

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -671,7 +671,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeRepository.saveAndFlush(programme);
 
     programmeMembership.setProgramme(programme);
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     curriculumMembership.setProgrammeMembership(programmeMembership);
     curriculumMembership
@@ -699,7 +698,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeRepository.saveAndFlush(programme);
 
     programmeMembership.setProgramme(programme);
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     curriculumMembership
         .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
@@ -729,7 +727,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeRepository.saveAndFlush(programme);
 
     programmeMembership.setProgramme(programme); // this programme doesn't exist in DB
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     curriculumMembership.setProgrammeMembership(programmeMembership);
     curriculumMembership
@@ -760,7 +757,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeRepository.saveAndFlush(programme);
 
     programmeMembership.setProgramme(programme);
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     curriculumMembership.setProgrammeMembership(programmeMembership);
 
@@ -790,7 +786,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeRepository.saveAndFlush(programme);
 
     programmeMembership.setProgramme(programme);
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     curriculumMembership.setProgrammeMembership(programmeMembership);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -40,7 +40,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import javax.persistence.EntityManager;
 
 import org.assertj.core.util.Sets;
@@ -184,15 +183,11 @@ public class ProgrammeMembershipResourceIntTest {
   public static CurriculumMembership createCurriculumMembershipEntity() {
     CurriculumMembership curriculumMembership = new CurriculumMembership()
         .intrepidId(DEFAULT_INTREPID_ID)
-        .programmeMembershipType(DEFAULT_PROGRAMME_MEMBERSHIP_TYPE)
         .curriculumStartDate(DEFAULT_CURRICULUM_START_DATE)
         .curriculumEndDate(DEFAULT_CURRICULUM_END_DATE)
         .periodOfGrace(DEFAULT_PERIOD_OF_GRACE)
-        .programmeStartDate(DEFAULT_PROGRAMME_START_DATE)
         .curriculumCompletionDate(DEFAULT_CURRICULUM_COMPLETION_DATE)
-        .programmeEndDate(DEFAULT_PROGRAMME_END_DATE)
-        .leavingDestination(DEFAULT_LEAVING_DESTINATION)
-        .leavingReason(DEFAULT_LEAVING_REASON);
+        .leavingDestination(DEFAULT_LEAVING_DESTINATION);
     return curriculumMembership;
   }
 
@@ -334,7 +329,6 @@ public class ProgrammeMembershipResourceIntTest {
         .isEqualTo(DEFAULT_CURRICULUM_COMPLETION_DATE);
     assertThat(testCurriculumMembership.getLeavingDestination())
         .isEqualTo(DEFAULT_LEAVING_DESTINATION);
-    assertThat(testCurriculumMembership.getLeavingReason()).isEqualTo(DEFAULT_LEAVING_REASON);
     assertThat(person.getStatus()).isEqualTo(Status.INACTIVE);
   }
 
@@ -713,16 +707,11 @@ public class ProgrammeMembershipResourceIntTest {
         .findById(curriculumMembership.getId()).orElse(null);
     updatedCurriculumMembership
         .intrepidId(UPDATED_INTREPID_ID)
-        .programmeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE)
-        .rotation(rotation)
         .curriculumStartDate(UPDATED_CURRICULUM_START_DATE)
         .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
         .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
-        .programmeStartDate(UPDATED_PROGRAMME_START_DATE)
-        .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE)
-        .programmeEndDate(UPDATED_PROGRAMME_END_DATE)
         .leavingDestination(UPDATED_LEAVING_DESTINATION)
-        .leavingReason(UPDATED_LEAVING_REASON);
+        .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
     ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper
         .toDto(updatedCurriculumMembership);
 
@@ -746,7 +735,6 @@ public class ProgrammeMembershipResourceIntTest {
         .isEqualTo(UPDATED_CURRICULUM_COMPLETION_DATE);
     assertThat(testCurriculumMembership.getLeavingDestination())
         .isEqualTo(UPDATED_LEAVING_DESTINATION);
-    assertThat(testCurriculumMembership.getLeavingReason()).isEqualTo(UPDATED_LEAVING_REASON);
     assertThat(testCurriculumMembership.getAmendedDate()).isAfter(DEFAULT_AMENDED_DATE);
   }
 
@@ -861,7 +849,7 @@ public class ProgrammeMembershipResourceIntTest {
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
 
-    // Validate the database is empty
+    // Validate the curriculum membership repository is empty
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
     assertThat(curriculumMembershipList).hasSize(databaseCmSizeBeforeDelete - 1);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -197,7 +197,8 @@ public class ProgrammeMembershipResourceIntTest {
         .programmeMembershipType(DEFAULT_PROGRAMME_MEMBERSHIP_TYPE)
         .programmeStartDate(DEFAULT_PROGRAMME_START_DATE)
         .programmeEndDate(DEFAULT_PROGRAMME_END_DATE)
-        .leavingReason(DEFAULT_LEAVING_REASON);
+        .leavingReason(DEFAULT_LEAVING_REASON)
+        .leavingDestination(DEFAULT_LEAVING_DESTINATION);
     return programmeMembership;
   }
 
@@ -893,7 +894,8 @@ public class ProgrammeMembershipResourceIntTest {
     assertThat(pmSize).isEqualTo(databasePmSizeBeforeDelete - 1);
 
     // Validate the programme membership has been deleted
-    Optional<ProgrammeMembership> optionalProgrammeMembership = programmeMembershipRepository.findById(programmeMembership.getId());
+    Optional<ProgrammeMembership> optionalProgrammeMembership
+        = programmeMembershipRepository.findById(programmeMembership.getId());
     assertThat(optionalProgrammeMembership).isNotPresent();
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -1,7 +1,10 @@
 package com.transformuk.hee.tis.tcs.service.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -35,7 +38,6 @@ import com.transformuk.hee.tis.tcs.service.service.RotationService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.PersonMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
-
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -47,12 +49,10 @@ import java.util.Optional;
 import javax.persistence.EntityManager;
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,7 +60,6 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -71,9 +70,8 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @see ProgrammeMembershipResource
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-public class ProgrammeMembershipResourceIntTest {
+class ProgrammeMembershipResourceIntTest {
 
   private static final ProgrammeMembershipType DEFAULT_PROGRAMME_MEMBERSHIP_TYPE = ProgrammeMembershipType.SUBSTANTIVE;
   private static final ProgrammeMembershipType UPDATED_PROGRAMME_MEMBERSHIP_TYPE = ProgrammeMembershipType.LAT;
@@ -187,47 +185,44 @@ public class ProgrammeMembershipResourceIntTest {
    * Create an entity for this test.
    * <p>
    * This is a static method, as tests for other entities might also need it, if they test an entity
-   * which requires the current entity.
-   * IntrepidId is used to distinguish between any additional entities created in the same way.
+   * which requires the current entity. IntrepidId is used to distinguish between any additional
+   * entities created in the same way.
    */
-  public static CurriculumMembership createCurriculumMembershipEntity(String intrepidId) {
-    CurriculumMembership curriculumMembership = new CurriculumMembership()
+  static CurriculumMembership createCurriculumMembershipEntity(String intrepidId) {
+    return new CurriculumMembership()
         .intrepidId(intrepidId)
         .curriculumStartDate(DEFAULT_CURRICULUM_START_DATE)
         .curriculumEndDate(DEFAULT_CURRICULUM_END_DATE)
         .periodOfGrace(DEFAULT_PERIOD_OF_GRACE)
         .curriculumCompletionDate(DEFAULT_CURRICULUM_COMPLETION_DATE);
-    return curriculumMembership;
   }
 
-  public static ProgrammeMembership createProgrammeMembershipEntity() {
-    ProgrammeMembership programmeMembership = new ProgrammeMembership()
+  static ProgrammeMembership createProgrammeMembershipEntity() {
+    return new ProgrammeMembership()
         .programmeMembershipType(DEFAULT_PROGRAMME_MEMBERSHIP_TYPE)
         .programmeStartDate(DEFAULT_PROGRAMME_START_DATE)
         .programmeEndDate(DEFAULT_PROGRAMME_END_DATE)
         .leavingReason(DEFAULT_LEAVING_REASON)
         .leavingDestination(DEFAULT_LEAVING_DESTINATION);
-    return programmeMembership;
   }
 
   /**
    * Create Person entity
    */
-  public static Person createPersonEntity() {
-    return new Person()
-        .intrepidId(DEFAULT_INTREPID_ID);
+  static Person createPersonEntity() {
+    return new Person().intrepidId(DEFAULT_INTREPID_ID);
   }
 
   /**
    * Create Rotation entity
    */
-  public static Rotation createRotationEntity() {
+  static Rotation createRotationEntity() {
     return new Rotation().name(DEFAULT_ROTATION).status(Status.CURRENT);
   }
 
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     MockitoAnnotations.initMocks(this);
     programmeMembershipValidator = new ProgrammeMembershipValidator(personRepository,
         programmeRepository, curriculumRepository, rotationService);
@@ -241,8 +236,8 @@ public class ProgrammeMembershipResourceIntTest {
         .setMessageConverters(jacksonMessageConverter).build();
   }
 
-  @Before
-  public void initTest() {
+  @BeforeEach
+  void initTest() {
     person = createPersonEntity();
     programme = ProgrammeResourceIntTest.createEntity();
     curriculum = CurriculumResourceIntTest.createCurriculumEntity();
@@ -255,7 +250,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldGetProgrammeMembershipDtoByCurriculumMembershipId() throws Exception {
+  void shouldGetProgrammeMembershipDtoByCurriculumMembershipId() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -275,9 +270,10 @@ public class ProgrammeMembershipResourceIntTest {
     CurriculumMembership savedCurriculumMembership1 = curriculumMembershipRepository.saveAndFlush(
         curriculumMembership1); //save second curriculum membership attached to programme membership
 
-    for (long id : new Long[]{savedCurriculumMembership.getId(), savedCurriculumMembership1.getId()}) {
+    for (long id : new Long[]{savedCurriculumMembership.getId(),
+        savedCurriculumMembership1.getId()}) {
       restProgrammeMembershipMockMvc.perform(
-              get("/api/programme-memberships/details/{ids}", id))
+          get("/api/programme-memberships/details/{ids}", id))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
           .andExpect(jsonPath("$.[*].programmeMembershipType")
@@ -299,7 +295,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldCreateCurriculumMembership() throws Exception {
+  void shouldCreateCurriculumMembership() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -323,8 +319,8 @@ public class ProgrammeMembershipResourceIntTest {
     ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper
         .toDto(curriculumMembership);
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isCreated());
 
     // Validate that ProgrammeMembership has been added to the database
@@ -349,7 +345,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldCreateProgrammeMembershipWithMultipleCurriculumMemberships() throws Exception {
+  void shouldCreateProgrammeMembershipWithMultipleCurriculumMemberships() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -371,7 +367,8 @@ public class ProgrammeMembershipResourceIntTest {
         .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
     curriculumMembership1.setProgrammeMembership(programmeMembership);
 
-    programmeMembership.setCurriculumMemberships(Sets.newLinkedHashSet(curriculumMembership, curriculumMembership1));
+    programmeMembership.setCurriculumMemberships(
+        Sets.newLinkedHashSet(curriculumMembership, curriculumMembership1));
 
     int databaseCmSizeBeforeCreate = curriculumMembershipRepository.findAll().size();
     int databasePmSizeBeforeCreate = programmeMembershipRepository.findAll().size();
@@ -380,8 +377,8 @@ public class ProgrammeMembershipResourceIntTest {
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
         .toDto(programmeMembership);
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isCreated());
 
     // Validate that ProgrammeMembership has been added to the database
@@ -424,7 +421,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldCreateCurriculumMembershipForExistingProgrammeMembership() throws Exception {
+  void shouldCreateCurriculumMembershipForExistingProgrammeMembership() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -462,8 +459,8 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembershipDTO.getCurriculumMemberships().add(newCurriculumMembershipDTO);
     programmeMembershipDTO.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isOk());
 
     // Validate the programme membership has been updated with the new curriculum membership
@@ -491,7 +488,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldPatchMultipleProgrammeMemberships() throws Exception {
+  void shouldPatchMultipleProgrammeMemberships() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -525,23 +522,24 @@ public class ProgrammeMembershipResourceIntTest {
     int databasePmSizeBeforeCreate = programmeMembershipRepository.findAll().size();
     int databaseCmSizeBeforeCreate = curriculumMembershipRepository.findAll().size();
 
-    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
+    ProgrammeMembershipDTO programmeMembershipDto = programmeMembershipMapper
         .toDto(programmeMembership);
-    CurriculumMembershipDTO curriculumMembershipDTO =
+    CurriculumMembershipDTO updatedCurriculumMembershipDto =
         curriculumMembershipMapper.toDto(curriculumMembership).getCurriculumMemberships().get(0);
-    curriculumMembershipDTO.setIntrepidId(UPDATED_INTREPID_ID);
-    programmeMembershipDTO.getCurriculumMemberships().clear();
-    programmeMembershipDTO.getCurriculumMemberships().add(curriculumMembershipDTO); //updated curriculum membership
+    updatedCurriculumMembershipDto.setIntrepidId(UPDATED_INTREPID_ID);
+    programmeMembershipDto.getCurriculumMemberships().clear();
+    programmeMembershipDto.getCurriculumMemberships().add(updatedCurriculumMembershipDto);
 
-    ProgrammeMembershipDTO programmeMembershipDTO1 = programmeMembershipMapper
+    ProgrammeMembershipDTO programmeMembershipDto1 = programmeMembershipMapper
         .toDto(programmeMembership1);
-    programmeMembershipDTO1.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
+    programmeMembershipDto1.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
 
     ArrayList<ProgrammeMembershipDTO> pmDTOs = new ArrayList<>();
-    pmDTOs.add(programmeMembershipDTO);
-    pmDTOs.add(programmeMembershipDTO1);
+    pmDTOs.add(programmeMembershipDto);
+    pmDTOs.add(programmeMembershipDto1);
 
-    restProgrammeMembershipMockMvc.perform(MockMvcRequestBuilders.patch("/api/programme-memberships")
+    restProgrammeMembershipMockMvc
+        .perform(MockMvcRequestBuilders.patch("/api/programme-memberships")
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(pmDTOs)))
         .andExpect(status().isOk());
@@ -564,7 +562,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void createProgrammeMembershipShouldError400WhenInvalidProgrammeDatesProvided()
+  void createProgrammeMembershipShouldError400WhenInvalidProgrammeDatesProvided()
       throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
@@ -598,7 +596,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void createProgrammeMembershipShouldError400WhenNullProgrammeDatesProvided()
+  void createProgrammeMembershipShouldError400WhenNullProgrammeDatesProvided()
       throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
@@ -634,14 +632,14 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateMandatoryFieldsWhenCreating() throws Exception {
+  void shouldValidateMandatoryFieldsWhenCreating() throws Exception {
     //given
     ProgrammeMembershipDTO programmeMembershipDTO = new ProgrammeMembershipDTO();
 
     //when & then
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[*].field").
@@ -651,14 +649,14 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateMandatoryFieldsWhenUpdating() throws Exception {
+  void shouldValidateMandatoryFieldsWhenUpdating() throws Exception {
     //given
     ProgrammeMembershipDTO programmeMembershipDTO = new ProgrammeMembershipDTO();
 
     //when & then
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[*].field").
@@ -668,7 +666,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidatePersonWhenCreating() throws Exception {
+  void shouldValidatePersonWhenCreating() throws Exception {
     //given
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -685,8 +683,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when & then
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("person"))
@@ -695,7 +693,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidatePersonWhenPersonIdIsNull() throws Exception {
+  void shouldValidatePersonWhenPersonIdIsNull() throws Exception {
     //given
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -713,8 +711,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when & then
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("person"))
@@ -724,7 +722,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateProgramme() throws Exception {
+  void shouldValidateProgramme() throws Exception {
     //given
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -743,8 +741,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when & then
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("programmeId"))
@@ -754,7 +752,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateCurriculum() throws Exception {
+  void shouldValidateCurriculum() throws Exception {
     //given
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -772,8 +770,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when & then
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("curriculumId"))
@@ -783,7 +781,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateProgrammeCurriculumAssociation() throws Exception {
+  void shouldValidateProgrammeCurriculumAssociation() throws Exception {
     //given
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -803,8 +801,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when & then
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("curriculumId"))
@@ -816,7 +814,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void createCurriculumMembershipWithExistingIdShouldFail() throws Exception {
+  void createCurriculumMembershipWithExistingIdShouldFail() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -840,8 +838,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     // An entity with an existing ID cannot be created, so this API call must fail
     restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest());
 
     // Validate the Alice in the database
@@ -851,7 +849,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldGetAllProgrammeMembershipDtos() throws Exception {
+  void shouldGetAllProgrammeMembershipDtos() throws Exception {
     // Initialize the database
     personRepository.saveAndFlush(person);
     rotationRepository.saveAndFlush(rotation);
@@ -890,7 +888,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldGetProgrammeMembershipDto() throws Exception {
+  void shouldGetProgrammeMembershipDto() throws Exception {
     // Initialize the database
     personRepository.saveAndFlush(person);
     programmeRepository.saveAndFlush(programme);
@@ -930,7 +928,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void getNonExistingProgrammeMembershipDtoShouldFail() throws Exception {
+  void getNonExistingProgrammeMembershipDtoShouldFail() throws Exception {
     // Get the programmeMembership
     restProgrammeMembershipMockMvc.perform(get("/api/programme-memberships/{id}", Long.MAX_VALUE))
         .andExpect(status().isNotFound());
@@ -938,7 +936,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldUpdateProgrammeAndCurriculumMembership() throws Exception {
+  void shouldUpdateProgrammeAndCurriculumMembership() throws Exception {
     // Initialize the database
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
@@ -949,7 +947,8 @@ public class ProgrammeMembershipResourceIntTest {
 
     programmeMembership.setPerson(person);
     programmeMembership.setProgramme(programme);
-    programmeMembership.setCurriculumMemberships(Sets.newLinkedHashSet(curriculumMembership, curriculumMembership1));
+    programmeMembership.setCurriculumMemberships(
+        Sets.newLinkedHashSet(curriculumMembership, curriculumMembership1));
 
     curriculumMembership.setProgrammeMembership(programmeMembership);
     curriculumMembership
@@ -966,7 +965,8 @@ public class ProgrammeMembershipResourceIntTest {
     ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
         .findById(programmeMembership.getUuid()).orElse(null);
 
-    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
+    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
+        .toDto(updatedProgrammeMembership);
 
     programmeMembershipDTO.setProgrammeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
     programmeMembershipDTO.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
@@ -982,16 +982,18 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isOk());
 
     //then
     // Validate the updated ProgrammeMembership in the database
     ProgrammeMembership retrievedProgrammeMembership = programmeMembershipRepository
         .findByUuid(programmeMembership.getUuid()).orElse(null);
-    assertThat(retrievedProgrammeMembership.getProgrammeMembershipType()).isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
-    assertThat(retrievedProgrammeMembership.getProgrammeEndDate()).isEqualTo(UPDATED_PROGRAMME_END_DATE);
+    assertThat(retrievedProgrammeMembership.getProgrammeMembershipType())
+        .isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
+    assertThat(retrievedProgrammeMembership.getProgrammeEndDate())
+        .isEqualTo(UPDATED_PROGRAMME_END_DATE);
 
     // Validate the updated CurriculumMembership in the database
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
@@ -1010,7 +1012,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void allEntityToDtoDoesNotDetachEntities() throws Exception {
+  void allEntityToDtoDoesNotDetachEntities() throws Exception {
     // Initialize the database
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
@@ -1039,7 +1041,8 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembershipRepository.saveAndFlush(programmeMembership1);
 
     List<ProgrammeMembershipDTO> programmeMembershipDtoList
-       = programmeMembershipMapper.allEntityToDto(Lists.newArrayList(programmeMembership, programmeMembership1));
+        = programmeMembershipMapper
+        .allEntityToDto(Lists.newArrayList(programmeMembership, programmeMembership1));
 
     assertThat(programmeMembershipDtoList).hasSize(2); //sanity check
     ProgrammeMembershipDTO pmDto1 = programmeMembershipDtoList.get(0);
@@ -1048,25 +1051,25 @@ public class ProgrammeMembershipResourceIntTest {
 
     //when
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(pmDto1)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(pmDto1)))
         .andExpect(status().isOk());
 
     //then
     // Validate the updated ProgrammeMembership in the database without a failed 'detached entities' error.
     ProgrammeMembership retrievedProgrammeMembership = programmeMembershipRepository
         .findByUuid(programmeMembership.getUuid()).orElse(null);
-    assertThat(retrievedProgrammeMembership.getProgrammeMembershipType()).isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
-    assertThat(retrievedProgrammeMembership.getProgrammeEndDate()).isEqualTo(UPDATED_PROGRAMME_END_DATE);
+    assertThat(retrievedProgrammeMembership.getProgrammeMembershipType())
+        .isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
+    assertThat(retrievedProgrammeMembership.getProgrammeEndDate())
+        .isEqualTo(UPDATED_PROGRAMME_END_DATE);
   }
 
-  @Test
   @Transactional
-  @ParameterizedTest
+  @ParameterizedTest(name = "Update CurriculumMembership Without {0} Should Fail")
   @ValueSource(strings = {"curriculumStartDate", "curriculumEndDate", "curriculumId"})
-  void updateCurriculumMembershipWithoutRequiredFieldsShouldFail(String fieldToNull) throws Exception {
-    setup();
-    initTest();
+  void updateCurriculumMembershipWithoutRequiredFieldsShouldFail(String fieldToNull)
+      throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -1099,8 +1102,8 @@ public class ProgrammeMembershipResourceIntTest {
     // assumed to be new and added instead of being updated).
     //TODO: confirm the ProgrammeMembershipDTO and CurriculumMembershipDTO Update.class field groups
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isBadRequest());
 
     // Validate the CurriculumMembership is not in the database
@@ -1111,7 +1114,7 @@ public class ProgrammeMembershipResourceIntTest {
   @Test
   @Transactional
   @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
-  public void deleteCurriculumMembershipShouldNotDeleteContainingProgrammeMembership()
+  void deleteCurriculumMembershipShouldNotDeleteContainingProgrammeMembership()
       throws Exception {
     // Initialize the database
     // The reason this test needs to run with a fresh context is that we want the same ID
@@ -1129,7 +1132,8 @@ public class ProgrammeMembershipResourceIntTest {
         .periodOfGrace(DEFAULT_PERIOD_OF_GRACE)
         .curriculumCompletionDate(DEFAULT_CURRICULUM_COMPLETION_DATE);
 
-    programmeMembership.setCurriculumMemberships(Sets.newLinkedHashSet(curriculumMembership, curriculumMembership1));
+    programmeMembership.setCurriculumMemberships(
+        Sets.newLinkedHashSet(curriculumMembership, curriculumMembership1));
     curriculumMembership.setProgrammeMembership(programmeMembership);
     programmeMembershipRepository.saveAndFlush(programmeMembership);
 
@@ -1154,7 +1158,7 @@ public class ProgrammeMembershipResourceIntTest {
   @Test
   @Transactional
   @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
-  public void deleteLastCurriculumMembershipShouldDeleteContainingProgrammeMembership()
+  void deleteLastCurriculumMembershipShouldDeleteContainingProgrammeMembership()
       throws Exception {
     //given
     programmeMembershipRepository.deleteAll();
@@ -1189,7 +1193,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void equalsVerifier() throws Exception {
+  void equalsVerifier() throws Exception {
     TestUtil.equalsVerifier(CurriculumMembership.class);
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -302,7 +302,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembership.setPerson(person);
     programmeMembership.setProgramme(programme);
     programmeMembership.setRotation(rotation);
-    programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     int databaseCmSizeBeforeCreate = curriculumMembershipRepository.findAll().size();
     int databasePmSizeBeforeCreate = programmeMembershipRepository.findAll().size();
@@ -320,9 +319,9 @@ public class ProgrammeMembershipResourceIntTest {
             .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isCreated());
 
-    // Validate that ProgrammeMembership has been updated in the database
+    // Validate that ProgrammeMembership has been added to the database
     List<ProgrammeMembership> programmeMembershipList = programmeMembershipRepository.findAll();
-    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeCreate);
+    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeCreate + 1);
 
     // Validate the CurriculumMembership in the database
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
@@ -330,24 +329,22 @@ public class ProgrammeMembershipResourceIntTest {
     CurriculumMembership testCurriculumMembership = curriculumMembershipList
         .get(curriculumMembershipList.size() - 1);
     assertThat(testCurriculumMembership.getIntrepidId()).isEqualTo(DEFAULT_INTREPID_ID);
-    assertThat(testCurriculumMembership.getProgrammeMembershipType())
-        .isEqualTo(DEFAULT_PROGRAMME_MEMBERSHIP_TYPE);
-    assertThat(testCurriculumMembership.getRotation()).isEqualTo(rotation);
     assertThat(testCurriculumMembership.getCurriculumStartDate())
         .isEqualTo(DEFAULT_CURRICULUM_START_DATE);
     assertThat(testCurriculumMembership.getCurriculumEndDate())
         .isEqualTo(DEFAULT_CURRICULUM_END_DATE);
     assertThat(testCurriculumMembership.getPeriodOfGrace()).isEqualTo(DEFAULT_PERIOD_OF_GRACE);
-    assertThat(testCurriculumMembership.getProgrammeStartDate())
-        .isEqualTo(DEFAULT_PROGRAMME_START_DATE);
     assertThat(testCurriculumMembership.getCurriculumCompletionDate())
         .isEqualTo(DEFAULT_CURRICULUM_COMPLETION_DATE);
-    assertThat(testCurriculumMembership.getProgrammeEndDate()).isEqualTo(DEFAULT_PROGRAMME_END_DATE);
     assertThat(testCurriculumMembership.getLeavingDestination())
         .isEqualTo(DEFAULT_LEAVING_DESTINATION);
     assertThat(testCurriculumMembership.getLeavingReason()).isEqualTo(DEFAULT_LEAVING_REASON);
     assertThat(person.getStatus()).isEqualTo(Status.INACTIVE);
   }
+
+  //TODO: add tests:
+  //saved PM and 2 new CMs
+  //saved PM and CM, update to both
 
 //  @Test
 //  @Transactional

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -185,8 +185,7 @@ public class ProgrammeMembershipResourceIntTest {
         .curriculumStartDate(DEFAULT_CURRICULUM_START_DATE)
         .curriculumEndDate(DEFAULT_CURRICULUM_END_DATE)
         .periodOfGrace(DEFAULT_PERIOD_OF_GRACE)
-        .curriculumCompletionDate(DEFAULT_CURRICULUM_COMPLETION_DATE)
-        .leavingDestination(DEFAULT_LEAVING_DESTINATION);
+        .curriculumCompletionDate(DEFAULT_CURRICULUM_COMPLETION_DATE);
     return curriculumMembership;
   }
 
@@ -326,8 +325,6 @@ public class ProgrammeMembershipResourceIntTest {
     assertThat(testCurriculumMembership.getPeriodOfGrace()).isEqualTo(DEFAULT_PERIOD_OF_GRACE);
     assertThat(testCurriculumMembership.getCurriculumCompletionDate())
         .isEqualTo(DEFAULT_CURRICULUM_COMPLETION_DATE);
-    assertThat(testCurriculumMembership.getLeavingDestination())
-        .isEqualTo(DEFAULT_LEAVING_DESTINATION);
     assertThat(person.getStatus()).isEqualTo(Status.INACTIVE);
   }
 
@@ -625,7 +622,6 @@ public class ProgrammeMembershipResourceIntTest {
             .value(hasItem(DEFAULT_PROGRAMME_START_DATE.toString())))
         .andExpect(jsonPath("$.[*].programmeEndDate")
             .value(hasItem(DEFAULT_PROGRAMME_END_DATE.toString())))
-        .andExpect(jsonPath("$.[*].leavingDestination").value(hasItem(DEFAULT_LEAVING_DESTINATION)))
         .andExpect(jsonPath("$.[*].leavingReason").value(hasItem(DEFAULT_LEAVING_REASON)))
         .andExpect(jsonPath("$.[*].curriculumMemberships[*].amendedDate").isNotEmpty());
   }
@@ -666,7 +662,6 @@ public class ProgrammeMembershipResourceIntTest {
             .value(hasItem(DEFAULT_PERIOD_OF_GRACE)))
         .andExpect(jsonPath("$.programmeStartDate").value(DEFAULT_PROGRAMME_START_DATE.toString()))
         .andExpect(jsonPath("$.programmeEndDate").value(DEFAULT_PROGRAMME_END_DATE.toString()))
-        .andExpect(jsonPath("$.leavingDestination").value(DEFAULT_LEAVING_DESTINATION))
         .andExpect(jsonPath("$.leavingReason").value(DEFAULT_LEAVING_REASON))
         .andExpect(jsonPath("$.curriculumMemberships[*].amendedDate").isNotEmpty());
   }
@@ -704,22 +699,44 @@ public class ProgrammeMembershipResourceIntTest {
     int databaseSizeBeforeUpdate = curriculumMembershipRepository.findAll().size();
 
     // Update the curriculumMembership
-    CurriculumMembership updatedCurriculumMembership = curriculumMembershipRepository
-        .findById(curriculumMembership.getId()).orElse(null);
+//    CurriculumMembership updatedCurriculumMembership = curriculumMembershipRepository
+//        .findById(curriculumMembership.getId()).orElse(null);
+//    updatedCurriculumMembership
+//        .intrepidId(UPDATED_INTREPID_ID)
+//        .curriculumStartDate(UPDATED_CURRICULUM_START_DATE)
+//        .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
+//        .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
+//        .leavingDestination(UPDATED_LEAVING_DESTINATION)
+//        .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
+//    ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper
+//        .toDto(updatedCurriculumMembership);
+
+    //make update from PM instead of from CM repo
+    ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
+        .findById(programmeMembership.getId()).orElse(null);
+    CurriculumMembership updatedCurriculumMembership = updatedProgrammeMembership.getCurriculumMemberships().iterator().next();
     updatedCurriculumMembership
         .intrepidId(UPDATED_INTREPID_ID)
         .curriculumStartDate(UPDATED_CURRICULUM_START_DATE)
         .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
         .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
-        .leavingDestination(UPDATED_LEAVING_DESTINATION)
         .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
-    ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper
-        .toDto(updatedCurriculumMembership);
 
-    restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
-        .andExpect(status().isOk());
+    //this works
+    //programmeMembershipRepository.save(updatedProgrammeMembership);
+
+    //this gives detached CM entity
+    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
+    ProgrammeMembership updatedPMfromDTO = programmeMembershipMapper.toEntity(programmeMembershipDTO);
+    programmeMembershipRepository.save(updatedPMfromDTO);
+
+
+
+//
+//    restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+//        .andExpect(status().isOk());
 
     // Validate the CurriculumMembership in the database
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
@@ -734,8 +751,6 @@ public class ProgrammeMembershipResourceIntTest {
     assertThat(testCurriculumMembership.getPeriodOfGrace()).isEqualTo(UPDATED_PERIOD_OF_GRACE);
     assertThat(testCurriculumMembership.getCurriculumCompletionDate())
         .isEqualTo(UPDATED_CURRICULUM_COMPLETION_DATE);
-    assertThat(testCurriculumMembership.getLeavingDestination())
-        .isEqualTo(UPDATED_LEAVING_DESTINATION);
     assertThat(testCurriculumMembership.getAmendedDate()).isAfter(DEFAULT_AMENDED_DATE);
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -336,39 +336,6 @@ public class ProgrammeMembershipResourceIntTest {
   //saved PM and 2 new CMs
   //saved PM and CM, update to both
 
-  //TODO: enable this
-//  @Test
-//  @Transactional
-//  public void createProgrammeMembershipDoesNotWriteToProgrammeMembershipRepository() throws Exception {
-//    personRepository.saveAndFlush(person);
-//    curriculumRepository.saveAndFlush(curriculum);
-//    programme.setCurricula(Collections.singleton(programmeCurriculum));
-//    programmeRepository.saveAndFlush(programme);
-//    rotation.setProgrammeId(programme.getId());
-//    rotationRepository.saveAndFlush(rotation);
-//    int databasePmSizeBeforeCreate = programmeMembershipRepository.findAll().size();
-//    int databaseCmSizeBeforeCreate = curriculumMembershipRepository.findAll().size();
-//
-//    programmeMembership.setPerson(person);
-//    programmeMembership.setProgramme(programme);
-//    programmeMembership
-//        .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
-//    programmeMembership.setRotation(rotation);
-//    // Create the ProgrammeMembership
-//    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
-//        .toDto(programmeMembership);
-//    restProgrammeMembershipMockMvc.perform(post("/api/programme-memberships")
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
-//        .andExpect(status().isCreated());
-//
-//    // Validate the ProgrammeMembershipRepository has NOT changed (it is actually saved as CurriculumMembership)
-//    List<ProgrammeMembership> programmeMembershipList = programmeMembershipRepository.findAll();
-//    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeCreate);
-//    List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
-//    assertThat(curriculumMembershipList).hasSize(databaseCmSizeBeforeCreate+1);
-//  }
-
   @Test
   @Transactional
   public void shouldValidateMandatoryFieldsWhenCreating() throws Exception {
@@ -680,7 +647,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void updateCurriculumMembership() throws Exception {
+  public void updateProgrammeAndCurriculumMembership() throws Exception {
     // Initialize the database
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
@@ -696,28 +663,18 @@ public class ProgrammeMembershipResourceIntTest {
     curriculumMembership.setProgrammeMembership(programmeMembership);
     curriculumMembership
         .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
-    //curriculumMembershipRepository.saveAndFlush(curriculumMembership);
 
     programmeMembershipRepository.saveAndFlush(programmeMembership);
 
     int databaseSizeBeforeUpdate = curriculumMembershipRepository.findAll().size();
 
-    // Update the curriculumMembership
-//    CurriculumMembership updatedCurriculumMembership = curriculumMembershipRepository
-//        .findById(curriculumMembership.getId()).orElse(null);
-//    updatedCurriculumMembership
-//        .intrepidId(UPDATED_INTREPID_ID)
-//        .curriculumStartDate(UPDATED_CURRICULUM_START_DATE)
-//        .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
-//        .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
-//        .leavingDestination(UPDATED_LEAVING_DESTINATION)
-//        .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
-//    ProgrammeMembershipDTO programmeMembershipDTO = curriculumMembershipMapper
-//        .toDto(updatedCurriculumMembership);
-
-    //make update from PM instead of from CM repo
+    //Update curriculumMembership
     ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
         .findById(programmeMembership.getId()).orElse(null);
+
+    updatedProgrammeMembership.setProgrammeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
+    updatedProgrammeMembership.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);
+
     CurriculumMembership updatedCurriculumMembership = updatedProgrammeMembership.getCurriculumMemberships().iterator().next();
     updatedCurriculumMembership
         .intrepidId(UPDATED_INTREPID_ID)
@@ -726,20 +683,19 @@ public class ProgrammeMembershipResourceIntTest {
         .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
         .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
-//
-//    //this works
-//    //programmeMembershipRepository.save(updatedProgrammeMembership);
-//
-//    //this gives detached CM entity
-//    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
-//    ProgrammeMembership updatedPMfromDTO = programmeMembershipMapper.toEntity(programmeMembershipDTO);
-//    //programmeMembershipRepository.save(updatedPMfromDTO);
 
-
+    //when
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isOk());
+
+    //then
+    // Validate the updated ProgrammeMembership in the database
+    ProgrammeMembership retrievedProgrammeMembership = programmeMembershipRepository
+        .findById(programmeMembership.getId()).orElse(null);
+    assertThat(retrievedProgrammeMembership.getProgrammeMembershipType()).isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
+    assertThat(retrievedProgrammeMembership.getProgrammeEndDate()).isEqualTo(UPDATED_PROGRAMME_END_DATE);
 
     // Validate the CurriculumMembership in the database
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
@@ -756,51 +712,6 @@ public class ProgrammeMembershipResourceIntTest {
         .isEqualTo(UPDATED_CURRICULUM_COMPLETION_DATE);
     assertThat(testCurriculumMembership.getAmendedDate()).isAfter(DEFAULT_AMENDED_DATE);
   }
-
-  //TODO: enable this test
-//  @Test
-//  @Transactional
-//  public void updateProgrammeMembershipShouldNotUpdateProgrammeMembershipRepository() throws Exception {
-//    // Initialize the database
-//    personRepository.saveAndFlush(person);
-//    curriculumRepository.saveAndFlush(curriculum);
-//    programme.setCurricula(Collections.singleton(programmeCurriculum));
-//    programmeRepository.saveAndFlush(programme);
-//    rotation.setProgrammeId(programme.getId());
-//    rotationRepository.saveAndFlush(rotation);
-//    programmeMembership.setPerson(person);
-//    programmeMembership.setProgramme(programme);
-//    programmeMembership
-//        .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
-//
-//    // Get a copy of the programmeMembership and update it
-//    programmeMembershipRepository.saveAndFlush(programmeMembership);
-//    ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
-//        .findById(programmeMembership.getId()).orElse(null);
-//    updatedProgrammeMembership.setIntrepidId(UPDATED_INTREPID_ID);
-//    updatedProgrammeMembership.setLeavingReason(UPDATED_LEAVING_REASON);
-//    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
-//        .toDto(updatedProgrammeMembership);
-//
-//    programmeMembership.setIntrepidId(DEFAULT_INTREPID_ID);
-//    programmeMembership.setLeavingReason(DEFAULT_LEAVING_REASON);
-//    programmeMembershipRepository.saveAndFlush(programmeMembership);
-//    int databaseSizeBeforeUpdate = programmeMembershipRepository.findAll().size();
-//
-//    //this will update the curriculum membership repository, not the programme membership repository
-//    restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
-//        .andExpect(status().isOk());
-//
-//    // Validate that the original ProgrammeMembership in the repository is unchanged
-//    List<ProgrammeMembership> programmeMembershipList = programmeMembershipRepository.findAll();
-//    assertThat(programmeMembershipList).hasSize(databaseSizeBeforeUpdate);
-//    ProgrammeMembership testProgrammeMembership = programmeMembershipList
-//        .get(programmeMembershipList.size() - 1);
-//    assertThat(testProgrammeMembership.getIntrepidId()).isEqualTo(DEFAULT_INTREPID_ID);
-//    assertThat(testProgrammeMembership.getLeavingReason()).isEqualTo(DEFAULT_LEAVING_REASON);
-//  }
 
   @Test
   @Transactional

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -351,8 +351,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembership.setProgrammeEndDate(LocalDate.now());
     programmeMembership.setPerson(person);
     programmeMembership.setProgramme(programme);
-    programmeMembership
-        .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
     programmeMembership.setRotation(rotation);
     // Create the ProgrammeMembership
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
@@ -387,8 +385,6 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembership.setProgrammeEndDate(null);
     programmeMembership.setPerson(person);
     programmeMembership.setProgramme(programme);
-    programmeMembership
-        .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
     programmeMembership.setRotation(rotation);
     // Create the ProgrammeMembership
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -2,7 +2,6 @@ package com.transformuk.hee.tis.tcs.service.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,7 +36,6 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMa
 import com.transformuk.hee.tis.tcs.service.service.mapper.PersonMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -45,12 +43,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import javax.persistence.EntityManager;
-
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -965,7 +960,7 @@ public class ProgrammeMembershipResourceIntTest {
 
     //Update first curriculumMembership and its programmeMembership
     ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
-        .findById(programmeMembership.getId()).orElse(null);
+        .findById(programmeMembership.getUuid()).orElse(null);
 
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
 
@@ -990,7 +985,7 @@ public class ProgrammeMembershipResourceIntTest {
     //then
     // Validate the updated ProgrammeMembership in the database
     ProgrammeMembership retrievedProgrammeMembership = programmeMembershipRepository
-        .findById(programmeMembership.getId()).orElse(null);
+        .findByUuid(programmeMembership.getUuid()).orElse(null);
     assertThat(retrievedProgrammeMembership.getProgrammeMembershipType()).isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
     assertThat(retrievedProgrammeMembership.getProgrammeEndDate()).isEqualTo(UPDATED_PROGRAMME_END_DATE);
 
@@ -1056,7 +1051,7 @@ public class ProgrammeMembershipResourceIntTest {
     //then
     // Validate the updated ProgrammeMembership in the database without a failed 'detached entities' error.
     ProgrammeMembership retrievedProgrammeMembership = programmeMembershipRepository
-        .findById(programmeMembership.getId()).orElse(null);
+        .findByUuid(programmeMembership.getUuid()).orElse(null);
     assertThat(retrievedProgrammeMembership.getProgrammeMembershipType()).isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
     assertThat(retrievedProgrammeMembership.getProgrammeEndDate()).isEqualTo(UPDATED_PROGRAMME_END_DATE);
   }
@@ -1173,7 +1168,7 @@ public class ProgrammeMembershipResourceIntTest {
 
     // Validate the programme membership has been deleted
     Optional<ProgrammeMembership> optionalProgrammeMembership
-        = programmeMembershipRepository.findById(programmeMembership.getId());
+        = programmeMembershipRepository.findByUuid(programmeMembership.getUuid());
     assertThat(optionalProgrammeMembership).isNotPresent();
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -721,22 +721,21 @@ public class ProgrammeMembershipResourceIntTest {
         .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
         .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
         .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE);
-
-    //this works
-    //programmeMembershipRepository.save(updatedProgrammeMembership);
-
-    //this gives detached CM entity
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
-    ProgrammeMembership updatedPMfromDTO = programmeMembershipMapper.toEntity(programmeMembershipDTO);
-    programmeMembershipRepository.save(updatedPMfromDTO);
-
-
-
 //
-//    restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
-//        .andExpect(status().isOk());
+//    //this works
+//    //programmeMembershipRepository.save(updatedProgrammeMembership);
+//
+//    //this gives detached CM entity
+//    ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper.toDto(updatedProgrammeMembership);
+//    ProgrammeMembership updatedPMfromDTO = programmeMembershipMapper.toEntity(programmeMembershipDTO);
+//    //programmeMembershipRepository.save(updatedPMfromDTO);
+
+
+    restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
+        .andExpect(status().isOk());
 
     // Validate the CurriculumMembership in the database
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -390,8 +390,7 @@ public class ProgrammeMembershipResourceIntTest {
     assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeCreate + 1);
     ProgrammeMembership testProgrammeMembership = programmeMembershipList
         .get(programmeMembershipList.size() - 1);
-    assertThat(testProgrammeMembership.getCurriculumMemberships().size())
-        .isEqualTo(2);
+    assertThat(testProgrammeMembership.getCurriculumMemberships()).hasSize(2);
     assertThat(testProgrammeMembership.getProgrammeStartDate())
         .isEqualTo(programmeMembership.getProgrammeStartDate());
 
@@ -1043,7 +1042,7 @@ public class ProgrammeMembershipResourceIntTest {
     List<ProgrammeMembershipDTO> programmeMembershipDtoList
        = programmeMembershipMapper.allEntityToDto(Lists.newArrayList(programmeMembership, programmeMembership1));
 
-    assertThat(programmeMembershipDtoList.size()).isEqualTo(2); //sanity check
+    assertThat(programmeMembershipDtoList).hasSize(2); //sanity check
     ProgrammeMembershipDTO pmDto1 = programmeMembershipDtoList.get(0);
     pmDto1.setProgrammeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
     pmDto1.setProgrammeEndDate(UPDATED_PROGRAMME_END_DATE);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -41,7 +41,6 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import javax.persistence.EntityManager;
-
 import org.assertj.core.util.Sets;
 import org.junit.Before;
 import org.junit.Test;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceTest.java
@@ -149,14 +149,12 @@ public class ProgrammeMembershipResourceTest {
     ProgrammeMembershipCurriculaDTO pmcDto1 = new ProgrammeMembershipCurriculaDTO(), pmcDto2 = new ProgrammeMembershipCurriculaDTO();
     pmcDto1.setId(1L);
     pmcDto1.setProgrammeId(Long.parseLong(PROGRAMME_ID));
-    pmcDto1.setLeavingDestination(DESTINATION_1);
     pmcDto1.setLeavingReason(REASON_1);
     pmcDto1.setProgrammeName(PROGRAMME_NAME);
     pmcDto1.setProgrammeNumber(PROGRAMME_NUMBER);
 
     pmcDto2.setId(2L);
     pmcDto2.setProgrammeId(Long.parseLong(PROGRAMME_ID));
-    pmcDto2.setLeavingDestination(DESTINATION_2);
     pmcDto2.setLeavingReason(REASON_2);
     pmcDto2.setProgrammeName(PROGRAMME_NAME);
     pmcDto2.setProgrammeNumber(PROGRAMME_NUMBER);
@@ -173,8 +171,6 @@ public class ProgrammeMembershipResourceTest {
         .andExpect(jsonPath("$.*.id").value(hasItem(1)))
         .andExpect(jsonPath("$.*.id").value(hasItem(2)))
         .andExpect(jsonPath("$.*.programmeId").value(hasItem(Integer.parseInt(PROGRAMME_ID))))
-        .andExpect(jsonPath("$.*.leavingDestination").value(hasItem(DESTINATION_1)))
-        .andExpect(jsonPath("$.*.leavingDestination").value(hasItem(DESTINATION_2)))
         .andExpect(jsonPath("$.*.leavingReason").value(hasItem(REASON_1)))
         .andExpect(jsonPath("$.*.leavingReason").value(hasItem(REASON_2)))
         .andExpect(jsonPath("$.*.programmeName").value(hasItem(PROGRAMME_NAME)))

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/PersonServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/PersonServiceImplTest.java
@@ -25,6 +25,7 @@ import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.PersonTrust;
 import com.transformuk.hee.tis.tcs.service.model.PersonalDetails;
 import com.transformuk.hee.tis.tcs.service.model.PostTrust;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.RightToWork;
 import com.transformuk.hee.tis.tcs.service.repository.ContactDetailsRepository;
 import com.transformuk.hee.tis.tcs.service.repository.GdcDetailsRepository;
@@ -86,7 +87,7 @@ public class PersonServiceImplTest {
   private ArgumentCaptor<PersonV2DTO> personV2DTOArgumentCaptor;
 
   private Person person;
-  private CurriculumMembership pm1, pm2, pm3, pm4;
+  private ProgrammeMembership pm1, pm2, pm3, pm4;
   private PersonDTO personDTO;
   private ProgrammeMembershipDTO pmDTO1, pmDTO2, pmDTO3, pmDTO4;
   private PersonDTO unsavedPersonDTOMock = mock(PersonDTO.class), savedPersonDTOMock = mock(
@@ -148,12 +149,12 @@ public class PersonServiceImplTest {
     LocalDate pm3Date = null;
     LocalDate pm4Date = LocalDate.of(2000, 1, 1);
 
-    pm1 = new CurriculumMembership().programmeStartDate(pm1Date);
-    pm2 = new CurriculumMembership().programmeStartDate(pm2Date);
-    pm3 = new CurriculumMembership().programmeStartDate(pm3Date);
-    pm4 = new CurriculumMembership().programmeStartDate(pm4Date);
+    pm1 = new ProgrammeMembership().programmeStartDate(pm1Date);
+    pm2 = new ProgrammeMembership().programmeStartDate(pm2Date);
+    pm3 = new ProgrammeMembership().programmeStartDate(pm3Date);
+    pm4 = new ProgrammeMembership().programmeStartDate(pm4Date);
 
-    person.setCurriculumMemberships(Sets.newHashSet(pm1, pm2, pm3, pm4));
+    person.setProgrammeMemberships(Sets.newHashSet(pm1, pm2, pm3, pm4));
 
     personDTO = new PersonDTO();
     pmDTO1 = new ProgrammeMembershipDTO();

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -291,7 +291,7 @@ public class ProgrammeMembershipServiceImplTest {
         .findProgrammeMembershipsForTrainee(TRAINEE_ID);
 
     Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.size());
+    Assert.assertEquals(2, result.size());
     Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getProgrammeMembershipId());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, result.get(0).getId());
     ProgrammeMembershipCurriculaDTO programmeMembershipCurriculaDTO = result.get(0);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
@@ -81,10 +80,10 @@ public class ProgrammeMembershipServiceImplTest {
   private final CurriculumDTO curriculumDto2 = new CurriculumDTO();
   private final TrainingNumber trainingNumber = new TrainingNumber();
   private final TrainingNumberDTO trainingNumberDto = new TrainingNumberDTO();
-  private ProgrammeMembershipDTO programmeMembershipDto1 = new ProgrammeMembershipDTO();
   private final Programme programme = new Programme();
   private final PersonDTO personDto = new PersonDTO();
   private final Person person = new Person();
+  private ProgrammeMembershipDTO programmeMembershipDto1 = new ProgrammeMembershipDTO();
   private ProgrammeMembershipServiceImpl testObj;
   private ProgrammeMembershipMapper programmeMembershipMapper;
   private CurriculumMembershipMapper curriculumMembershipMapper;
@@ -108,9 +107,10 @@ public class ProgrammeMembershipServiceImplTest {
     CurriculumMapper curriculumMapper = new CurriculumMapperImpl();
     ReflectionTestUtils.setField(curriculumMapper, "specialtyMapper",
         new SpecialtyMapperImpl());
-    testObj = new ProgrammeMembershipServiceImpl(programmeMembershipRepositoryMock, curriculumMembershipRepositoryMock,
-        programmeMembershipMapper, curriculumMembershipMapper, curriculumRepositoryMock, curriculumMapper,
-        applicationEventPublisherMock, personRepositoryMock);
+    testObj = new ProgrammeMembershipServiceImpl(programmeMembershipRepositoryMock,
+        curriculumMembershipRepositoryMock, programmeMembershipMapper, curriculumMembershipMapper,
+        curriculumRepositoryMock, curriculumMapper, applicationEventPublisherMock,
+        personRepositoryMock);
 
     initialiseData();
   }
@@ -141,7 +141,8 @@ public class ProgrammeMembershipServiceImplTest {
     programmeMembership1.setProgrammeEndDate(PROGRAMME_END_DATE);
     programmeMembership1.setPerson(person);
     programmeMembership1.setTrainingNumber(trainingNumber);
-    programmeMembership1.setCurriculumMemberships(Sets.newLinkedHashSet(curriculumMembership1, curriculumMembership2));
+    programmeMembership1.setCurriculumMemberships(
+        Sets.newLinkedHashSet(curriculumMembership1, curriculumMembership2));
 
     trainingNumberDto.setId(TRAINEE_ID);
     trainingNumberDto.setTrainingNumber(TRAINEE_NUMBER);
@@ -294,7 +295,7 @@ public class ProgrammeMembershipServiceImplTest {
 
     Assert.assertNotNull(result);
     Assert.assertEquals(2, result.size());
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getProgrammeMembershipUuid());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getUuid());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, result.get(0).getId());
     ProgrammeMembershipCurriculaDTO programmeMembershipCurriculaDTO = result.get(0);
     Assert.assertEquals(PROGRAMME_NAME, programmeMembershipCurriculaDTO.getProgrammeName());
@@ -485,13 +486,13 @@ public class ProgrammeMembershipServiceImplTest {
     Assert.assertEquals(2, result.size());
 
     ProgrammeMembershipCurriculaDTO pmc1 = result.get(0);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc1.getProgrammeMembershipUuid());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc1.getUuid());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, pmc1.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc1.getProgrammeId().longValue());
     Assert.assertEquals(curriculum1.getId(), pmc1.getCurriculumDTO().getId());
 
     ProgrammeMembershipCurriculaDTO pmc2 = result.get(1);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getProgrammeMembershipUuid());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getUuid());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_2, pmc2.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc2.getProgrammeId().longValue());
     Assert.assertEquals(curriculum2.getId(), pmc2.getCurriculumDTO().getId());
@@ -515,7 +516,7 @@ public class ProgrammeMembershipServiceImplTest {
         .save(any());
     Assert.assertEquals(PROGRAMME_ID, programmeMembershipDTO.getProgrammeId().longValue());
     Assert.assertEquals(CURRICULUM_1_ID, programmeMembershipDTO.getCurriculumMemberships()
-            .get(0).getCurriculumId().longValue());
+        .get(0).getCurriculumId().longValue());
   }
 
   @Test

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -32,7 +32,6 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapperImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.SpecialtyMapperImpl;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
-import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipCurriculaDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
@@ -21,6 +20,7 @@ import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.Programme;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumRepository;
@@ -34,6 +34,8 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMap
 import com.transformuk.hee.tis.tcs.service.service.mapper.SpecialtyMapperImpl;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -59,24 +61,26 @@ public class ProgrammeMembershipServiceImplTest {
   private static final long TRAINEE_ID = 1L;
   private static final String TRAINEE_NUMBER = "XXX/XXX/XXX";
   private static final long CURRICULUM_1_ID = 5L;
-  private static final long CURRICULUM_2_ID = 6L;
   private static final long PROGRAMME_ID = 2L;
-  private static final Long PROGRAMME_MEMBERSHIP_ID_1 = 7777L;
-  private static final Long PROGRAMME_MEMBERSHIP_ID_2 = 8888L;
+  private static final ProgrammeMembershipType PROGRAMME_MEMBERSHIP_TYPE = ProgrammeMembershipType.SUBSTANTIVE;
+  private static final Long PROGRAMME_MEMBERSHIP_ID_1 = 11L;
+  private static final Long PROGRAMME_MEMBERSHIP_ID_2 = 22L;
+  private static final Long CURRICULUM_MEMBERSHIP_ID_1 = 7777L;
+  private static final Long CURRICULUM_MEMBERSHIP_ID_2 = 8888L;
+  private static final LocalDate PROGRAMME_START_DATE = LocalDate.of(2020, 1, 1);
+  private static final LocalDate PROGRAMME_END_DATE = LocalDate.of(2022, 1, 1);
   private static final String PROGRAMME_NUMBER1 = "Programme number";
   private static final String PROGRAMME_NAME = "Programme Name";
   private final CurriculumMembership curriculumMembership1 = new CurriculumMembership();
   private final CurriculumMembership curriculumMembership2 = new CurriculumMembership();
-  private final ProgrammeMembershipDTO programmeMembershipDto1 = new ProgrammeMembershipDTO();
-  private final ProgrammeMembershipDTO programmeMembershipDto2 = new ProgrammeMembershipDTO();
+  private final ProgrammeMembership programmeMembership1 = new ProgrammeMembership();
   private final Curriculum curriculum1 = new Curriculum();
   private final Curriculum curriculum2 = new Curriculum();
   private final CurriculumDTO curriculumDto1 = new CurriculumDTO();
   private final CurriculumDTO curriculumDto2 = new CurriculumDTO();
   private final TrainingNumber trainingNumber = new TrainingNumber();
   private final TrainingNumberDTO trainingNumberDto = new TrainingNumberDTO();
-  private final CurriculumMembershipDTO curriculumMembershipDto1 = new CurriculumMembershipDTO();
-  private final CurriculumMembershipDTO curriculumMembershipDto2 = new CurriculumMembershipDTO();
+  private ProgrammeMembershipDTO programmeMembershipDto1 = new ProgrammeMembershipDTO();
   private final Programme programme = new Programme();
   private final PersonDTO personDto = new PersonDTO();
   private final Person person = new Person();
@@ -111,6 +115,9 @@ public class ProgrammeMembershipServiceImplTest {
   }
 
   private void initialiseData() {
+    person.setId(1L);
+    person.setCurriculumMemberships(Sets.newHashSet());
+
     trainingNumber.setId(TRAINEE_ID);
     trainingNumber.setTrainingNumber(TRAINEE_NUMBER);
 
@@ -118,40 +125,31 @@ public class ProgrammeMembershipServiceImplTest {
     programme.setProgrammeNumber(PROGRAMME_NUMBER1);
     programme.setProgrammeName(PROGRAMME_NAME);
 
-    curriculumMembership1.setId(PROGRAMME_MEMBERSHIP_ID_1);
-    curriculumMembership1.setProgramme(programme);
-    curriculumMembership1.setTrainingNumber(trainingNumber);
+    curriculumMembership1.setId(CURRICULUM_MEMBERSHIP_ID_1);
     curriculumMembership1.setCurriculumId(5L);
-    curriculumMembership1.setPerson(person);
+    curriculumMembership1.setProgrammeMembership(programmeMembership1);
 
-    curriculumMembership2.setId(PROGRAMME_MEMBERSHIP_ID_2);
-    curriculumMembership2.setProgramme(programme);
-    curriculumMembership2.setTrainingNumber(trainingNumber);
+    curriculumMembership2.setId(CURRICULUM_MEMBERSHIP_ID_2);
     curriculumMembership2.setCurriculumId(6L);
-    curriculumMembership2.setPerson(person);
+    curriculumMembership2.setProgrammeMembership(programmeMembership1);
+
+    programmeMembership1.setId(PROGRAMME_MEMBERSHIP_ID_1);
+    programmeMembership1.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
+    programmeMembership1.setProgramme(programme);
+    programmeMembership1.setProgrammeStartDate(PROGRAMME_START_DATE);
+    programmeMembership1.setProgrammeEndDate(PROGRAMME_END_DATE);
+    programmeMembership1.setPerson(person);
+    programmeMembership1.setTrainingNumber(trainingNumber);
+    programmeMembership1.setCurriculumMemberships(Sets.newLinkedHashSet(curriculumMembership1, curriculumMembership2));
 
     trainingNumberDto.setId(TRAINEE_ID);
     trainingNumberDto.setTrainingNumber(TRAINEE_NUMBER);
-
-    curriculumMembershipDto1.setId(PROGRAMME_MEMBERSHIP_ID_1);
-    curriculumMembershipDto1.setCurriculumId(CURRICULUM_1_ID);
-    curriculumMembershipDto2.setCurriculumId(CURRICULUM_2_ID);
 
     personDto.setId(1L);
     personDto.setStatus(Status.INACTIVE);
     personDto.setProgrammeMemberships(Sets.newHashSet());
 
-    person.setId(1L);
-    person.setCurriculumMemberships(Sets.newHashSet());
-
-    programmeMembershipDto1.setProgrammeId(PROGRAMME_ID);
-    programmeMembershipDto1.setTrainingNumber(trainingNumberDto);
-    programmeMembershipDto1.setCurriculumMemberships(Lists.newArrayList(curriculumMembershipDto1));
-    programmeMembershipDto1.setPerson(personDto);
-
-    programmeMembershipDto2.setProgrammeId(PROGRAMME_ID);
-    programmeMembershipDto2.setTrainingNumber(trainingNumberDto);
-    programmeMembershipDto2.setCurriculumMemberships(Lists.newArrayList());
+    programmeMembershipDto1 = programmeMembershipMapper.toDto(programmeMembership1);
 
     curriculum1.setId(5L);
     curriculum1.setName("XXX");
@@ -272,9 +270,6 @@ public class ProgrammeMembershipServiceImplTest {
 
   @Test()
   public void findProgrammeMembershipsForTraineeShouldReturnEmptyListWhenNoResultsFound() {
-    List<CurriculumMembership> emptyCurriculumMembershipList = Lists.emptyList();
-    when(curriculumMembershipRepositoryMock.findByTraineeId(TRAINEE_ID))
-        .thenReturn(emptyCurriculumMembershipList);
 
     List<ProgrammeMembershipCurriculaDTO> result = testObj
         .findProgrammeMembershipsForTrainee(TRAINEE_ID);
@@ -288,21 +283,17 @@ public class ProgrammeMembershipServiceImplTest {
     List<CurriculumMembership> curriculumMemberships = Lists
         .newArrayList(curriculumMembership1, curriculumMembership2);
     List<Curriculum> foundCurricula = Lists.newArrayList(curriculum1, curriculum2);
-    Set<Long> curriculumIds = Sets.newLinkedHashSet(new Long(5L), new Long(6L));
+    Set<Long> curriculumIds = Sets.newLinkedHashSet(5L, 6L);
 
-    when(curriculumMembershipRepositoryMock.findByTraineeId(TRAINEE_ID))
-        .thenReturn(curriculumMemberships);
-    when(curriculumRepositoryMock.findAllById(curriculumIds)).thenReturn(foundCurricula);
-    when(programmeRepositoryMock.findByIdIn(Sets.newLinkedHashSet(PROGRAMME_ID)))
-        .thenReturn(Lists.newArrayList(programme));
+    when(programmeMembershipRepositoryMock.findByTraineeId(TRAINEE_ID))
+        .thenReturn(Collections.singletonList(programmeMembership1));
 
     List<ProgrammeMembershipCurriculaDTO> result = testObj
         .findProgrammeMembershipsForTrainee(TRAINEE_ID);
 
     Assert.assertNotNull(result);
-    Assert.assertEquals(2, result.size());
+    Assert.assertEquals(1, result.size());
     Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getId());
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_2, result.get(1).getId());
     ProgrammeMembershipCurriculaDTO programmeMembershipCurriculaDTO = result.get(0);
     Assert.assertEquals(PROGRAMME_NAME, programmeMembershipCurriculaDTO.getProgrammeName());
     Assert.assertEquals(PROGRAMME_NUMBER1, programmeMembershipCurriculaDTO.getProgrammeNumber());
@@ -321,46 +312,59 @@ public class ProgrammeMembershipServiceImplTest {
 
   @Test
   public void findProgrammeMembershipsForTraineeRolledUpShouldRollUpPMs() {
+    //TODO: vary no. of CMs per PM
     LocalDate dateFrom = LocalDate.of(1999, 12, 31);
     LocalDate dateTo = LocalDate.of(2000, 12, 31);
     LocalDate anotherDateFrom = LocalDate.of(2011, 12, 31);
     LocalDate anotherDateTo = LocalDate.of(2015, 12, 31);
 
+    ProgrammeMembership pm1 = new ProgrammeMembership();
+    ProgrammeMembership pm2 = new ProgrammeMembership();
+    ProgrammeMembership pm3 = new ProgrammeMembership();
+
+    pm1.setProgramme(programme);
+    pm1.setProgrammeStartDate(dateFrom);
+    pm1.setProgrammeEndDate(dateTo);
+    pm1.setProgrammeMembershipType(ProgrammeMembershipType.FTSTA);
+
+    pm2.setProgramme(programme);
+    pm2.setProgrammeStartDate(dateFrom);
+    pm2.setProgrammeEndDate(dateTo);
+    pm2.setProgrammeMembershipType(ProgrammeMembershipType.FTSTA);
+
+    pm3.setProgramme(programme);
+    pm3.setProgrammeStartDate(anotherDateFrom);
+    pm3.setProgrammeEndDate(anotherDateTo);
+    pm3.setProgrammeMembershipType(ProgrammeMembershipType.ACADEMIC);
+
     CurriculumMembership cm1 = new CurriculumMembership();
     CurriculumMembership cm2 = new CurriculumMembership();
     CurriculumMembership cm3 = new CurriculumMembership();
 
-    cm1.setProgramme(programme);
-    cm1.setProgrammeStartDate(dateFrom);
-    cm1.setProgrammeEndDate(dateTo);
     cm1.setCurriculumId(curriculum1.getId());
     cm1.setCurriculumStartDate(dateFrom);
     cm1.setCurriculumEndDate(dateTo);
-    cm1.setProgrammeMembershipType(ProgrammeMembershipType.FTSTA);
+    cm1.setProgrammeMembership(pm1);
 
-    cm2.setProgramme(programme);
-    cm2.setProgrammeStartDate(dateFrom);
-    cm2.setProgrammeEndDate(dateTo);
     cm2.setCurriculumId(curriculum1.getId());
     cm2.setCurriculumStartDate(anotherDateFrom);
     cm2.setCurriculumEndDate(anotherDateTo);
-    cm2.setProgrammeMembershipType(ProgrammeMembershipType.FTSTA);
+    cm2.setProgrammeMembership(pm2);
 
-    cm3.setProgramme(programme);
-    cm3.setProgrammeStartDate(anotherDateFrom);
-    cm3.setProgrammeEndDate(anotherDateTo);
     cm3.setCurriculumId(curriculum2.getId());
     cm3.setCurriculumStartDate(anotherDateFrom);
     cm3.setCurriculumEndDate(anotherDateTo);
-    cm3.setProgrammeMembershipType(ProgrammeMembershipType.ACADEMIC);
+    cm3.setProgrammeMembership(pm3);
 
-    when(curriculumMembershipRepositoryMock.findByTraineeId(TRAINEE_ID))
-        .thenReturn(Lists.newArrayList(cm1, cm2, cm3));
-    Set<Long> curriculumIds = Sets.newLinkedHashSet(Long.valueOf(5L), Long.valueOf(6L));
+    pm1.setCurriculumMemberships(Sets.newLinkedHashSet(cm1));
+    pm2.setCurriculumMemberships(Sets.newLinkedHashSet(cm2));
+    pm3.setCurriculumMemberships(Sets.newLinkedHashSet(cm3));
+
+    when(programmeMembershipRepositoryMock.findByTraineeId(TRAINEE_ID))
+        .thenReturn(Lists.newArrayList(pm1, pm2, pm3));
+    Set<Long> curriculumIds = Sets.newLinkedHashSet(5L, 6L);
     when(curriculumRepositoryMock.findAllById(curriculumIds))
         .thenReturn(Lists.newArrayList(curriculum1, curriculum2));
-    when(programmeRepositoryMock.findByIdIn(Sets.newLinkedHashSet(PROGRAMME_ID)))
-        .thenReturn(Lists.newArrayList(programme));
 
     List<ProgrammeMembershipCurriculaDTO> result = testObj
         .findProgrammeMembershipsForTraineeRolledUp(TRAINEE_ID);
@@ -383,6 +387,7 @@ public class ProgrammeMembershipServiceImplTest {
 
   @Test
   public void testProgrammeMembershipWithCertificateType() {
+    //TODO: vary no. of CMs per PM
     LocalDate pm1DateFrom = LocalDate.of(2019, 12, 31);
     LocalDate pm1DateTo = LocalDate.of(2020, 12, 31);
     LocalDate pm2DateFrom = LocalDate.of(2011, 12, 31);
@@ -394,40 +399,52 @@ public class ProgrammeMembershipServiceImplTest {
     CurriculumMembership cm2 = new CurriculumMembership();
     CurriculumMembership cm3 = new CurriculumMembership();
 
-    cm1.setProgramme(programme);
-    cm1.setProgrammeStartDate(pm1DateFrom);
-    cm1.setProgrammeEndDate(pm1DateTo);
+    ProgrammeMembership pm1 = new ProgrammeMembership();
+    ProgrammeMembership pm2 = new ProgrammeMembership();
+    ProgrammeMembership pm3 = new ProgrammeMembership();
+
+    pm1.setProgramme(programme);
+    pm1.setProgrammeStartDate(pm1DateFrom);
+    pm1.setProgrammeEndDate(pm1DateTo);
+    pm1.setProgrammeMembershipType(ProgrammeMembershipType.FTSTA);
+    pm1.setTrainingPathway("CCT");
+
+    pm2.setProgramme(programme);
+    pm2.setProgrammeStartDate(pm2DateFrom);
+    pm2.setProgrammeEndDate(pm2DateTo);
+    pm2.setProgrammeMembershipType(ProgrammeMembershipType.SUBSTANTIVE);
+    pm2.setTrainingPathway("CESR");
+
+    pm3.setProgramme(programme);
+    pm3.setProgrammeStartDate(pm3DateFrom);
+    pm3.setProgrammeEndDate(pm3DateTo);
+    pm3.setProgrammeMembershipType(ProgrammeMembershipType.ACADEMIC);
+    pm3.setTrainingPathway("CESR");
+
     cm1.setCurriculumId(curriculum1.getId());
     cm1.setCurriculumStartDate(pm1DateFrom);
     cm1.setCurriculumEndDate(pm1DateTo);
-    cm1.setProgrammeMembershipType(ProgrammeMembershipType.FTSTA);
-    cm1.setTrainingPathway("CCT");
+    cm1.setProgrammeMembership(pm1);
 
-    cm2.setProgramme(programme);
-    cm2.setProgrammeStartDate(pm2DateFrom);
-    cm2.setProgrammeEndDate(pm2DateTo);
     cm2.setCurriculumId(curriculum1.getId());
     cm2.setCurriculumStartDate(pm2DateFrom);
     cm2.setCurriculumEndDate(pm2DateTo);
-    cm2.setProgrammeMembershipType(ProgrammeMembershipType.SUBSTANTIVE);
-    cm2.setTrainingPathway("CESR");
+    cm2.setProgrammeMembership(pm2);
 
-    cm3.setProgramme(programme);
-    cm3.setProgrammeStartDate(pm3DateFrom);
-    cm3.setProgrammeEndDate(pm3DateTo);
     cm3.setCurriculumId(curriculum2.getId());
     cm3.setCurriculumStartDate(pm3DateFrom);
     cm3.setCurriculumEndDate(pm3DateTo);
-    cm3.setProgrammeMembershipType(ProgrammeMembershipType.ACADEMIC);
-    cm3.setTrainingPathway("CESR");
+    cm3.setProgrammeMembership(pm3);
 
-    when(curriculumMembershipRepositoryMock.findByTraineeId(TRAINEE_ID)).thenReturn(
-        Lists.newArrayList(cm1, cm2, cm3));
-    Set<Long> curriculumIds = Sets.newLinkedHashSet(Long.valueOf(5L), Long.valueOf(6L));
+    pm1.setCurriculumMemberships(Sets.newLinkedHashSet(cm1));
+    pm2.setCurriculumMemberships(Sets.newLinkedHashSet(cm2));
+    pm3.setCurriculumMemberships(Sets.newLinkedHashSet(cm3));
+
+    when(programmeMembershipRepositoryMock.findByTraineeId(TRAINEE_ID)).thenReturn(
+        Lists.newArrayList(pm1, pm2, pm3));
+    Set<Long> curriculumIds = Sets.newLinkedHashSet(5L, 6L);
     when(curriculumRepositoryMock.findAllById(curriculumIds)).thenReturn(
         Lists.newArrayList(curriculum1, curriculum2));
-    when(programmeRepositoryMock.findByIdIn(Sets.newLinkedHashSet(PROGRAMME_ID)))
-        .thenReturn(Lists.newArrayList(programme));
 
     List<ProgrammeMembershipCurriculaDTO> result = testObj
         .findProgrammeMembershipsForTraineeRolledUp(TRAINEE_ID);
@@ -471,19 +488,21 @@ public class ProgrammeMembershipServiceImplTest {
     Assert.assertEquals(curriculum1.getId(), pmc1.getCurriculumDTO().getId());
 
     ProgrammeMembershipCurriculaDTO pmc2 = result.get(1);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_2, pmc2.getId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc2.getProgrammeId().longValue());
     Assert.assertEquals(curriculum2.getId(), pmc2.getCurriculumDTO().getId());
   }
 
   @Test
-  public void shouldSaveProgrammeMembershipDtoToCurriculumMembershipRepository() {
+  public void shouldSaveProgrammeMembershipDtoToRepository() {
     //given
     List<CurriculumMembership> curriculumMembershipList
-        = curriculumMembershipMapper.toEntity(programmeMembershipDto1);
+        = new ArrayList<>(programmeMembership1.getCurriculumMemberships());
 
     when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
         .thenReturn(curriculumMembershipList);
+    when(programmeMembershipRepositoryMock.save(any()))
+        .thenReturn(programmeMembership1);
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
 
     //when
@@ -498,13 +517,15 @@ public class ProgrammeMembershipServiceImplTest {
   }
 
   @Test
-  public void shouldSaveProgrammeMembershipDtoListToCurriculumMembershipRepository() {
+  public void shouldSaveProgrammeMembershipDtoListToRepositories() {
     //given
     List<CurriculumMembership> curriculumMembershipList
         = curriculumMembershipMapper.toEntity(programmeMembershipDto1);
 
     when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
         .thenReturn(curriculumMembershipList);
+    when(programmeMembershipRepositoryMock.save(any()))
+        .thenReturn(programmeMembership1);
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
 
     //when
@@ -512,6 +533,8 @@ public class ProgrammeMembershipServiceImplTest {
         testObj.save(Lists.newArrayList(programmeMembershipDto1));
 
     //then
+    verify(programmeMembershipRepositoryMock, times(1))
+        .save(any());
     verify(curriculumMembershipRepositoryMock, times(1))
         .saveAll(anyCollection());
     Assert.assertEquals(PROGRAMME_ID, programmeMembershipDTOList.get(0)
@@ -524,15 +547,17 @@ public class ProgrammeMembershipServiceImplTest {
   public void shouldDeleteFromCurriculumMembershipRepository() {
     //given
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
-    when(curriculumMembershipRepositoryMock.getOne(PROGRAMME_MEMBERSHIP_ID_1))
+    when(curriculumMembershipRepositoryMock.getOne(CURRICULUM_MEMBERSHIP_ID_1))
         .thenReturn(curriculumMembership1);
 
     //when
-    testObj.delete(PROGRAMME_MEMBERSHIP_ID_1);
+    testObj.delete(CURRICULUM_MEMBERSHIP_ID_1);
 
     //then
+    verify(programmeMembershipRepositoryMock, times(0))
+        .deleteById(anyLong());
     verify(curriculumMembershipRepositoryMock, times(1))
-        .deleteById(PROGRAMME_MEMBERSHIP_ID_1);
+        .deleteById(CURRICULUM_MEMBERSHIP_ID_1);
   }
 
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -110,7 +110,7 @@ public class ProgrammeMembershipServiceImplTest {
         new SpecialtyMapperImpl());
     testObj = new ProgrammeMembershipServiceImpl(programmeMembershipRepositoryMock, curriculumMembershipRepositoryMock,
         programmeMembershipMapper, curriculumMembershipMapper, curriculumRepositoryMock, curriculumMapper,
-        programmeRepositoryMock, applicationEventPublisherMock, personRepositoryMock);
+        applicationEventPublisherMock, personRepositoryMock);
 
     initialiseData();
   }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -115,7 +115,7 @@ public class ProgrammeMembershipServiceImplTest {
 
   private void initialiseData() {
     person.setId(1L);
-    person.setCurriculumMemberships(Sets.newHashSet());
+    person.setProgrammeMemberships(Sets.newHashSet());
 
     trainingNumber.setId(TRAINEE_ID);
     trainingNumber.setTrainingNumber(TRAINEE_NUMBER);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -499,8 +499,6 @@ public class ProgrammeMembershipServiceImplTest {
     List<CurriculumMembership> curriculumMembershipList
         = new ArrayList<>(programmeMembership1.getCurriculumMemberships());
 
-    when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(curriculumMembershipList);
     when(programmeMembershipRepositoryMock.save(any()))
         .thenReturn(programmeMembership1);
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
@@ -509,8 +507,8 @@ public class ProgrammeMembershipServiceImplTest {
     ProgrammeMembershipDTO programmeMembershipDTO = testObj.save(programmeMembershipDto1);
 
     //then
-    verify(curriculumMembershipRepositoryMock, times(1))
-        .saveAll(anyCollection());
+    verify(programmeMembershipRepositoryMock, times(1))
+        .save(any());
     Assert.assertEquals(PROGRAMME_ID, programmeMembershipDTO.getProgrammeId().longValue());
     Assert.assertEquals(CURRICULUM_1_ID, programmeMembershipDTO.getCurriculumMemberships()
             .get(0).getCurriculumId().longValue());
@@ -519,11 +517,6 @@ public class ProgrammeMembershipServiceImplTest {
   @Test
   public void shouldSaveProgrammeMembershipDtoListToRepositories() {
     //given
-    List<CurriculumMembership> curriculumMembershipList
-        = curriculumMembershipMapper.toEntity(programmeMembershipDto1);
-
-    when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(curriculumMembershipList);
     when(programmeMembershipRepositoryMock.save(any()))
         .thenReturn(programmeMembership1);
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
@@ -534,9 +527,7 @@ public class ProgrammeMembershipServiceImplTest {
 
     //then
     verify(programmeMembershipRepositoryMock, times(1))
-        .save(any());
-    verify(curriculumMembershipRepositoryMock, times(1))
-        .saveAll(anyCollection());
+        .save(any()); //only 1 call since only 1 element in list
     Assert.assertEquals(PROGRAMME_ID, programmeMembershipDTOList.get(0)
         .getProgrammeId().longValue());
     Assert.assertEquals(CURRICULUM_1_ID, programmeMembershipDTOList.get(0)

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -292,7 +292,8 @@ public class ProgrammeMembershipServiceImplTest {
 
     Assert.assertNotNull(result);
     Assert.assertEquals(1, result.size());
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getProgrammeMembershipId());
+    Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, result.get(0).getId());
     ProgrammeMembershipCurriculaDTO programmeMembershipCurriculaDTO = result.get(0);
     Assert.assertEquals(PROGRAMME_NAME, programmeMembershipCurriculaDTO.getProgrammeName());
     Assert.assertEquals(PROGRAMME_NUMBER1, programmeMembershipCurriculaDTO.getProgrammeNumber());
@@ -482,12 +483,14 @@ public class ProgrammeMembershipServiceImplTest {
     Assert.assertEquals(2, result.size());
 
     ProgrammeMembershipCurriculaDTO pmc1 = result.get(0);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc1.getId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc1.getProgrammeMembershipId());
+    Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, pmc1.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc1.getProgrammeId().longValue());
     Assert.assertEquals(curriculum1.getId(), pmc1.getCurriculumDTO().getId());
 
     ProgrammeMembershipCurriculaDTO pmc2 = result.get(1);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getProgrammeMembershipId());
+    Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_2, pmc2.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc2.getProgrammeId().longValue());
     Assert.assertEquals(curriculum2.getId(), pmc2.getCurriculumDTO().getId());
   }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -39,6 +39,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
@@ -62,8 +64,8 @@ public class ProgrammeMembershipServiceImplTest {
   private static final long CURRICULUM_1_ID = 5L;
   private static final long PROGRAMME_ID = 2L;
   private static final ProgrammeMembershipType PROGRAMME_MEMBERSHIP_TYPE = ProgrammeMembershipType.SUBSTANTIVE;
-  private static final Long PROGRAMME_MEMBERSHIP_ID_1 = 11L;
-  private static final Long PROGRAMME_MEMBERSHIP_ID_2 = 22L;
+  private static final UUID PROGRAMME_MEMBERSHIP_ID_1 = UUID.randomUUID();
+  private static final UUID PROGRAMME_MEMBERSHIP_ID_2 = UUID.randomUUID();
   private static final Long CURRICULUM_MEMBERSHIP_ID_1 = 7777L;
   private static final Long CURRICULUM_MEMBERSHIP_ID_2 = 8888L;
   private static final LocalDate PROGRAMME_START_DATE = LocalDate.of(2020, 1, 1);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -134,7 +134,7 @@ public class ProgrammeMembershipServiceImplTest {
     curriculumMembership2.setCurriculumId(6L);
     curriculumMembership2.setProgrammeMembership(programmeMembership1);
 
-    programmeMembership1.setId(PROGRAMME_MEMBERSHIP_ID_1);
+    programmeMembership1.setUuid(PROGRAMME_MEMBERSHIP_ID_1);
     programmeMembership1.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
     programmeMembership1.setProgramme(programme);
     programmeMembership1.setProgrammeStartDate(PROGRAMME_START_DATE);
@@ -294,7 +294,7 @@ public class ProgrammeMembershipServiceImplTest {
 
     Assert.assertNotNull(result);
     Assert.assertEquals(2, result.size());
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getProgrammeMembershipId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, result.get(0).getProgrammeMembershipUuid());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, result.get(0).getId());
     ProgrammeMembershipCurriculaDTO programmeMembershipCurriculaDTO = result.get(0);
     Assert.assertEquals(PROGRAMME_NAME, programmeMembershipCurriculaDTO.getProgrammeName());
@@ -485,13 +485,13 @@ public class ProgrammeMembershipServiceImplTest {
     Assert.assertEquals(2, result.size());
 
     ProgrammeMembershipCurriculaDTO pmc1 = result.get(0);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc1.getProgrammeMembershipId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc1.getProgrammeMembershipUuid());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_1, pmc1.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc1.getProgrammeId().longValue());
     Assert.assertEquals(curriculum1.getId(), pmc1.getCurriculumDTO().getId());
 
     ProgrammeMembershipCurriculaDTO pmc2 = result.get(1);
-    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getProgrammeMembershipId());
+    Assert.assertEquals(PROGRAMME_MEMBERSHIP_ID_1, pmc2.getProgrammeMembershipUuid());
     Assert.assertEquals(CURRICULUM_MEMBERSHIP_ID_2, pmc2.getId());
     Assert.assertEquals(PROGRAMME_ID, pmc2.getProgrammeId().longValue());
     Assert.assertEquals(curriculum2.getId(), pmc2.getCurriculumDTO().getId());

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -534,20 +534,26 @@ public class ProgrammeMembershipServiceImplTest {
   }
 
   @Test
-  public void shouldDeleteFromCurriculumMembershipRepository() {
+  public void shouldDeleteCurriculumMemberships() {
     //given
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
     when(curriculumMembershipRepositoryMock.getOne(CURRICULUM_MEMBERSHIP_ID_1))
         .thenReturn(curriculumMembership1);
+    when(curriculumMembershipRepositoryMock.getOne(CURRICULUM_MEMBERSHIP_ID_2))
+        .thenReturn(curriculumMembership2);
 
     //when
     testObj.delete(CURRICULUM_MEMBERSHIP_ID_1);
 
     //then
-    verify(programmeMembershipRepositoryMock, times(0))
-        .deleteById(anyLong());
-    verify(curriculumMembershipRepositoryMock, times(1))
-        .deleteById(CURRICULUM_MEMBERSHIP_ID_1);
+    verify(programmeMembershipRepositoryMock, times(1))
+        .save(any()); //since there were 2 CMs, so the PM is updated not deleted
+
+    testObj.delete(CURRICULUM_MEMBERSHIP_ID_2);
+
+    verify(programmeMembershipRepositoryMock, times(1))
+        .delete(any()); //since the last CM is deleted, so the PM is deleted too
+
   }
 
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -81,7 +81,10 @@ public class ProgrammeMembershipServiceImplTest {
   private final PersonDTO personDto = new PersonDTO();
   private final Person person = new Person();
   private ProgrammeMembershipServiceImpl testObj;
+  private ProgrammeMembershipMapper programmeMembershipMapper;
   private CurriculumMembershipMapper curriculumMembershipMapper;
+  @Mock
+  private ProgrammeMembershipRepository programmeMembershipRepositoryMock;
   @Mock
   private CurriculumMembershipRepository curriculumMembershipRepositoryMock;
   @Mock
@@ -96,12 +99,13 @@ public class ProgrammeMembershipServiceImplTest {
   @Before
   public void setup() {
     curriculumMembershipMapper = new CurriculumMembershipMapper();
+    programmeMembershipMapper = new ProgrammeMembershipMapper(curriculumMembershipMapper);
     CurriculumMapper curriculumMapper = new CurriculumMapperImpl();
     ReflectionTestUtils.setField(curriculumMapper, "specialtyMapper",
         new SpecialtyMapperImpl());
-    testObj = new ProgrammeMembershipServiceImpl(curriculumMembershipRepositoryMock, curriculumMembershipMapper,
-        curriculumRepositoryMock, curriculumMapper, programmeRepositoryMock,
-        applicationEventPublisherMock, personRepositoryMock);
+    testObj = new ProgrammeMembershipServiceImpl(programmeMembershipRepositoryMock, curriculumMembershipRepositoryMock,
+        programmeMembershipMapper, curriculumMembershipMapper, curriculumRepositoryMock, curriculumMapper,
+        programmeRepositoryMock, applicationEventPublisherMock, personRepositoryMock);
 
     initialiseData();
   }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -29,6 +29,7 @@ import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.GmcDetails;
 import com.transformuk.hee.tis.tcs.service.model.Placement;
 import com.transformuk.hee.tis.tcs.service.model.Programme;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.GmcDetailsRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
@@ -97,6 +98,7 @@ public class RevalidationServiceImplTest {
   List<Placement> currentPlacementsForTrainee;
   Map<String,Object> connectionMap;
   private CurriculumMembership curriculumMembership, curriculumMembership1;
+  private ProgrammeMembership programmeMembership, programmeMembership1;
   @Mock
   private ContactDetailsService contactDetailsService;
   @Mock
@@ -141,21 +143,31 @@ public class RevalidationServiceImplTest {
     gmcDetailsDTO.setId(PERSON_ID);
     gmcDetailsDTO.setGmcNumber(GMC_NUMBER);
 
-    curriculumMembership = new CurriculumMembership();
-    curriculumMembership.setProgrammeEndDate(CURRICULUM_END_DATE);
-    curriculumMembership.setCurriculumEndDate(CURRICULUM_END_DATE);
-    curriculumMembership.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
-    curriculumMembership1 = new CurriculumMembership();
-    curriculumMembership1.setProgrammeStartDate(PM_START_DATE);
-    curriculumMembership1.setProgrammeEndDate(PM_END_DATE);
-    curriculumMembership1.setCurriculumEndDate(PM_END_DATE);
-    curriculumMembership1.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
-
     Programme programme = new Programme();
     programme.setProgrammeName(PROGRAMME_NAME);
     programme.setOwner(PROGRAMME_OWNER);
-    curriculumMembership.setProgramme(programme);
-    curriculumMembership1.setProgramme(programme);
+
+    //TODO: maybe also test with a PM with multiple CMs
+
+    programmeMembership = new ProgrammeMembership();
+    programmeMembership.setProgrammeEndDate(CURRICULUM_END_DATE);
+    programmeMembership.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
+    programmeMembership.setProgramme(programme);
+
+    curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setCurriculumEndDate(CURRICULUM_END_DATE);
+    curriculumMembership.setProgrammeMembership(programmeMembership);
+
+    programmeMembership1 = new ProgrammeMembership();
+    programmeMembership1.setProgrammeStartDate(PM_START_DATE);
+    programmeMembership1.setProgrammeEndDate(PM_END_DATE);
+    programmeMembership1.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
+    programmeMembership1.setProgramme(programme);
+
+    curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setCurriculumEndDate(PM_END_DATE);
+    curriculumMembership1.setProgrammeMembership(programmeMembership1);
+
     Placement placement = new Placement();
     placement.setId(PLACEMENT_ID);
     placement.setGradeId(GRADE_ID);
@@ -290,7 +302,7 @@ public class RevalidationServiceImplTest {
   @Test
   public void connectionStatusMustBeNoIfProgrammeStartDateIsTodayOrOlder() {
     when(gmcDetailsRepositoryMock.findByGmcNumberIn(GMC_IDS)).thenReturn(gmcDetailList);
-    curriculumMembership1.setProgrammeStartDate(PM_START_DATE.plusDays(1));
+    programmeMembership1.setProgrammeStartDate(PM_START_DATE.plusDays(1));
     when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
         .thenReturn(curriculumMembership1);
     Map<String, ConnectionRecordDto> result = testObj.findAllConnectionsByGmcIds(GMC_IDS);
@@ -305,8 +317,8 @@ public class RevalidationServiceImplTest {
   @Test
   public void connectionStatusMustBeYesIfProgrammeStartDateIsTodayAndEndDateIsInFuture() {
     when(gmcDetailsRepositoryMock.findByGmcNumberIn(GMC_IDS)).thenReturn(gmcDetailList);
-    curriculumMembership1.setProgrammeStartDate(PM_START_DATE);
-    curriculumMembership1.setProgrammeEndDate(now().plusDays(1));
+    programmeMembership1.setProgrammeStartDate(PM_START_DATE);
+    programmeMembership1.setProgrammeEndDate(now().plusDays(1));
     when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
         .thenReturn(curriculumMembership1);
     Map<String, ConnectionRecordDto> result = testObj.findAllConnectionsByGmcIds(GMC_IDS);
@@ -322,8 +334,8 @@ public class RevalidationServiceImplTest {
     when(gmcDetailsRepositoryMock.findByGmcNumberIn(GMC_IDS)).thenReturn(gmcDetailList);
     final LocalDate programmeStartDate = PM_START_DATE.minusDays(1);
     final LocalDate programmeEndDate = now().plusDays(5);
-    curriculumMembership1.setProgrammeStartDate(programmeStartDate);
-    curriculumMembership1.setProgrammeEndDate(programmeEndDate);
+    programmeMembership1.setProgrammeStartDate(programmeStartDate);
+    programmeMembership1.setProgrammeEndDate(programmeEndDate);
     when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
         .thenReturn(curriculumMembership1);
     Map<String, ConnectionRecordDto> result = testObj.findAllConnectionsByGmcIds(GMC_IDS);
@@ -341,7 +353,7 @@ public class RevalidationServiceImplTest {
   public void connectionStatusShouldBeNoIfProgrammeStartDateNotExists() {
 
     when(gmcDetailsRepositoryMock.findByGmcNumberIn(GMC_IDS)).thenReturn(gmcDetailList);
-    curriculumMembership1.setProgrammeStartDate(null);
+    programmeMembership1.setProgrammeStartDate(null);
     when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
         .thenReturn(curriculumMembership1);
     Map<String, ConnectionRecordDto> result = testObj.findAllConnectionsByGmcIds(GMC_IDS);
@@ -358,7 +370,7 @@ public class RevalidationServiceImplTest {
   public void connectionStatusShouldBeNoIfProgrammeEndDateNotExists() {
 
     when(gmcDetailsRepositoryMock.findByGmcNumberIn(GMC_IDS)).thenReturn(gmcDetailList);
-    curriculumMembership1.setProgrammeEndDate(null);
+    programmeMembership1.setProgrammeEndDate(null);
     when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
         .thenReturn(curriculumMembership1);
     Map<String, ConnectionRecordDto> result = testObj.findAllConnectionsByGmcIds(GMC_IDS);
@@ -394,7 +406,7 @@ public class RevalidationServiceImplTest {
 
     when(gmcDetailsRepositoryMock.findByGmcNumberIn(GMC_IDS)).thenReturn(gmcDetailList);
     final LocalDate programmeEndDate = now().minusDays(1);
-    curriculumMembership1.setProgrammeEndDate(programmeEndDate);
+    programmeMembership1.setProgrammeEndDate(programmeEndDate);
     when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
         .thenReturn(curriculumMembership1);
     Map<String, ConnectionRecordDto> result = testObj.findAllConnectionsByGmcIds(GMC_IDS);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -6,6 +6,8 @@ import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
+
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
@@ -29,15 +31,17 @@ public class ProgrammeMembershipMapperTest {
 
   @Test
   public void entityToDtoShouldReturnListOfAllElementsInAsDto() {
+    UUID pmID = UUID.randomUUID();
+    UUID pm2ID = UUID.randomUUID();
     ProgrammeMembership pm1 = new ProgrammeMembership(), pm2 = new ProgrammeMembership();
     CurriculumMembership cm1 = new CurriculumMembership(), cm2 = new CurriculumMembership(),
         cm3 = new CurriculumMembership();
     ProgrammeMembershipDTO pmDTO = new ProgrammeMembershipDTO();
-    pmDTO.setProgrammeMembershipId(12345L);
+    pmDTO.setProgrammeMembershipId(pmID);
     pmDTO.setId(1L);
 
-    pm1.setId(12345L);
-    pm2.setId(99876L);
+    pm1.setId(pmID);
+    pm2.setId(pm2ID);
 
     cm1.setId(1L);
     cm2.setId(2L);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -50,20 +50,6 @@ public class ProgrammeMembershipMapperTest {
     pm1.setCurriculumMemberships(Sets.newLinkedHashSet(cm1));
     pm2.setCurriculumMemberships(Sets.newLinkedHashSet(cm2, cm3));
 
-    LocalDate programmeStartDate1 = LocalDate.now(), programmeStartDate2 = LocalDate.of(1999, 1, 1);
-    pm1.setProgrammeStartDate(programmeStartDate1);
-    pm2.setProgrammeStartDate(programmeStartDate1);
-
-    LocalDate programmeEndDate1 = LocalDate.now(), programmeEndDate2 = LocalDate.of(2000, 1, 1);
-    pm1.setProgrammeEndDate(programmeEndDate1);
-    pm2.setProgrammeEndDate(programmeEndDate1);
-
-    Person person1 = new Person();
-    person1.setId(1L);
-
-    pm1.setPerson(person1);
-    pm2.setPerson(person1);
-
     CurriculumMembershipDTO cmDTO1 = new CurriculumMembershipDTO();
     cmDTO1.setId(1L);
     CurriculumMembershipDTO cmDTO2 = new CurriculumMembershipDTO();
@@ -80,7 +66,7 @@ public class ProgrammeMembershipMapperTest {
     Assert.assertEquals(3, result.size()); //listed by curriculum membership
     ProgrammeMembershipDTO pmDTOreturned = result.get(0);
     Assert.assertNotNull(pmDTOreturned);
-    assertThat(cm1.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm1 is the first entity converted to a DTO
+    assertThat(cm1.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm ID is used as pm ID
     assertThat(pmID).isEqualTo(pmDTOreturned.getProgrammeMembershipId());
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -38,8 +38,8 @@ public class ProgrammeMembershipMapperTest {
     CurriculumMembership cm1 = new CurriculumMembership(), cm2 = new CurriculumMembership(),
         cm3 = new CurriculumMembership();
 
-    pm1.setId(pmID);
-    pm2.setId(pm2ID);
+    pm1.setUuid(pmID);
+    pm2.setUuid(pm2ID);
 
     cm1.setId(1L);
     cm2.setId(2L);
@@ -67,6 +67,6 @@ public class ProgrammeMembershipMapperTest {
     ProgrammeMembershipDTO pmDTOreturned = result.get(0);
     Assert.assertNotNull(pmDTOreturned);
     assertThat(cm1.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm ID is used as pm ID
-    assertThat(pmID).isEqualTo(pmDTOreturned.getProgrammeMembershipId());
+    assertThat(pmID).isEqualTo(pmDTOreturned.getProgrammeMembershipUuid());
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -39,10 +39,6 @@ public class ProgrammeMembershipMapperTest {
     pm2.setProgrammeEndDate(programmeEndDate1);
     pm3.setProgrammeEndDate(programmeEndDate2);
 
-    pm1.setCurriculumId(1L);
-    pm2.setCurriculumId(2L);
-    pm3.setCurriculumId(3L);
-
     Person person1 = new Person();
     person1.setId(1L);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -1,53 +1,75 @@
 package com.transformuk.hee.tis.tcs.service.service.mapper;
 
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
+import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import java.time.LocalDate;
 import java.util.List;
 import org.assertj.core.util.Lists;
+import org.assertj.core.util.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProgrammeMembershipMapperTest {
+
+  @Mock
+  CurriculumMembershipMapper curriculumMembershipMapperMock;
 
   @InjectMocks
   private ProgrammeMembershipMapper testObj;
 
   @Test
   public void entityToDtoShouldReturnListOfAllElementsInAsDto() {
-    //programme membership 1 and 2 are to have same programme data but different curricula
-    //the issue was that the equals method use programme fields to check for equality and the the mapper method used a map collection using
-    //the dto as the key (therefore not converting all of the entities when data is duplicated)
-    ProgrammeMembership pm1 = new ProgrammeMembership(), pm2 = new ProgrammeMembership(), pm3 = new ProgrammeMembership();
+    ProgrammeMembership pm1 = new ProgrammeMembership(), pm2 = new ProgrammeMembership();
+    CurriculumMembership cm1 = new CurriculumMembership(), cm2 = new CurriculumMembership(),
+        cm3 = new CurriculumMembership();
+    ProgrammeMembershipDTO pmDTO = new ProgrammeMembershipDTO();
+    pmDTO.setProgrammeMembershipId(12345L);
+    pmDTO.setId(1L);
 
     pm1.setId(12345L);
     pm2.setId(99876L);
-    pm3.setId(45667L);
+
+    cm1.setId(1L);
+    cm2.setId(2L);
+    cm3.setId(3L);
+    cm1.setProgrammeMembership(pm1);
+    cm2.setProgrammeMembership(pm2);
+    cm3.setProgrammeMembership(pm2);
+    pm1.setCurriculumMemberships(Sets.newLinkedHashSet(cm1));
+    pm2.setCurriculumMemberships(Sets.newLinkedHashSet(cm2, cm3));
 
     LocalDate programmeStartDate1 = LocalDate.now(), programmeStartDate2 = LocalDate.of(1999, 1, 1);
     pm1.setProgrammeStartDate(programmeStartDate1);
     pm2.setProgrammeStartDate(programmeStartDate1);
-    pm3.setProgrammeStartDate(programmeStartDate2);
 
     LocalDate programmeEndDate1 = LocalDate.now(), programmeEndDate2 = LocalDate.of(2000, 1, 1);
     pm1.setProgrammeEndDate(programmeEndDate1);
     pm2.setProgrammeEndDate(programmeEndDate1);
-    pm3.setProgrammeEndDate(programmeEndDate2);
 
     Person person1 = new Person();
     person1.setId(1L);
 
     pm1.setPerson(person1);
     pm2.setPerson(person1);
-    pm3.setPerson(person1);
 
-    List<ProgrammeMembershipDTO> result = testObj.allEntityToDto(Lists.newArrayList(pm1, pm2, pm3));
+    when(curriculumMembershipMapperMock.toDto(cm1)).thenReturn(pmDTO);
 
-    Assert.assertEquals(3, result.size());
+    List<ProgrammeMembershipDTO> result = testObj.allEntityToDto(Lists.newArrayList(pm1, pm2));
+
+    Assert.assertEquals(3, result.size()); //listed by curriculum membership
+    ProgrammeMembershipDTO pmDTOreturned = result.get(0);
+    Assert.assertNotNull(pmDTOreturned);
+    assertThat(pmDTO.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm1 is the first entity converted to a DTO
+    assertThat(pmDTO.getProgrammeMembershipId()).isEqualTo(pmDTOreturned.getProgrammeMembershipId());
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.tcs.service.service.mapper;
 
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
@@ -36,9 +37,6 @@ public class ProgrammeMembershipMapperTest {
     ProgrammeMembership pm1 = new ProgrammeMembership(), pm2 = new ProgrammeMembership();
     CurriculumMembership cm1 = new CurriculumMembership(), cm2 = new CurriculumMembership(),
         cm3 = new CurriculumMembership();
-    ProgrammeMembershipDTO pmDTO = new ProgrammeMembershipDTO();
-    pmDTO.setProgrammeMembershipId(pmID);
-    pmDTO.setId(1L);
 
     pm1.setId(pmID);
     pm2.setId(pm2ID);
@@ -66,14 +64,23 @@ public class ProgrammeMembershipMapperTest {
     pm1.setPerson(person1);
     pm2.setPerson(person1);
 
-    when(curriculumMembershipMapperMock.toDto(cm1)).thenReturn(pmDTO);
+    CurriculumMembershipDTO cmDTO1 = new CurriculumMembershipDTO();
+    cmDTO1.setId(1L);
+    CurriculumMembershipDTO cmDTO2 = new CurriculumMembershipDTO();
+    cmDTO2.setId(2L);
+    CurriculumMembershipDTO cmDTO3 = new CurriculumMembershipDTO();
+    cmDTO3.setId(3L);
+
+    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm1)).thenReturn(cmDTO1);
+    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm2)).thenReturn(cmDTO2);
+    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm3)).thenReturn(cmDTO3);
 
     List<ProgrammeMembershipDTO> result = testObj.allEntityToDto(Lists.newArrayList(pm1, pm2));
 
     Assert.assertEquals(3, result.size()); //listed by curriculum membership
     ProgrammeMembershipDTO pmDTOreturned = result.get(0);
     Assert.assertNotNull(pmDTOreturned);
-    assertThat(pmDTO.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm1 is the first entity converted to a DTO
-    assertThat(pmDTO.getProgrammeMembershipId()).isEqualTo(pmDTOreturned.getProgrammeMembershipId());
+    assertThat(cm1.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm1 is the first entity converted to a DTO
+    assertThat(pmID).isEqualTo(pmDTOreturned.getProgrammeMembershipId());
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -1,14 +1,14 @@
 package com.transformuk.hee.tis.tcs.service.service.mapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
-import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
-
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
@@ -16,10 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProgrammeMembershipMapperTest {
@@ -57,9 +54,12 @@ public class ProgrammeMembershipMapperTest {
     CurriculumMembershipDTO cmDTO3 = new CurriculumMembershipDTO();
     cmDTO3.setId(3L);
 
-    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm1)).thenReturn(cmDTO1);
-    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm2)).thenReturn(cmDTO2);
-    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm3)).thenReturn(cmDTO3);
+    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm1))
+        .thenReturn(cmDTO1);
+    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm2))
+        .thenReturn(cmDTO2);
+    when(curriculumMembershipMapperMock.curriculumMembershipToCurriculumMembershipDto(cm3))
+        .thenReturn(cmDTO3);
 
     List<ProgrammeMembershipDTO> result = testObj.allEntityToDto(Lists.newArrayList(pm1, pm2));
 
@@ -67,6 +67,6 @@ public class ProgrammeMembershipMapperTest {
     ProgrammeMembershipDTO pmDTOreturned = result.get(0);
     Assert.assertNotNull(pmDTOreturned);
     assertThat(cm1.getId()).isEqualTo(pmDTOreturned.getId()); //check that cm ID is used as pm ID
-    assertThat(pmID).isEqualTo(pmDTOreturned.getProgrammeMembershipUuid());
+    assertThat(pmID).isEqualTo(pmDTOreturned.getUuid());
   }
 }

--- a/tcs-service/src/test/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
+++ b/tcs-service/src/test/resources/db/migration/schema/V4.21__refactor_programmeMembership.sql
@@ -1,0 +1,1 @@
+/* For testing keep this blank */


### PR DESCRIPTION
Final fields for new ProgrammeMembership table must be confirmed. In particular, periodOfGrace is inconsistent in 2 records using the current script.

The definition of the ProgrammeMembership table was based on https://hee-tis.atlassian.net/browse/TIS21-2372 and https://hee-tis.atlassian.net/browse/TIS21-2381

This PR will remain draft until the associated code changes for the new programme membership table structure are made as well (mainly just decoupling the parallel programme membership - curriculum membership record saves).

Depends on: https://github.com/Health-Education-England/TIS-TCS/pull/861

TIS21-2421: Rebuild ProgrammeMembership table & populate the actual data