### PR TITLE
feat:use RevalSyncSql for Single Person export

### DIFF
--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -21,7 +21,7 @@ from (
       personId,
       count(if(pm.programmeStartDate <= current_date() and pm.programmeEndDate >= current_date(), true, null)) as count_num
     from ProgrammeMembership pm
-    WHERECLAUSE
+    WHERECLAUSE(pm, personId)
     group by personId
   ) currentPmCounts on p.id = currentPmCounts.personId
   left join ProgrammeMembership pm1
@@ -32,11 +32,11 @@ from (
           cm.programmeMembershipUuid,
           max(cm.curriculumEndDate) curriculumEndDate
       from CurriculumMembership cm
-      WHERECLAUSE
+      WHERECLAUSE(cm, personId)
       group by cm.programmeMembershipUuid
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   left join Programme prg on prg.id = pm1.programmeId
-  WHERECLAUSE
+  WHERECLAUSE(p, id)
   ) as ot
 ORDERBYCLAUSE
 LIMITCLAUSE

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -1,7 +1,7 @@
 select distinct ot.*
 from (
   select
-    p.id personId,
+    cd.id personId,
     gmc.gmcNumber,
     cd.forenames,
     cd.surname,
@@ -12,9 +12,8 @@ from (
     if(prg.programmeName is null and currentPmCounts.count_num > 1, "multiple programmes", prg.programmeName) as programmeName,
     prg.owner
   from
-    Person p
-  join ContactDetails cd on (cd.id = p.id)
-  left join GmcDetails gmc on (gmc.id = p.id)
+    ContactDetails cd
+  left join GmcDetails gmc on (gmc.id = cd.id)
   left join (
     -- count current PMs for each person
     select
@@ -23,7 +22,7 @@ from (
     from ProgrammeMembership pm
     WHERECLAUSE(pm, personId)
     group by personId
-  ) currentPmCounts on p.id = currentPmCounts.personId
+  ) currentPmCounts on cd.id = currentPmCounts.personId
   left join ProgrammeMembership pm1
     on pm1.personId = currentPmCounts.personId and currentPmCounts.count_num = 1 and (pm1.programmeStartDate <= current_date() and pm1.programmeEndDate >= current_date())
   left join (
@@ -36,7 +35,7 @@ from (
       group by cm.programmeMembershipUuid
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   left join Programme prg on prg.id = pm1.programmeId
-  WHERECLAUSE(p, id)
+  WHERECLAUSE(cd, id)
   ) as ot
 ORDERBYCLAUSE
 LIMITCLAUSE

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.6</version>
+  <version>6.26.7</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationRabbitServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationRabbitServiceImpl.java
@@ -26,7 +26,7 @@ public class RevalidationRabbitServiceImpl implements RevalidationRabbitService 
 
   @Override
   public void updateReval(Object object) {
-    if (!exchange.equals("false")) {
+    if (!exchange.equals("false") && object != null) {
       rabbitTemplate.convertAndSend(exchange, routingKey, object);
     }
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -10,13 +10,11 @@ import com.transformuk.hee.tis.reference.client.ReferenceService;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionDetailDto;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionDto;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionInfoDto;
-import com.transformuk.hee.tis.tcs.api.dto.ConnectionInfoDto.ConnectionInfoDtoBuilder;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionRecordDto;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionSummaryDto;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionSummaryRecordDto;
 import com.transformuk.hee.tis.tcs.api.dto.ConnectionSummaryRecordDto.ConnectionSummaryRecordDtoBuilder;
 import com.transformuk.hee.tis.tcs.api.dto.ContactDetailsDTO;
-import com.transformuk.hee.tis.tcs.api.dto.GmcDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.RevalidationRecordDto;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
@@ -215,53 +213,45 @@ public class RevalidationServiceImpl implements RevalidationService {
         .build();
   }
 
+  /**
+   * The returned regular expression matches strings in format of <b>WHERECLAUSE(p, id)<b/>.
+   * Whitespaces are allowed in the brackets.
+   * and it also recognises p and id as parenthesized match sub patterns.
+   *
+   * @return the regular expression for WhereClause macro
+   */
+  private String getWhereClauseMacro() {
+    return "WHERECLAUSE\\(\\s*([^\\(\\)\\s]+)\\s*,\\s*([^\\(\\)\\s]+)\\s*\\)";
+  }
+
   @Override
   public ConnectionInfoDto buildTcsConnectionInfo(Long personId) {
 
-    final ConnectionInfoDtoBuilder connectionInfoDtoBuilder = ConnectionInfoDto.builder();
-    connectionInfoDtoBuilder.tcsPersonId(personId);
+    // $1 and $2 will be injected with the parenthesized match sub patterns from the RegEx
+    final String whereClause = String.format("where $1.$2 = %s", personId);
 
-    // GMC Details
-    final GmcDetailsDTO gmcDetailsDto = gmcDetailsService.findOne(personId);
-    if (gmcDetailsDto != null) {
-      connectionInfoDtoBuilder.gmcReferenceNumber(gmcDetailsDto.getGmcNumber());
+    final String query = sqlQuerySupplier
+        .getQuery(SqlQuerySupplier.TRAINEE_CONNECTION_INFO)
+        .replaceAll(getWhereClauseMacro(), whereClause)
+        .replace("ORDERBYCLAUSE", "")
+        .replace("LIMITCLAUSE", "");
+
+    MapSqlParameterSource paramSource = new MapSqlParameterSource();
+    List<ConnectionInfoDto> connectionInfoDtos = namedParameterJdbcTemplate
+        .query(query, paramSource, new RevalidationConnectionInfoMapper());
+    if (connectionInfoDtos.size() == 1) {
+      return connectionInfoDtos.get(0);
+    } else {
+      LOG.error("There are {} connectionInfoDtos found for personId: {}",
+          connectionInfoDtos.size(), personId);
+      return null;
     }
-
-    // Contact Details
-    final ContactDetailsDTO contactDetailsDto = contactDetailsService.findOne(personId);
-    if (contactDetailsDto != null) {
-      connectionInfoDtoBuilder.doctorFirstName(contactDetailsDto.getForenames());
-      connectionInfoDtoBuilder.doctorLastName(contactDetailsDto.getSurname());
-    }
-
-    // latest Programme Membership
-    final CurriculumMembership latestCurriculumMembership = curriculumMembershipRepository
-        .findLatestCurriculumMembershipByTraineeId(personId);
-    final ProgrammeMembershipDTO programmeMembershipDto = curriculumMembershipMapper
-        .toDto(latestCurriculumMembership);
-    if (programmeMembershipDto != null) {
-      final String owner = programmeMembershipDto.getProgrammeOwner();
-      final ProgrammeMembershipType membershipType = programmeMembershipDto
-          .getProgrammeMembershipType();
-      connectionInfoDtoBuilder
-          .tcsDesignatedBody(owner != null ? DesignatedBodyMapper.getDbcByOwner(owner) : null)
-          .programmeOwner(owner)
-          .programmeName(programmeMembershipDto.getProgrammeName())
-          .programmeMembershipStartDate(programmeMembershipDto.getProgrammeStartDate())
-          .programmeMembershipEndDate(programmeMembershipDto.getProgrammeEndDate())
-          .curriculumEndDate(latestCurriculumMembership.getCurriculumEndDate())
-          .programmeMembershipType(membershipType != null ? membershipType.toString() : null);
-
-    }
-
-    connectionInfoDtoBuilder.dataSource("TCS");
-    return connectionInfoDtoBuilder.build();
   }
 
   @Override
   public List<ConnectionInfoDto> extractConnectionInfoForSync() {
     final String query = sqlQuerySupplier.getQuery(SqlQuerySupplier.TRAINEE_CONNECTION_INFO)
-        .replace("WHERECLAUSE", "")
+        .replaceAll(getWhereClauseMacro(), "")
         .replace("ORDERBYCLAUSE", "")
         .replace("LIMITCLAUSE", "");
     MapSqlParameterSource paramSource = new MapSqlParameterSource();

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -75,7 +75,7 @@ public class RevalidationServiceImpl implements RevalidationService {
    * and it also recognises p and id as parenthesized match sub patterns.
    */
   private static final String WHERE_CLAUSE_MACRO_REGEX =
-      "WHERECLAUSE\\(\\s*([^\\(\\)\\s]+)\\s*,\\s*([^\\(\\)\\s]+)\\s*\\)";
+      "WHERECLAUSE\\(\\s*(\\w+?)\\s*,\\s*(\\w+?)\\s*\\)";
 
   public static final int SIZE = 20;
   private static final Logger LOG = LoggerFactory.getLogger(RevalidationServiceImpl.class);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationRabbitServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationRabbitServiceImplTest.java
@@ -51,4 +51,12 @@ public class RevalidationRabbitServiceImplTest {
     verify(rabbitTemplate, never()).convertAndSend(EXCHANGE_NIMDTA, ROUTINGKEY_NIMDTA,
         OBJECT);
   }
+
+  @Test
+  public void shouldNotSendMessageWhenObjectIsNull() {
+    tcsFieldsSetup();
+    testObj.updateReval(null);
+    verify(rabbitTemplate, never()).convertAndSend(EXCHANGE_NIMDTA, ROUTINGKEY_NIMDTA,
+        OBJECT);
+  }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -504,7 +504,7 @@ public class RevalidationServiceImplTest {
         any(MapSqlParameterSource.class), any(RowMapper.class));
 
     String querySql = stringArgCaptor.getValue();
-    assertThat(querySql, containsString("where p.id = " + PERSON_ID));
+    assertThat(querySql, containsString("where cd.id = " + PERSON_ID));
     assertThat(querySql, containsString("where pm.personId = " + PERSON_ID));
     assertThat(querySql, containsString("where cm.personId = " + PERSON_ID));
     assertThat(querySql, not(containsString("ORDERBYCLAUSE")));

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -4,7 +4,9 @@ import static com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipTyp
 import static com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType.VISITOR;
 import static java.time.LocalDate.now;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,9 +53,12 @@ import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.data.domain.Page;
@@ -121,13 +126,15 @@ public class RevalidationServiceImplTest {
   private ProgrammeMembershipDTO programmeMembershipDTO;
   @Mock
   private NamedParameterJdbcTemplate namedParameterJdbcTemplateMock;
-  @Mock
+  @Spy
   private SqlQuerySupplier sqlQuerySupplier;
 
   private ContactDetailsDTO contactDetails;
   private GmcDetailsDTO gmcDetailsDTO;
   @InjectMocks
   private RevalidationServiceImpl testObj;
+  @Captor
+  private ArgumentCaptor<String> stringArgCaptor;
 
   @Before
   public void setup() {
@@ -484,95 +491,57 @@ public class RevalidationServiceImplTest {
   }
 
   @Test
-  public void shouldBuildTcsConnectionInfo() {
-    when(contactDetailsService.findOne(PERSON_ID)).thenReturn(contactDetails);
-    when(gmcDetailsServiceMock.findOne(PERSON_ID)).thenReturn(gmcDetailsDTO);
-    when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
-        .thenReturn(curriculumMembership);
-    when(cmMapper.toDto(curriculumMembership)).thenReturn(programmeMembershipDTO);
-    when(programmeMembershipDTO.getProgrammeName()).thenReturn(PROGRAMME_NAME);
-    when(programmeMembershipDTO.getProgrammeMembershipType()).thenReturn(PROGRAMME_MEMBERSHIP_TYPE);
+  public void shouldReturnDtoWhenBuildTcsConnectionInfo() {
+    MockitoAnnotations.initMocks(this);
+
+    ConnectionInfoDto connectionInfoDto = ConnectionInfoDto.builder().build();
+    when(namedParameterJdbcTemplateMock.query(
+          anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(Lists.newArrayList(connectionInfoDto));
 
     ConnectionInfoDto result = testObj.buildTcsConnectionInfo(PERSON_ID);
+    verify(namedParameterJdbcTemplateMock).query(stringArgCaptor.capture(),
+        any(MapSqlParameterSource.class), any(RowMapper.class));
 
+    String querySql = stringArgCaptor.getValue();
+    assertThat(querySql, containsString("where p.id = " + PERSON_ID));
+    assertThat(querySql, containsString("where pm.personId = " + PERSON_ID));
+    assertThat(querySql, containsString("where cm.personId = " + PERSON_ID));
+    assertThat(querySql, not(containsString("ORDERBYCLAUSE")));
+    assertThat(querySql, not(containsString("LIMITCLAUSE")));
     assertThat(result, notNullValue());
-    assertThat(result.getTcsPersonId(), is(PERSON_ID));
-    assertThat(result.getGmcReferenceNumber(), is("1000"));
-    assertThat(result.getDoctorFirstName(), is(FORENAME));
-    assertThat(result.getDoctorLastName(), is(SURNAME));
-    assertThat(result.getProgrammeMembershipType(), is(PROGRAMME_MEMBERSHIP_TYPE.toString()));
-    assertThat(result.getProgrammeName(), is(PROGRAMME_NAME));
   }
 
   @Test
-  public void shouldBuildTcsConnectionInfoWithoutContactDetails() {
-    when(contactDetailsService.findOne(PERSON_ID)).thenReturn(null);
-    when(gmcDetailsServiceMock.findOne(PERSON_ID)).thenReturn(gmcDetailsDTO);
-    when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
-        .thenReturn(curriculumMembership);
-    when(cmMapper.toDto(curriculumMembership)).thenReturn(programmeMembershipDTO);
-    when(programmeMembershipDTO.getProgrammeName()).thenReturn(PROGRAMME_NAME);
-    when(programmeMembershipDTO.getProgrammeMembershipType()).thenReturn(PROGRAMME_MEMBERSHIP_TYPE);
+  public void shouldReturnNullWhenBuildTcsConnectionInfo() {
+    MockitoAnnotations.initMocks(this);
+
+    when(namedParameterJdbcTemplateMock.query(
+          anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(Lists.newArrayList());
 
     ConnectionInfoDto result = testObj.buildTcsConnectionInfo(PERSON_ID);
+    verify(namedParameterJdbcTemplateMock).query(anyString(),
+        any(MapSqlParameterSource.class), any(RowMapper.class));
 
-    assertThat(result, notNullValue());
-    assertThat(result.getTcsPersonId(), is(PERSON_ID));
-    assertThat(result.getGmcReferenceNumber(), is("1000"));
-    assertThat(result.getDoctorFirstName(), is(nullValue()));
-    assertThat(result.getDoctorLastName(), is(nullValue()));
-    assertThat(result.getProgrammeMembershipType(), is(PROGRAMME_MEMBERSHIP_TYPE.toString()));
-    assertThat(result.getProgrammeName(), is(PROGRAMME_NAME));
-  }
-
-  @Test
-  public void shouldBuildTcsConnectionInfoWithoutGMCDetails() {
-    when(contactDetailsService.findOne(PERSON_ID)).thenReturn(contactDetails);
-    when(gmcDetailsServiceMock.findOne(PERSON_ID)).thenReturn(null);
-    when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
-        .thenReturn(curriculumMembership);
-    when(cmMapper.toDto(curriculumMembership)).thenReturn(programmeMembershipDTO);
-    when(programmeMembershipDTO.getProgrammeName()).thenReturn(PROGRAMME_NAME);
-    when(programmeMembershipDTO.getProgrammeMembershipType()).thenReturn(PROGRAMME_MEMBERSHIP_TYPE);
-
-    ConnectionInfoDto result = testObj.buildTcsConnectionInfo(PERSON_ID);
-
-    assertThat(result, notNullValue());
-    assertThat(result.getTcsPersonId(), is(PERSON_ID));
-    assertThat(result.getGmcReferenceNumber(), is(nullValue()));
-    assertThat(result.getDoctorFirstName(), is(FORENAME));
-    assertThat(result.getDoctorLastName(), is(SURNAME));
-    assertThat(result.getProgrammeMembershipType(), is(PROGRAMME_MEMBERSHIP_TYPE.toString()));
-    assertThat(result.getProgrammeName(), is(PROGRAMME_NAME));
-  }
-
-  @Test
-  public void shouldBuildTcsConnectionInfoWithoutProgrammeMembership() {
-    when(contactDetailsService.findOne(PERSON_ID)).thenReturn(contactDetails);
-    when(gmcDetailsServiceMock.findOne(PERSON_ID)).thenReturn(gmcDetailsDTO);
-    when(curriculumMembershipRepositoryMock.findLatestCurriculumMembershipByTraineeId(PERSON_ID))
-        .thenReturn(null);
-
-    ConnectionInfoDto result = testObj.buildTcsConnectionInfo(PERSON_ID);
-
-    assertThat(result, notNullValue());
-    assertThat(result.getGmcReferenceNumber(), is("1000"));
-    assertThat(result.getDoctorFirstName(), is(FORENAME));
-    assertThat(result.getDoctorLastName(), is(SURNAME));
-    assertThat(result.getProgrammeMembershipType(), is(nullValue()));
-    assertThat(result.getProgrammeName(), is(nullValue()));
+    assertThat(result, nullValue());
   }
 
   @Test
   public void shouldExtractTraineeConnectionInfo() {
     MockitoAnnotations.initMocks(this);
-    when(sqlQuerySupplier.getQuery(any(String.class))).thenReturn("Query");
 
-    when(namedParameterJdbcTemplateMock
-        .query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class))).thenReturn(new ArrayList<>());
+    when(namedParameterJdbcTemplateMock.query(
+          anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(new ArrayList<>());
 
-    List<ConnectionInfoDto> result = testObj.extractConnectionInfoForSync();
-    verify(namedParameterJdbcTemplateMock).query(any(String.class), any(MapSqlParameterSource.class), any(RowMapper.class));
+    testObj.extractConnectionInfoForSync();
+    verify(namedParameterJdbcTemplateMock).query(stringArgCaptor.capture(),
+        any(MapSqlParameterSource.class), any(RowMapper.class));
 
+    String querySql = stringArgCaptor.getValue();
+    assertThat(querySql, not(containsString("WHERECLAUSE")));
+    assertThat(querySql, not(containsString("ORDERBYCLAUSE")));
+    assertThat(querySql, not(containsString("LIMITCLAUSE")));
   }
 }


### PR DESCRIPTION
1. [The commit](https://github.com/Health-Education-England/TIS-TCS/pull/896/commits/a4dd1e1ad2f71f424bada7f2f0184100be266467) which uses alias `personId` for the 3rd where clause doesn't work. (I thought I had tested it very well, but apparently not😢)Because: 

- personId exists in temporary tables `latestCm` and `currentPmCounts`, so it's ambiguous for where clause; 
- MySQL executes where clauses first, then maps aliases, so personId is not available for p.id when where clause is being executed, unless we use `having`. But using `having` means that we will lose the optimisation of the DB and results in bad performance.

2. add macros in the format of `WHERECLAUSE(p, id)` in the SQL, so that we can recognise the macro by RegEx and get the parameters from the macro and populate the real where clauses.

3. apply the SQL to export a single ConnectionInfoDto.

TIS21-3229