### PR TITLE
feat: add clauses For Reval Sync Sql

### DIFF
--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -21,6 +21,7 @@ from (
       personId,
       count(if(pm.programmeStartDate <= current_date() and pm.programmeEndDate >= current_date(), true, null)) as count_num
     from ProgrammeMembership pm
+    WHERECLAUSE1 -- where personId in ()
     group by personId
   ) currentPmCounts on p.id = currentPmCounts.personId
   left join ProgrammeMembership pm1
@@ -31,8 +32,12 @@ from (
           cm.programmeMembershipUuid,
           max(cm.curriculumEndDate) curriculumEndDate
       from CurriculumMembership cm
+      WHERECLAUSE1 -- where personId in ()
       group by cm.programmeMembershipUuid
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   left join Programme prg on prg.id = pm1.programmeId
+  WHERECLAUSE2 -- where p.id in ()
   ) as ot
+ORDERBYCLAUSE
+LIMITCLAUSE
 ;

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -1,7 +1,7 @@
 select distinct ot.*
 from (
   select
-    p.id,
+    p.id personId,
     gmc.gmcNumber,
     cd.forenames,
     cd.surname,
@@ -21,7 +21,7 @@ from (
       personId,
       count(if(pm.programmeStartDate <= current_date() and pm.programmeEndDate >= current_date(), true, null)) as count_num
     from ProgrammeMembership pm
-    WHERECLAUSE1 -- where personId in ()
+    WHERECLAUSE
     group by personId
   ) currentPmCounts on p.id = currentPmCounts.personId
   left join ProgrammeMembership pm1
@@ -32,11 +32,11 @@ from (
           cm.programmeMembershipUuid,
           max(cm.curriculumEndDate) curriculumEndDate
       from CurriculumMembership cm
-      WHERECLAUSE1 -- where personId in ()
+      WHERECLAUSE
       group by cm.programmeMembershipUuid
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   left join Programme prg on prg.id = pm1.programmeId
-  WHERECLAUSE2 -- where p.id in ()
+  WHERECLAUSE
   ) as ot
 ORDERBYCLAUSE
 LIMITCLAUSE

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.5</version>
+  <version>6.26.6</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
 @Transactional
 public class RevalidationServiceImpl implements RevalidationService {
 
+  private static final String PERSON_ID_FIELD = "personId";
   private static final String CONNECTION_OWNER = "owner";
   private static final String CURRICULUM_END_DATE_FIELD = "curriculumEndDate";
   private static final String GMC_NUMBER_FIELD = "gmcNumber";
@@ -259,10 +260,10 @@ public class RevalidationServiceImpl implements RevalidationService {
 
   @Override
   public List<ConnectionInfoDto> extractConnectionInfoForSync() {
-    final String query = sqlQuerySupplier
-        .getQuery(SqlQuerySupplier.TRAINEE_CONNECTION_INFO)
-        .replace("WHERECLAUSE1", "").replace("WHERECLAUSE2", "")
-        .replace("ORDERBYCLAUSE", "").replace("LIMITCLAUSE", "");
+    final String query = sqlQuerySupplier.getQuery(SqlQuerySupplier.TRAINEE_CONNECTION_INFO)
+        .replace("WHERECLAUSE", "")
+        .replace("ORDERBYCLAUSE", "")
+        .replace("LIMITCLAUSE", "");
     MapSqlParameterSource paramSource = new MapSqlParameterSource();
     return namedParameterJdbcTemplate
         .query(query, paramSource, new RevalidationConnectionInfoMapper());
@@ -439,7 +440,7 @@ public class RevalidationServiceImpl implements RevalidationService {
         curriculumEnd = null;
       }
       return ConnectionInfoDto.builder()
-          .tcsPersonId(rs.getLong("id"))
+          .tcsPersonId(rs.getLong(PERSON_ID_FIELD))
           .gmcReferenceNumber(rs.getString(GMC_NUMBER_FIELD))
           .doctorFirstName(rs.getString(FORENAMES_FIELD))
           .doctorLastName(rs.getString(SURNAME_FIELD))

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -260,7 +260,9 @@ public class RevalidationServiceImpl implements RevalidationService {
   @Override
   public List<ConnectionInfoDto> extractConnectionInfoForSync() {
     final String query = sqlQuerySupplier
-        .getQuery(SqlQuerySupplier.TRAINEE_CONNECTION_INFO);
+        .getQuery(SqlQuerySupplier.TRAINEE_CONNECTION_INFO)
+        .replace("WHERECLAUSE1", "").replace("WHERECLAUSE2", "")
+        .replace("ORDERBYCLAUSE", "").replace("LIMITCLAUSE", "");
     MapSqlParameterSource paramSource = new MapSqlParameterSource();
     return namedParameterJdbcTemplate
         .query(query, paramSource, new RevalidationConnectionInfoMapper());


### PR DESCRIPTION
I did "EXPLAIN" traineeInfoForConnection.sql, I think the performance are decided by the rows of Person, nested query to get current PMs and nested query to get max CM.

So I tried limiting the query rows of personId to 10000, and the below pics are comparison of EXPLAIN output when I added _where clauses_ in different places:

- Add where clause in `ot` only:

![image](https://user-images.githubusercontent.com/33690649/196150304-efebf2a6-2319-4fa1-bbcf-e5f646f4ead8.png)
https://build.tis.nhs.uk/metabase/question/474

- Add where clauses in nested queries and Person table:

![image](https://user-images.githubusercontent.com/33690649/196150420-711a3715-6528-4fae-a950-dc565a74d5ee.png)
https://build.tis.nhs.uk/metabase/question/473

We can see the 1st query needs to examine more rows to execute the whole query.

Some docs of "EXPLAIN": https://dev.mysql.com/doc/refman/5.7/en/explain-output.html

TIS21-3229