### PR TITLE
chore:bump version of H2 & flyway-core

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
+      <version>8.5.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -48,7 +49,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.0.206</version>
+      <version>2.1.214</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
for tcs-persistence.

Current version of flyway-core is 7.1.1 and current version of h2 database is 2.0.206.
When I ran all tests in tcs-persistence, I got an error for all the integration tests as below:
```
java.lang.IllegalStateException: Failed to load ApplicationContext
...
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]: Invocation of init method failed; nested exception is org.flywaydb.core.internal.exception.FlywaySqlException: 
Unable to determine H2 compatibility mode
-----------------------------------------
SQL State  : 42001
Error Code : 42001
Message    : Syntax error in SQL statement "SELECT VALUE[*] FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME = 'MODE'"; expected "DISTINCT, ALL, ,, NOT, EXISTS, INTERSECTS, UNIQUE"; SQL statement:
SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME = 'MODE' [42001-206]
...
```
This was flagged as an issue of Flyway dependency here: https://github.com/flyway/flyway/issues/3336. 
And according to the issue, this error is due to the incompatibility of flyway-core and h2 dependencies. So we need to bump the version of flyway-core to >8.3.

The version of h2 was bumpped 1 year ago in this [PR](https://github.com/Health-Education-England/TIS-TCS/pull/807), but it seems the quality analysis have been skipped for 1 year, which is really strange!

What's more, we have another open PR to bump h2 to the latest version 2.1.214, so I think I can bump it here and the latest version of flyway-core which is compatible to h2 2.1.214 is 8.5.13.

Tested on my local.

TIS21-2388