### PR TITLE
fix: trim and remove all non-breaking spaces in emails

### DIFF
--- a/tcs-service/src/main/resources/db/migration/schema/V4.22__update_contactDetails_email.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.22__update_contactDetails_email.sql
@@ -1,0 +1,3 @@
+UPDATE ContactDetails
+SET email = REPLACE(TRIM(email), UNHEX('C2A0'),'')
+WHERE email LIKE CONCAT('%', UNHEX('C2A0'), '%') OR TRIM(email) <> email;


### PR DESCRIPTION
1. emails shouldn't have any non-breaking spaces, so replace all of them with ''
2. the setting 'sql_safe_updates' are off on Stage/Prod/NIMDTA, so it's okay not to have ID in where clause for updates.
3. records affected: Prod: 108, NIMDTA: 4.

TIS21-2866