### PR TITLE
test: add tests for email validation

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.0</version>
+  <version>6.26.1</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidatorTest.java
@@ -848,6 +848,8 @@ class ContactDetailsValidatorTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"a..b@b.com", "()@b.com", "a@f%.com", "a@b|.com", "a.b.com", "a@f'%com",
+      " abc.com", "abc.com ", "a bc.com",
+      "\u00A0abc.com", "abc.com\u00A0", "a\u00A0bc.com", // non-breaking spaces
       //following examples drawn from https://en.wikipedia.org/wiki/Email_address
       //failing entries with the current REGEXP are commented out
       "Abc.example.com",


### PR DESCRIPTION
Before we applied the flyway script to fix the email on Prod/NIMDTA, the latest email needed to be fixed had the amendedDate "2021-10-12T14:42:23.155", and we fixed the RegEx of email on 06/04/2022. By adding the tests, I found the whitespaces and non-breaking spaces are already filtered out by the new RegEx.

Besides, according to [Wikipedia](https://en.wikipedia.org/wiki/Non-breaking_space), the non-breaking space in Unicode is `U+00A0`.

TIS21-2866