### PR TITLE
refactor:CM repository to remove deprecated fields

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.23.1</version>
+  <version>2.23.2</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
@@ -12,45 +12,51 @@ import org.springframework.data.repository.query.Param;
  */
 @SuppressWarnings("unused")
 public interface CurriculumMembershipRepository extends JpaRepository<CurriculumMembership, Long> {
-  //Note: personId, programme, programmeEndDate etc. should be updated in the
-  //programmeMembership table, and removed from the CurriculumMembership table.
-  //See commit 43657e57f8068704ed5ad81f8b9d66090845d025 for initial work to refactor this
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE personId = :traineeId "
-      + "AND cm.programme.id = :programmeId")
+      + "JOIN FETCH cm.programmeMembership pm "
+      + "WHERE pm.person.id = :traineeId "
+      + "AND pm.programme.id = :programmeId")
   List<CurriculumMembership> findByTraineeIdAndProgrammeId(@Param("traineeId") Long traineeId,
                                                           @Param("programmeId") Long programmeId);
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE personId = :traineeId")
+      + "JOIN FETCH cm.programmeMembership pm "
+      + "WHERE pm.person.id  = :traineeId")
   List<CurriculumMembership> findByTraineeId(@Param("traineeId") Long traineeId);
 
   //Find latest curriculum membership of a trainee
-  @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "WHERE cm.personId = :traineeId ORDER BY cm.programmeEndDate DESC LIMIT 1",
-      nativeQuery = true)
+  @Query(value = "SELECT cm.* "
+      + "FROM CurriculumMembership cm "
+      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipUuid = pm.uuid "
+      + "WHERE pm.personId  = :traineeId "
+      + "ORDER BY pm.programmeEndDate DESC LIMIT 1", nativeQuery = true)
   CurriculumMembership findLatestCurriculumMembershipByTraineeId(@Param("traineeId")
-                                                                     Long traineeId);
+      Long traineeId);
 
-  @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "WHERE cm.personId = :traineeId "
-      + "ORDER BY cm.programmeEndDate DESC", nativeQuery = true)
+  @Query(value = "SELECT cm "
+      + "FROM CurriculumMembership cm "
+      + "JOIN FETCH cm.programmeMembership pm "
+      + "WHERE pm.person.id = :traineeId "
+      + "ORDER BY pm.programmeEndDate DESC")
   List<CurriculumMembership> findAllCurriculumMembershipInDescOrderByTraineeId(
       @Param("traineeId") Long traineeId);
 
   @Query(value = "SELECT cm "
       + "FROM CurriculumMembership cm "
-      + "WHERE cm.programme.id = :programmeId")
+      + "JOIN FETCH cm.programmeMembership pm "
+      + "WHERE pm.programme.id = :programmeId")
   List<CurriculumMembership> findByProgrammeId(@Param("programmeId") Long programmeId);
 
   List<CurriculumMembership> findByIdIn(Set<Long> ids);
 
   //Find latest curriculum membership of a trainee order by curriculum end date
-  @Query(value = "SELECT cm.* FROM CurriculumMembership cm "
-      + "WHERE cm.personId = :traineeId ORDER BY cm.curriculumEndDate DESC LIMIT 1",
-      nativeQuery = true)
+  @Query(value = "SELECT cm.* "
+      + "FROM CurriculumMembership cm "
+      + "JOIN ProgrammeMembership pm ON cm.programmeMembershipUuid = pm.uuid "
+      + "WHERE pm.personId = :traineeId "
+      + "ORDER BY cm.curriculumEndDate DESC LIMIT 1", nativeQuery = true)
   CurriculumMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepositoryIntTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepositoryIntTest.java
