### PR TITLE
fix: get personStatus updated when a programmeMembership is deleted

### DIFF
--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ProgrammeMembership.java
@@ -17,6 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.PreRemove;
 import javax.persistence.Version;
 import lombok.Data;
 import org.hibernate.annotations.GenericGenerator;
@@ -124,5 +125,10 @@ public class ProgrammeMembership implements Serializable {
   @Override
   public int hashCode() {
     return Objects.hashCode(uuid);
+  }
+
+  @PreRemove
+  private void dismissParent() {
+    this.getPerson().getProgrammeMemberships().remove(this);
   }
 }

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.3</version>
+  <version>6.26.4</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -41,7 +41,7 @@ public class ProgrammeMembershipMapper {
         result.setCurriculumMemberships(Lists.newArrayList());
       }
       result.getCurriculumMemberships()
-          .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
+          .addAll(programmeMembershipToCurriculumMembershipDtos(programmeMembership));
     }
     return result;
   }
@@ -82,7 +82,7 @@ public class ProgrammeMembershipMapper {
         programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
       }
       programmeMembershipDto.getCurriculumMemberships()
-          .addAll(programmeMembershipToCurriculumMembershipDTOs(programmeMembership));
+          .addAll(programmeMembershipToCurriculumMembershipDtos(programmeMembership));
       listMap.put(programmeMembershipDto, programmeMembershipDto);
     }
 
@@ -174,7 +174,7 @@ public class ProgrammeMembershipMapper {
     return result;
   }
 
-  private List<CurriculumMembershipDTO> programmeMembershipToCurriculumMembershipDTOs(
+  private List<CurriculumMembershipDTO> programmeMembershipToCurriculumMembershipDtos(
       ProgrammeMembership programmeMembership) {
     List<CurriculumMembershipDTO> curriculumMembershipDtos = Lists.newArrayList();
     Set<CurriculumMembership> curriculumMemberships

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -1224,8 +1224,8 @@ class ProgrammeMembershipResourceIntTest {
     person.setStatus(Status.CURRENT);
     personRepository.saveAndFlush(person);
 
-    assertThat(programmeMembershipRepository.findAll().size()).isEqualTo(2);
-    assertThat(curriculumMembershipRepository.findAll().size()).isEqualTo(2);
+    assertThat(programmeMembershipRepository.findAll()).hasSize(2);
+    assertThat(curriculumMembershipRepository.findAll()).hasSize(2);
 
     // Prepare the programmeMembershipDto to be deleted
     ProgrammeMembershipDTO programmeMembershipDto = programmeMembershipMapper
@@ -1240,9 +1240,9 @@ class ProgrammeMembershipResourceIntTest {
 
     Person personToCheck = personRepository.findPersonById(personSaved.getId()).get();
     assertThat(personToCheck.getStatus()).isEqualTo(Status.INACTIVE);
-    assertThat(personToCheck.getProgrammeMemberships().size()).isEqualTo(1);
-    assertThat(programmeMembershipRepository.findAll().size()).isEqualTo(1);
-    assertThat(curriculumMembershipRepository.findAll().size()).isEqualTo(1);
+    assertThat(personToCheck.getProgrammeMemberships()).hasSize(1);
+    assertThat(programmeMembershipRepository.findAll()).hasSize(1);
+    assertThat(curriculumMembershipRepository.findAll()).hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
Cause of the bug:
The entities Person and ProgrammeMembership are 1 to many mapping (bidirectional relationship), and when a programmeMembership is deleted from the child side, the deletion doesn't get synchronised to the parent side. 
Some similar discussion can be found here: https://stackoverflow.com/questions/22688402/delete-not-working-with-jparepository

Solutions I can think of and have verified on local:
1. get the changes flushed to the DB before populating personStatus, so that (I think) the cached person object will get updated.
2. add a `@PreRemove` hook to dimiss the parent before the child programmeMembership is deleted.

I've chosen the 2nd solution as it doesn't break the transaction itself and solves the real problem.

TIS21-3311