### PR TITLE
fix: getPlacementForTrainee return Dto

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>5.15.0</version>
+  <version>6.0.0</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -18,6 +18,7 @@ import com.transformuk.hee.tis.tcs.api.dto.PlacementCommentDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementFunderDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PlacementSummaryDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostFundingDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeDTO;
@@ -351,10 +352,10 @@ public class TcsServiceImpl extends AbstractClientService {
         }).getBody();
   }
 
-  public List<PlacementDetailsDTO> getPlacementForTrainee(Long traineeId) {
+  public List<PlacementSummaryDTO> getPlacementForTrainee(Long traineeId) {
     String uri = String.format(API_TRAINEE_PLACEMENTS, traineeId);
     return tcsRestTemplate.exchange(serviceUrl + uri,
-        HttpMethod.GET, null, new ParameterizedTypeReference<List<PlacementDetailsDTO>>() {
+        HttpMethod.GET, null, new ParameterizedTypeReference<List<PlacementSummaryDTO>>() {
         }).getBody();
   }
 

--- a/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplMockTest.java
+++ b/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplMockTest.java
@@ -15,6 +15,7 @@ import com.google.common.collect.Maps;
 import com.transformuk.hee.tis.tcs.api.dto.AbsenceDTO;
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PlacementSummaryDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipCurriculaDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainerApprovalDTO;
 import java.util.Collections;
@@ -179,6 +180,24 @@ public class TcsServiceImplMockTest {
     // Then.
     assertThat("Unexpected number of patched DTOs.", returnDtos.size(), is(1));
     assertThat("Unexpected patched DTOs.", returnDtos.get(0), is(dto));
+  }
+
+  @Test
+  public void getPlacementForTraineeShouldReturnResponse() {
+    PlacementSummaryDTO dto = new PlacementSummaryDTO();
+    dto.setPlacementId(1L);
+    dto.setTraineeId(2L);
+
+    ResponseEntity<List<PlacementSummaryDTO>> response = ResponseEntity.ok(Lists.newArrayList(dto));
+    when(restTemplateMock.exchange(anyString(), eq(HttpMethod.GET), eq(null), any(
+        ParameterizedTypeReference.class))).thenReturn(response);
+
+    // When.
+    List<PlacementSummaryDTO> returnDtos = testObj
+        .getPlacementForTrainee(2L);
+    // Then.
+    assertThat("Unexpected number of placement DTOs.", returnDtos.size(), is(1));
+    assertThat("Unexpected placement DTO.", returnDtos.get(0), is(dto));
   }
 
   @Test


### PR DESCRIPTION
Make the returned DTO type consistent with the DTO returned by the API
call.

Note: breaking change to tcs-client.

TIS21-3127: Ensure placement IDs are included in the response from TCS
client