### PR TITLE
chore: remove distributionManagement from pom

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -80,12 +80,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <distributionManagement>
-    <repository>
-      <id>codeartifact</id>
-      <name>CodeArtifact</name>
-      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
-    </repository>
-  </distributionManagement>
 </project>

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -106,12 +106,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <distributionManagement>
-    <repository>
-      <id>codeartifact</id>
-      <name>CodeArtifact</name>
-      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
-    </repository>
-  </distributionManagement>
 </project>

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -134,12 +134,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <distributionManagement>
-    <repository>
-      <id>codeartifact</id>
-      <name>CodeArtifact</name>
-      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
-    </repository>
-  </distributionManagement>
 </project>


### PR DESCRIPTION
Currently, in dockerize phase of CI CD workflow, Publishing artifacts(tcs-client, tcs-api, tcs-persistence) to aws get a [409 conflict error](https://github.com/Health-Education-England/TIS-TCS/runs/6998992744?check_suite_focus=true#step:8:84). I suspect it might be caused by the distributionManagement  config in pom file. Not very confident if the PR can fix this 409 error, but

anyway, we have migrated tcs to aws ECS, so this distributionManagement  config is not needed.

no-ticket