### PR TITLE
fix:buildRevalidationRecord

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.7</version>
+  <version>6.26.8</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ConnectionInfoToRevalidationRecordMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ConnectionInfoToRevalidationRecordMapper.java
@@ -1,0 +1,16 @@
+package com.transformuk.hee.tis.tcs.service.service.mapper;
+
+import com.transformuk.hee.tis.tcs.api.dto.ConnectionInfoDto;
+import com.transformuk.hee.tis.tcs.api.dto.RevalidationRecordDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ConnectionInfoToRevalidationRecordMapper {
+
+  @Mapping(target = "tisPersonId", source = "tcsPersonId")
+  @Mapping(target = "gmcNumber", source = "gmcReferenceNumber")
+  @Mapping(target = "forenames", source = "doctorFirstName")
+  @Mapping(target = "surname", source = "doctorLastName")
+  RevalidationRecordDto toRevalidationRecord(ConnectionInfoDto connectionInfoDto);
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/RevalidationRecordMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/RevalidationRecordMapper.java
@@ -4,13 +4,18 @@ import com.transformuk.hee.tis.tcs.api.dto.ConnectionInfoDto;
 import com.transformuk.hee.tis.tcs.api.dto.RevalidationRecordDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
+/**
+ * Mapper for revalidation record objects.
+ */
 @Mapper(componentModel = "spring")
-public interface ConnectionInfoToRevalidationRecordMapper {
+public interface RevalidationRecordMapper {
 
   @Mapping(target = "tisPersonId", source = "tcsPersonId")
-  @Mapping(target = "gmcNumber", source = "gmcReferenceNumber")
+  @Mapping(target = "gmcNumber", ignore = true)
   @Mapping(target = "forenames", source = "doctorFirstName")
   @Mapping(target = "surname", source = "doctorLastName")
-  RevalidationRecordDto toRevalidationRecord(ConnectionInfoDto connectionInfoDto);
+  void toRevalidationRecord(ConnectionInfoDto source,
+      @MappingTarget RevalidationRecordDto target);
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -39,8 +39,8 @@ import com.transformuk.hee.tis.tcs.service.repository.PlacementRepository;
 import com.transformuk.hee.tis.tcs.service.service.ContactDetailsService;
 import com.transformuk.hee.tis.tcs.service.service.GmcDetailsService;
 import com.transformuk.hee.tis.tcs.service.service.helper.SqlQuerySupplier;
-import com.transformuk.hee.tis.tcs.service.service.mapper.ConnectionInfoToRevalidationRecordMapper;
-import com.transformuk.hee.tis.tcs.service.service.mapper.ConnectionInfoToRevalidationRecordMapperImpl;
+import com.transformuk.hee.tis.tcs.service.service.mapper.RevalidationRecordMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.RevalidationRecordMapperImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.DesignatedBodyMapper;
 
@@ -130,7 +130,7 @@ public class RevalidationServiceImplTest {
   @Spy
   private SqlQuerySupplier sqlQuerySupplier = new SqlQuerySupplier();
   @Spy
-  private ConnectionInfoToRevalidationRecordMapper connectionInfoToRevalidationRecordMapper = new ConnectionInfoToRevalidationRecordMapperImpl();
+  private RevalidationRecordMapper revalidationRecordMapper = new RevalidationRecordMapperImpl();
 
   private ContactDetailsDTO contactDetails;
   private GmcDetailsDTO gmcDetailsDTO;


### PR DESCRIPTION
1. call `buildTcsConnectionInfo` method to use `traineeInfoForConnection.sql` to get ConnectionInfoDto and then map it to RevalidtionRecordDto.
2. use Repositories to get grade of the first current placement. -- I haven't changed logic for this bit, but we allow overlapping placements, not sure if it was discussed to use the first current one.

TIS21-3229