### PR TITLE
feat: stop parallel data writes to PM table

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.24.3</version>
+  <version>6.25.0</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -20,7 +20,6 @@ import com.transformuk.hee.tis.tcs.service.repository.ProgrammeRepository;
 import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
-import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +56,19 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   private final ApplicationEventPublisher applicationEventPublisher;
   private final PersonRepository personRepository;
 
-  public ProgrammeMembershipServiceImpl(CurriculumMembershipRepository curriculumMembershipRepository,
+  /**
+   * Initialise the ProgrammeMembershipService.
+   *
+   * @param curriculumMembershipRepository  the CurriculumMembershipRepository
+   * @param curriculumMembershipMapper      the CurriculumMembershipMapper
+   * @param curriculumRepository            the CurriculumRepository
+   * @param curriculumMapper                the CurriculumMapper
+   * @param programmeRepository             the ProgrammeRepository
+   * @param applicationEventPublisher       the ApplicationEventPublisher
+   * @param personRepository                the PersonRepository
+   */
+  public ProgrammeMembershipServiceImpl(
+      CurriculumMembershipRepository curriculumMembershipRepository,
       CurriculumMembershipMapper curriculumMembershipMapper,
       CurriculumRepository curriculumRepository, CurriculumMapper curriculumMapper,
       ProgrammeRepository programmeRepository, ApplicationEventPublisher applicationEventPublisher,

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -16,7 +16,6 @@ import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
-import com.transformuk.hee.tis.tcs.service.repository.ProgrammeMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.ProgrammeRepository;
 import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapper;
@@ -50,9 +49,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
 
   private final Logger log = LoggerFactory.getLogger(ProgrammeMembershipServiceImpl.class);
 
-  private final ProgrammeMembershipRepository programmeMembershipRepository;
   private final CurriculumMembershipRepository curriculumMembershipRepository;
-  private final ProgrammeMembershipMapper programmeMembershipMapper;
   private final CurriculumMembershipMapper curriculumMembershipMapper;
   private final CurriculumRepository curriculumRepository;
   private final CurriculumMapper curriculumMapper;
@@ -60,16 +57,12 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   private final ApplicationEventPublisher applicationEventPublisher;
   private final PersonRepository personRepository;
 
-  public ProgrammeMembershipServiceImpl(ProgrammeMembershipRepository programmeMembershipRepository,
-      CurriculumMembershipRepository curriculumMembershipRepository,
-      ProgrammeMembershipMapper programmeMembershipMapper,
+  public ProgrammeMembershipServiceImpl(CurriculumMembershipRepository curriculumMembershipRepository,
       CurriculumMembershipMapper curriculumMembershipMapper,
       CurriculumRepository curriculumRepository, CurriculumMapper curriculumMapper,
       ProgrammeRepository programmeRepository, ApplicationEventPublisher applicationEventPublisher,
       PersonRepository personRepository) {
-    this.programmeMembershipRepository = programmeMembershipRepository;
     this.curriculumMembershipRepository = curriculumMembershipRepository;
-    this.programmeMembershipMapper = programmeMembershipMapper;
     this.curriculumMembershipMapper = curriculumMembershipMapper;
     this.curriculumRepository = curriculumRepository;
     this.curriculumMapper = curriculumMapper;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -40,7 +40,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import javax.persistence.EntityManager;
 import org.junit.Before;
 import org.junit.Test;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -40,6 +40,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.EntityManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -337,7 +338,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void createProgrammeMembership() throws Exception {
+  public void createProgrammeMembershipDoesNotWriteToProgrammeMembershipRepository() throws Exception {
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
     programme.setCurricula(Collections.singleton(programmeCurriculum));
@@ -345,6 +346,7 @@ public class ProgrammeMembershipResourceIntTest {
     rotation.setProgrammeId(programme.getId());
     rotationRepository.saveAndFlush(rotation);
     int databasePmSizeBeforeCreate = programmeMembershipRepository.findAll().size();
+    int databaseCmSizeBeforeCreate = curriculumMembershipRepository.findAll().size();
 
     programmeMembership.setPerson(person);
     programmeMembership.setProgramme(programme);
@@ -359,29 +361,11 @@ public class ProgrammeMembershipResourceIntTest {
             .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isCreated());
 
-    // Validate the ProgrammeMembership in the database
+    // Validate the ProgrammeMembershipRepository has NOT changed (it is actually saved as CurriculumMembership)
     List<ProgrammeMembership> programmeMembershipList = programmeMembershipRepository.findAll();
-    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeCreate + 1);
-    ProgrammeMembership testProgrammeMembership = programmeMembershipList
-        .get(programmeMembershipList.size() - 1);
-    assertThat(testProgrammeMembership.getIntrepidId()).isEqualTo(DEFAULT_INTREPID_ID);
-    assertThat(testProgrammeMembership.getProgrammeMembershipType())
-        .isEqualTo(DEFAULT_PROGRAMME_MEMBERSHIP_TYPE);
-    assertThat(testProgrammeMembership.getRotation()).isEqualTo(rotation);
-    assertThat(testProgrammeMembership.getCurriculumStartDate())
-        .isEqualTo(DEFAULT_CURRICULUM_START_DATE);
-    assertThat(testProgrammeMembership.getCurriculumEndDate())
-        .isEqualTo(DEFAULT_CURRICULUM_END_DATE);
-    assertThat(testProgrammeMembership.getPeriodOfGrace()).isEqualTo(DEFAULT_PERIOD_OF_GRACE);
-    assertThat(testProgrammeMembership.getProgrammeStartDate())
-        .isEqualTo(DEFAULT_PROGRAMME_START_DATE);
-    assertThat(testProgrammeMembership.getCurriculumCompletionDate())
-        .isEqualTo(DEFAULT_CURRICULUM_COMPLETION_DATE);
-    assertThat(testProgrammeMembership.getProgrammeEndDate()).isEqualTo(DEFAULT_PROGRAMME_END_DATE);
-    assertThat(testProgrammeMembership.getLeavingDestination())
-        .isEqualTo(DEFAULT_LEAVING_DESTINATION);
-    assertThat(testProgrammeMembership.getLeavingReason()).isEqualTo(DEFAULT_LEAVING_REASON);
-    assertThat(person.getStatus()).isEqualTo(Status.INACTIVE);
+    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeCreate);
+    List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
+    assertThat(curriculumMembershipList).hasSize(databaseCmSizeBeforeCreate+1);
   }
 
   @Test
@@ -727,7 +711,7 @@ public class ProgrammeMembershipResourceIntTest {
 
   @Test
   @Transactional
-  public void updateProgrammeMembership() throws Exception {
+  public void updateProgrammeMembershipShouldNotUpdateProgrammeMembershipRepository() throws Exception {
     // Initialize the database
     personRepository.saveAndFlush(person);
     curriculumRepository.saveAndFlush(curriculum);
@@ -739,56 +723,34 @@ public class ProgrammeMembershipResourceIntTest {
     programmeMembership.setProgramme(programme);
     programmeMembership
         .setCurriculumId(programme.getCurricula().iterator().next().getCurriculum().getId());
+
+    // Get a copy of the programmeMembership and update it
     programmeMembershipRepository.saveAndFlush(programmeMembership);
-
-    int databaseSizeBeforeUpdate = programmeMembershipRepository.findAll().size();
-
-    // Update the programmeMembership
     ProgrammeMembership updatedProgrammeMembership = programmeMembershipRepository
         .findById(programmeMembership.getId()).orElse(null);
-    updatedProgrammeMembership
-        .intrepidId(UPDATED_INTREPID_ID)
-        .programmeMembershipType(UPDATED_PROGRAMME_MEMBERSHIP_TYPE)
-        .rotation(rotation)
-        .curriculumStartDate(UPDATED_CURRICULUM_START_DATE)
-        .curriculumEndDate(UPDATED_CURRICULUM_END_DATE)
-        .periodOfGrace(UPDATED_PERIOD_OF_GRACE)
-        .programmeStartDate(UPDATED_PROGRAMME_START_DATE)
-        .curriculumCompletionDate(UPDATED_CURRICULUM_COMPLETION_DATE)
-        .programmeEndDate(UPDATED_PROGRAMME_END_DATE)
-        .leavingDestination(UPDATED_LEAVING_DESTINATION)
-        .leavingReason(UPDATED_LEAVING_REASON);
+    updatedProgrammeMembership.setIntrepidId(UPDATED_INTREPID_ID);
+    updatedProgrammeMembership.setLeavingReason(UPDATED_LEAVING_REASON);
     ProgrammeMembershipDTO programmeMembershipDTO = programmeMembershipMapper
         .toDto(updatedProgrammeMembership);
 
+    programmeMembership.setIntrepidId(DEFAULT_INTREPID_ID);
+    programmeMembership.setLeavingReason(DEFAULT_LEAVING_REASON);
+    programmeMembershipRepository.saveAndFlush(programmeMembership);
+    int databaseSizeBeforeUpdate = programmeMembershipRepository.findAll().size();
+
+    //this will update the curriculum membership repository, not the programme membership repository
     restProgrammeMembershipMockMvc.perform(put("/api/programme-memberships")
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(programmeMembershipDTO)))
         .andExpect(status().isOk());
 
-    // Validate the ProgrammeMembership in the database
+    // Validate that the original ProgrammeMembership in the repository is unchanged
     List<ProgrammeMembership> programmeMembershipList = programmeMembershipRepository.findAll();
     assertThat(programmeMembershipList).hasSize(databaseSizeBeforeUpdate);
     ProgrammeMembership testProgrammeMembership = programmeMembershipList
         .get(programmeMembershipList.size() - 1);
-    assertThat(testProgrammeMembership.getIntrepidId()).isEqualTo(UPDATED_INTREPID_ID);
-    assertThat(testProgrammeMembership.getProgrammeMembershipType())
-        .isEqualTo(UPDATED_PROGRAMME_MEMBERSHIP_TYPE);
-    assertThat(testProgrammeMembership.getRotation()).isEqualTo(rotation);
-    assertThat(testProgrammeMembership.getCurriculumStartDate())
-        .isEqualTo(UPDATED_CURRICULUM_START_DATE);
-    assertThat(testProgrammeMembership.getCurriculumEndDate())
-        .isEqualTo(UPDATED_CURRICULUM_END_DATE);
-    assertThat(testProgrammeMembership.getPeriodOfGrace()).isEqualTo(UPDATED_PERIOD_OF_GRACE);
-    assertThat(testProgrammeMembership.getProgrammeStartDate())
-        .isEqualTo(UPDATED_PROGRAMME_START_DATE);
-    assertThat(testProgrammeMembership.getCurriculumCompletionDate())
-        .isEqualTo(UPDATED_CURRICULUM_COMPLETION_DATE);
-    assertThat(testProgrammeMembership.getProgrammeEndDate()).isEqualTo(UPDATED_PROGRAMME_END_DATE);
-    assertThat(testProgrammeMembership.getLeavingDestination())
-        .isEqualTo(UPDATED_LEAVING_DESTINATION);
-    assertThat(testProgrammeMembership.getLeavingReason()).isEqualTo(UPDATED_LEAVING_REASON);
-    assertThat(testProgrammeMembership.getAmendedDate()).isAfter(DEFAULT_AMENDED_DATE);
+    assertThat(testProgrammeMembership.getIntrepidId()).isEqualTo(DEFAULT_INTREPID_ID);
+    assertThat(testProgrammeMembership.getLeavingReason()).isEqualTo(DEFAULT_LEAVING_REASON);
   }
 
   @Test
@@ -821,7 +783,7 @@ public class ProgrammeMembershipResourceIntTest {
   @Test
   @Transactional
   @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
-  public void deleteProgrammeAndCurriculumMemberships() throws Exception {
+  public void deleteProgrammeAndCurriculumMembershipsShouldOnlyDeleteCurriculumMembership() throws Exception {
     // Initialize the database
     // The reason this test needs to run with a fresh context is that the delete function expects
     // the record to have the same ID in both the CurriculumMembership and ProgrammeMembership
@@ -832,8 +794,6 @@ public class ProgrammeMembershipResourceIntTest {
     curriculumMembershipRepository.saveAndFlush(curriculumMembership);
     int databaseCmSizeBeforeDelete = curriculumMembershipRepository.findAll().size();
 
-    //deprecated: when the programmeMembershipRepository is no longer updated in parallel,
-    //these lines should be removed
     programmeMembership.setPerson(person);
     programmeMembershipRepository.deleteAll();
     programmeMembershipRepository.saveAndFlush(programmeMembership);
@@ -849,10 +809,9 @@ public class ProgrammeMembershipResourceIntTest {
     List<CurriculumMembership> curriculumMembershipList = curriculumMembershipRepository.findAll();
     assertThat(curriculumMembershipList).hasSize(databaseCmSizeBeforeDelete - 1);
 
-    //deprecated: when the programmeMembershipRepository is no longer updated in parallel,
-    //these lines should be removed
+    //check that programme membership repository is unaffected
     List<ProgrammeMembership> programmeMembershipList = programmeMembershipRepository.findAll();
-    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeDelete - 1);
+    assertThat(programmeMembershipList).hasSize(databasePmSizeBeforeDelete);
   }
 
   @Test

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -81,10 +81,7 @@ public class ProgrammeMembershipServiceImplTest {
   private final PersonDTO personDto = new PersonDTO();
   private final Person person = new Person();
   private ProgrammeMembershipServiceImpl testObj;
-  private ProgrammeMembershipMapper programmeMembershipMapper;
   private CurriculumMembershipMapper curriculumMembershipMapper;
-  @Mock
-  private ProgrammeMembershipRepository programmeMembershipRepositoryMock;
   @Mock
   private CurriculumMembershipRepository curriculumMembershipRepositoryMock;
   @Mock
@@ -98,7 +95,6 @@ public class ProgrammeMembershipServiceImplTest {
 
   @Before
   public void setup() {
-    programmeMembershipMapper = new ProgrammeMembershipMapper();
     curriculumMembershipMapper = new CurriculumMembershipMapper();
     CurriculumMapper curriculumMapper = new CurriculumMapperImpl();
     ReflectionTestUtils.setField(curriculumMapper, "specialtyMapper",

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -103,8 +103,7 @@ public class ProgrammeMembershipServiceImplTest {
     CurriculumMapper curriculumMapper = new CurriculumMapperImpl();
     ReflectionTestUtils.setField(curriculumMapper, "specialtyMapper",
         new SpecialtyMapperImpl());
-    testObj = new ProgrammeMembershipServiceImpl(programmeMembershipRepositoryMock,
-        curriculumMembershipRepositoryMock, programmeMembershipMapper, curriculumMembershipMapper,
+    testObj = new ProgrammeMembershipServiceImpl(curriculumMembershipRepositoryMock, curriculumMembershipMapper,
         curriculumRepositoryMock, curriculumMapper, programmeRepositoryMock,
         applicationEventPublisherMock, personRepositoryMock);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,7 +21,6 @@ import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.Programme;
-import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.repository.CurriculumRepository;
@@ -36,7 +34,6 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMap
 import com.transformuk.hee.tis.tcs.service.service.mapper.SpecialtyMapperImpl;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -502,30 +499,6 @@ public class ProgrammeMembershipServiceImplTest {
   }
 
   @Test
-  public void shouldSaveProgrammeMembershipDtoToProgrammeMembershipRepository() {
-    //this is deprecated and should be removed once parallel updates to the
-    //ProgrammeMembershipRepository are stopped
-
-    //given
-    List<ProgrammeMembership> programmeMembershipList
-        = programmeMembershipMapper.toEntity(programmeMembershipDto1);
-    when(programmeMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(programmeMembershipList);
-    List<CurriculumMembership> curriculumMembershipList
-        = curriculumMembershipMapper.toEntity(programmeMembershipDto1);
-    when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(curriculumMembershipList);
-    when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
-
-    //when
-    testObj.save(programmeMembershipDto1);
-
-    //then
-    verify(programmeMembershipRepositoryMock, times(1))
-        .saveAll(anyCollection());
-  }
-
-  @Test
   public void shouldSaveProgrammeMembershipDtoListToCurriculumMembershipRepository() {
     //given
     List<CurriculumMembership> curriculumMembershipList
@@ -549,30 +522,6 @@ public class ProgrammeMembershipServiceImplTest {
   }
 
   @Test
-  public void shouldSaveProgrammeMembershipDtoListToProgrammeMembershipRepository() {
-    //this is deprecated and should be removed once parallel updates to the
-    //ProgrammeMembershipRepository are stopped
-
-    //given
-    List<ProgrammeMembership> programmeMembershipList
-        = programmeMembershipMapper.toEntity(programmeMembershipDto1);
-    when(programmeMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(programmeMembershipList);
-    List<CurriculumMembership> curriculumMembershipList
-        = curriculumMembershipMapper.toEntity(programmeMembershipDto1);
-    when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(curriculumMembershipList);
-    when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
-
-    //when
-    testObj.save(Lists.newArrayList(programmeMembershipDto1));
-
-    //then
-    verify(programmeMembershipRepositoryMock, times(1))
-        .saveAll(anyCollection());
-  }
-
-  @Test
   public void shouldDeleteFromCurriculumMembershipRepository() {
     //given
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
@@ -587,57 +536,5 @@ public class ProgrammeMembershipServiceImplTest {
         .deleteById(PROGRAMME_MEMBERSHIP_ID_1);
   }
 
-  @Test
-  public void shouldDeleteFromProgrammeMembershipRepository() {
-    //this is deprecated and should be removed once parallel updates to the
-    //ProgrammeMembershipRepository are stopped
-    //given
-    when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
-    when(curriculumMembershipRepositoryMock.getOne(PROGRAMME_MEMBERSHIP_ID_1))
-        .thenReturn(curriculumMembership1);
 
-    //when
-    testObj.delete(PROGRAMME_MEMBERSHIP_ID_1);
-
-    //then
-    verify(programmeMembershipRepositoryMock, times(1))
-        .deleteById(PROGRAMME_MEMBERSHIP_ID_1);
-  }
-
-  @Test
-  public void shouldSetAmendedDateForProgrammeMembershipFromDbWhenUpdating() {
-    //given
-    LocalDateTime dbAmendedDate = LocalDateTime.parse("2021-01-01T01:01:01.001");
-    LocalDateTime staleAmendedDate = LocalDateTime.parse("2021-01-01T00:00:00.000");
-
-    ProgrammeMembership pmInDb = new ProgrammeMembership();
-    pmInDb.setId(PROGRAMME_MEMBERSHIP_ID_1);
-    pmInDb.setAmendedDate(dbAmendedDate);
-
-    programmeMembershipDto1.getCurriculumMemberships().get(0).setAmendedDate(dbAmendedDate);
-    List<ProgrammeMembership> pmToSaveUpdatedList
-        = programmeMembershipMapper.toEntity(programmeMembershipDto1);
-    programmeMembershipDto1.getCurriculumMemberships().get(0).setAmendedDate(staleAmendedDate);
-
-    when(programmeMembershipRepositoryMock.findById(PROGRAMME_MEMBERSHIP_ID_1))
-        .thenReturn(Optional.of(pmInDb));
-    when(programmeMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(pmToSaveUpdatedList);
-
-    List<CurriculumMembership> curriculumMembershipList
-        = curriculumMembershipMapper.toEntity(programmeMembershipDto1);
-    when(curriculumMembershipRepositoryMock.saveAll(anyCollection()))
-        .thenReturn(curriculumMembershipList);
-    when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
-
-    //when
-    testObj.save(Lists.newArrayList(programmeMembershipDto1));
-
-    //then
-    verify(programmeMembershipRepositoryMock, times(1))
-        .saveAll(argThat((List<ProgrammeMembership> pmList)
-            -> pmList.get(0).getAmendedDate().compareTo(dbAmendedDate) == 0));
-    verify(programmeMembershipRepositoryMock, times(1))
-        .findById(PROGRAMME_MEMBERSHIP_ID_1);
-  }
 }


### PR DESCRIPTION
Prior to making changes to the structure and content of the
ProgrammeMembership table. All interactions should now be with the
CurriculumMembership table.

TIS21-2900