### PR TITLE
fix: audit logging for deleting PM

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.4</version>
+  <version>6.26.5</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -161,7 +161,7 @@ public class ProgrammeMembershipResource {
    */
   @PostMapping("/programme-memberships/delete/")
   @PreAuthorize("hasAuthority('tcs:delete:entities')")
-  public ResponseEntity<Void> removeProgrammeMembershipAndItsCurriculum(
+  public ResponseEntity<Void> deleteProgrammeMembershipAndItsCurriculum(
       @RequestBody ProgrammeMembershipDTO programmeMembershipDTO) {
     log.debug("REST request to delete ProgrammeMembership : {}", programmeMembershipDTO);
     List<String> idsDeleted = new ArrayList<>();


### PR DESCRIPTION
Description: the AuditingAspect only allows logging for method update/delete/create. So change remove to delete to turn on logging.

There're 2 endpoints in TCS for deleting PM or CM. How are they used by frontend?
TIS frontend sends requests to `@PostMapping("/programme-memberships/delete/")` when deleting a while PM or the last CM under one PM, while sends request to `@DeleteMapping("/programme-memberships/{id}")` when deleting a single CM which is not the only one under the PM.

Logging tested on local.


TIS21-3463