### PR TITLE
chore: bump version of reference-client

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.11.6</version>
+      <version>4.12.2</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>


### PR DESCRIPTION
depend on [TIS-REFERENCE #268](https://github.com/Health-Education-England/TIS-REFERENCE/pull/268)

TIS21-3518