@@ -1,0 +1,89 @@
+package com.transformuk.hee.tis.tcs.service.repository;
+
+import com.transformuk.hee.tis.tcs.service.TestConfig;
+import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfig.class)
+@Sql(scripts = "/scripts/curriculumMembership.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/scripts/deleteCurriculumMembership.sql",
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+public class CurriculumMembershipRepositoryIntTest {
+
+  @Autowired
+  private CurriculumMembershipRepository testObj;
+
+  @Transactional
+  @Test
+  public void shouldFindByTraineeIdAndProgrammeId() {
+    List<CurriculumMembership> result = testObj.findByTraineeIdAndProgrammeId(1L, 1L);
+
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals(result.get(0).getProgrammeMembership().getUuid(),
+        result.get(1).getProgrammeMembership().getUuid());
+    List<Long> resultIds = result.stream().map(r -> r.getId()).collect(Collectors.toList());
+    Assert.assertTrue(resultIds.contains(1L));
+    Assert.assertTrue(resultIds.contains(2L));
+  }
+
+  @Transactional
+  @Test
+  public void shouldFindByTraineeId() {
+    List<CurriculumMembership> result = testObj.findByTraineeId(2L);
+
+    Assert.assertEquals(1, result.size());
+    Assert.assertEquals(3L, result.get(0).getId().longValue());
+  }
+
+  @Transactional
+  @Test
+  public void shouldFindLatestCurriculumMembershipByTraineeId() {
+    CurriculumMembership result = testObj.findLatestCurriculumMembershipByTraineeId(1L);
+    Assert.assertEquals(1L, result.getId().longValue());
+  }
+
+  @Transactional
+  @Test
+  public void shouldFindAllCurriculumMembershipInDescOrderByTraineeId() {
+    List<CurriculumMembership> result = testObj.findAllCurriculumMembershipInDescOrderByTraineeId(
+        1L);
+    Assert.assertEquals(3, result.size());
+    LocalDate date1 = result.get(0).getProgrammeMembership().getProgrammeEndDate();
+    LocalDate date2 = result.get(1).getProgrammeMembership().getProgrammeEndDate();
+    LocalDate date3 = result.get(2).getProgrammeMembership().getProgrammeEndDate();
+
+    Assert.assertFalse(date1.isBefore(date2));
+    Assert.assertFalse(date2.isBefore(date3));
+  }
+
+  @Transactional
+  @Test
+  public void shouldFindByProgrammeId() {
+    List<CurriculumMembership> result = testObj.findByProgrammeId(1L);
+    Assert.assertEquals(3, result.size());
+    List<Long> resultIds = result.stream().map(r -> r.getId()).collect(Collectors.toList());
+    Assert.assertTrue(resultIds.contains(1L));
+    Assert.assertTrue(resultIds.contains(2L));
+    Assert.assertTrue(resultIds.contains(5L));
+  }
+
+  @Transactional
+  @Test
+  public void shouldFindLatestCurriculumByTraineeId() {
+    CurriculumMembership result = testObj.findLatestCurriculumByTraineeId(1L);
+    Assert.assertEquals(2L, result.getId().longValue());
+  }
+}

--- a/tcs-persistence/src/test/resources/scripts/curriculumMembership.sql
+++ b/tcs-persistence/src/test/resources/scripts/curriculumMembership.sql
@@ -1,0 +1,28 @@
+SET MODE MYSQL;
+
+INSERT INTO `Person` (`id`)
+VALUES
+    (1),
+    (2),
+    (3);
+
+INSERT INTO `Programme` (`id`, `status`, `owner`, `programmeName`, `programmeNumber`, `intrepidId`)
+VALUES
+	(1, 'CURRENT', 'Health Education England Yorkshire and the Humber', 'Core Psychiatry Training', 'YAH052', '64063'),
+	(2, 'CURRENT', 'Health Education England East of England', 'General Practice', 'EOE801', '66687'),
+	(3, 'CURRENT', 'Health Education England North East', 'Neurosurgery', 'NOR089', '113289');
+
+INSERT INTO `ProgrammeMembership` (`uuid`, `programmeId`, `personId`, `programmeEndDate`)
+VALUES
+  ('0023f7bc-defa-48b4-8186-5e680e981db4', 1, 1, '2023-08-01'),
+  ('002e46cf-c966-4ca9-ac2b-ef2e5a2b57f0', 2, 2, '2022-09-07'),
+  ('00aca6ce-6e0d-405c-931e-1fcb1aa7a28c', 3, 1, '2022-08-01'),
+  ('004c4a2a-80fd-4312-83b4-5e8666db5166', 1, 3, '2027-09-04');
+
+INSERT INTO `CurriculumMembership` (`id`, `programmeMembershipUuid`, `curriculumEndDate`)
+VALUES
+  (1, '0023f7bc-defa-48b4-8186-5e680e981db4', '2023-07-01'),
+  (2, '0023f7bc-defa-48b4-8186-5e680e981db4', '2023-08-01'),
+  (3, '002e46cf-c966-4ca9-ac2b-ef2e5a2b57f0', '2022-09-07'),
+  (4, '00aca6ce-6e0d-405c-931e-1fcb1aa7a28c', '2022-08-01'),
+  (5, '004c4a2a-80fd-4312-83b4-5e8666db5166', '2027-09-04');

--- a/tcs-persistence/src/test/resources/scripts/deleteCurriculumMembership.sql
+++ b/tcs-persistence/src/test/resources/scripts/deleteCurriculumMembership.sql
@@ -1,0 +1,6 @@
+DELETE FROM `CurriculumMembership` WHERE `id` IN (1, 2, 3, 4, 5);
+DELETE FROM `ProgrammeMembership` WHERE `uuid` IN
+  ('0023f7bc-defa-48b4-8186-5e680e981db4', '002e46cf-c966-4ca9-ac2b-ef2e5a2b57f0',
+  '00aca6ce-6e0d-405c-931e-1fcb1aa7a28c', '004c4a2a-80fd-4312-83b4-5e8666db5166');
+DELETE FROM `Person` WHERE `id` IN (1, 2, 3);
+DELETE FROM `Programme` WHERE `id` IN (1, 2, 3);

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
personId, programme, programmeEndDate etc. should be updated in the
ProgrammeMembership table, and removed from the CurriculumMembership table.

TIS21-2388