### PR TITLE
refactor: trainingNumberEsEventListener to use ProgrammeMembershipRepository.

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.23.2</version>
+  <version>2.23.3</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -47,5 +47,5 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
 
   Optional<ProgrammeMembership> findByUuid(UUID id);
 
-  List<ProgrammeMembership> findByTrainingNumber_Id(Long trainingNumberId);
+  List<ProgrammeMembership> findByTrainingNumberId(Long trainingNumberId);
 }

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -46,4 +46,6 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
   List<ProgrammeMembership> findByUuidIn(Set<UUID> ids);
 
   Optional<ProgrammeMembership> findByUuid(UUID id);
+
+  List<ProgrammeMembership> findByTrainingNumber_Id(Long trainingNumberId);
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepositoryIntTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepositoryIntTest.java
@@ -70,7 +70,7 @@ public class ProgrammeMembershipRepositoryIntTest {
   @Test
   public void shouldFindByTrainingNumberId() {
     List<ProgrammeMembership> programmeMemberships =
-        programmeMembershipRepository.findByTrainingNumber_Id(trainingNumber1.getId());
+        programmeMembershipRepository.findByTrainingNumberId(trainingNumber1.getId());
     Assert.assertEquals(2, programmeMemberships.size());
   }
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepositoryIntTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepositoryIntTest.java
@@ -1,0 +1,76 @@
+package com.transformuk.hee.tis.tcs.service.repository;
+
+import com.transformuk.hee.tis.tcs.service.TestConfig;
+import com.transformuk.hee.tis.tcs.service.model.Person;
+import com.transformuk.hee.tis.tcs.service.model.Programme;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
+import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
+import java.util.List;
+import org.assertj.core.util.Lists;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfig.class)
+public class ProgrammeMembershipRepositoryIntTest {
+
+  @Autowired
+  ProgrammeMembershipRepository programmeMembershipRepository;
+
+  @Autowired
+  ProgrammeRepository programmeRepository;
+
+  @Autowired
+  PersonRepository personRepository;
+
+  @Autowired
+  TrainingNumberRepository trainingNumberRepository;
+
+  Programme programme1;
+  Person person1;
+  Person person2;
+  TrainingNumber trainingNumber1;
+  ProgrammeMembership pm1;
+  ProgrammeMembership pm2;
+
+  @Before
+  public void setUp() {
+    programme1 = new Programme();
+    programme1 = programmeRepository.saveAndFlush(programme1);
+
+    person1 = new Person();
+    person2 = new Person();
+    person1 = personRepository.saveAndFlush(person1);
+    person2 = personRepository.saveAndFlush(person2);
+
+    trainingNumber1 = new TrainingNumber();
+    trainingNumber1 = trainingNumberRepository.saveAndFlush(trainingNumber1);
+
+    pm1 = new ProgrammeMembership();
+    pm1.setProgramme(programme1);
+    pm1.setPerson(person1);
+    pm1.setTrainingNumber(trainingNumber1);
+
+    pm2 = new ProgrammeMembership();
+    pm2.setProgramme(programme1);
+    pm2.setPerson(person2);
+    pm2.setTrainingNumber(trainingNumber1);
+
+    programmeMembershipRepository.saveAll(Lists.newArrayList(pm1, pm2));
+    programmeMembershipRepository.flush();
+  }
+
+  @Transactional
+  @Test
+  public void shouldFindByTrainingNumberId() {
+    List<ProgrammeMembership> programmeMemberships =
+        programmeMembershipRepository.findByTrainingNumber_Id(trainingNumber1.getId());
+    Assert.assertEquals(2, programmeMemberships.size());
+  }
+}

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.8</version>
+  <version>6.26.9</version>
 
   <dependencies>
     <dependency>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.23.2</version>
+      <version>2.23.3</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListener.java
@@ -46,7 +46,7 @@ public class TrainingNumberElasticSearchEventListener {
 
   private void publishEventsForRelatedProgrammeMemberships(Long trainingNumberId) {
     List<ProgrammeMembership> programmeMemberships = programmeMembershipRepository
-        .findByTrainingNumber_Id(trainingNumberId);
+        .findByTrainingNumberId(trainingNumberId);
 
     if (CollectionUtils.isNotEmpty(programmeMemberships)) {
       programmeMemberships.stream()

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListener.java
@@ -1,10 +1,11 @@
 package com.transformuk.hee.tis.tcs.service.listener.person;
 
 import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipSavedEvent;
+import com.transformuk.hee.tis.tcs.service.event.TrainingNumberDeletedEvent;
 import com.transformuk.hee.tis.tcs.service.event.TrainingNumberSavedEvent;
-import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
-import com.transformuk.hee.tis.tcs.service.repository.CurriculumMembershipRepository;
-import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
+import com.transformuk.hee.tis.tcs.service.repository.ProgrammeMembershipRepository;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
 import java.util.List;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
@@ -21,10 +22,10 @@ public class TrainingNumberElasticSearchEventListener {
       .getLogger(TrainingNumberElasticSearchEventListener.class);
 
   @Autowired
-  private CurriculumMembershipRepository curriculumMembershipRepository;
+  private ProgrammeMembershipRepository programmeMembershipRepository;
 
   @Autowired
-  private CurriculumMembershipMapper curriculumMembershipMapper;
+  private ProgrammeMembershipMapper programmeMembershipMapper;
 
   @Autowired
   private ApplicationEventPublisher applicationEventPublisher;
@@ -33,24 +34,24 @@ public class TrainingNumberElasticSearchEventListener {
   public void handleTrainingNumberSavedEvent(TrainingNumberSavedEvent event) {
     LOG.info("Received TrainingNumber saved event for TrainingNumber id: [{}]",
         event.getTrainingNumberDTO().getId());
-    publishEventsForRelatedCurriculumMemberships(event.getTrainingNumberDTO().getId());
+    publishEventsForRelatedProgrammeMemberships(event.getTrainingNumberDTO().getId());
   }
 
   @EventListener
-  public void handleTrainingNumberDeletedEvent(TrainingNumberSavedEvent event) {
+  public void handleTrainingNumberDeletedEvent(TrainingNumberDeletedEvent event) {
     LOG.info("Received TrainingNumber deleted event for TrainingNumber id: [{}]",
         event.getTrainingNumberDTO().getId());
-    publishEventsForRelatedCurriculumMemberships(event.getTrainingNumberDTO().getId());
+    publishEventsForRelatedProgrammeMemberships(event.getTrainingNumberDTO().getId());
   }
 
-  private void publishEventsForRelatedCurriculumMemberships(Long trainingNumberId) {
-    List<CurriculumMembership> curriculumMembershipsByTraineeId = curriculumMembershipRepository
-        .findByTraineeId(trainingNumberId);
+  private void publishEventsForRelatedProgrammeMemberships(Long trainingNumberId) {
+    List<ProgrammeMembership> programmeMemberships = programmeMembershipRepository
+        .findByTrainingNumber_Id(trainingNumberId);
 
-    if (CollectionUtils.isNotEmpty(curriculumMembershipsByTraineeId)) {
-      curriculumMembershipsByTraineeId.stream()
+    if (CollectionUtils.isNotEmpty(programmeMemberships)) {
+      programmeMemberships.stream()
           .distinct()
-          .map(curriculumMembershipMapper::toDto)
+          .map(programmeMembershipMapper::toDto)
           .map(CurriculumMembershipSavedEvent::new)
           .forEach(applicationEventPublisher::publishEvent);
     }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListenerTest.java
@@ -1,0 +1,108 @@
+package com.transformuk.hee.tis.tcs.service.listener.person;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
+import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipSavedEvent;
+import com.transformuk.hee.tis.tcs.service.event.TrainingNumberDeletedEvent;
+import com.transformuk.hee.tis.tcs.service.event.TrainingNumberSavedEvent;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
+import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
+import com.transformuk.hee.tis.tcs.service.repository.ProgrammeMembershipRepository;
+import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TrainingNumberElasticSearchEventListenerTest {
+
+  private static final long TRAININGNUMER_ID = 1111L;
+  private static final String TRAININGNUBER_TRAININGNUMBER = "AAA/BBB/CCC";
+  private static final UUID PROGRAMME_MEMBERSHIP_UUID_1 = UUID.randomUUID();
+  private static final UUID PROGRAMME_MEMBERSHIP_UUID_2 = UUID.randomUUID();
+
+  @InjectMocks
+  TrainingNumberElasticSearchEventListener testObj;
+
+  @Mock
+  ProgrammeMembershipRepository programmeMembershipRepositoryMock;
+
+  @Mock
+  ApplicationEventPublisher applicationEventPublisherMock;
+
+  @Captor
+  ArgumentCaptor<CurriculumMembershipSavedEvent> eventArgumentCaptor;
+
+  TrainingNumberDTO trainingNumberDto;
+  TrainingNumber trainingNumber;
+
+  @Before
+  public void setup() {
+    CurriculumMembershipMapper curriculumMembershipMapper = new CurriculumMembershipMapper();
+    ReflectionTestUtils.setField(testObj, "programmeMembershipMapper",
+        new ProgrammeMembershipMapper(curriculumMembershipMapper));
+
+    trainingNumberDto = new TrainingNumberDTO();
+    trainingNumberDto.setId(TRAININGNUMER_ID);
+    trainingNumberDto.setTrainingNumber(TRAININGNUBER_TRAININGNUMBER);
+
+    trainingNumber = new TrainingNumber();
+    trainingNumber.setId(TRAININGNUMER_ID);
+    trainingNumberDto.setTrainingNumber(TRAININGNUBER_TRAININGNUMBER);
+
+    ProgrammeMembership programmeMembership1 = new ProgrammeMembership();
+    programmeMembership1.setUuid(PROGRAMME_MEMBERSHIP_UUID_1);
+    programmeMembership1.setTrainingNumber(trainingNumber);
+
+    ProgrammeMembership programmeMembership2 = new ProgrammeMembership();
+    programmeMembership2.setUuid(PROGRAMME_MEMBERSHIP_UUID_2);
+    programmeMembership2.setTrainingNumber(trainingNumber);
+
+    when(programmeMembershipRepositoryMock.findByTrainingNumber_Id(TRAININGNUMER_ID)).thenReturn(
+        Lists.newArrayList(programmeMembership1, programmeMembership2));
+  }
+
+  @Test
+  public void shouldHandleTrainingNumberSavedEvent() {
+    TrainingNumberSavedEvent savedEvent = new TrainingNumberSavedEvent(trainingNumberDto);
+    testObj.handleTrainingNumberSavedEvent(savedEvent);
+
+    verify(applicationEventPublisherMock, times(2)).publishEvent(eventArgumentCaptor.capture());
+    List<CurriculumMembershipSavedEvent> events = eventArgumentCaptor.getAllValues();
+
+    List<UUID> pmUuids = events.stream().map(e -> e.getProgrammeMembershipDTO().getUuid())
+        .collect(Collectors.toList());
+    Assert.assertTrue(pmUuids.containsAll(
+        Lists.newArrayList(PROGRAMME_MEMBERSHIP_UUID_1, PROGRAMME_MEMBERSHIP_UUID_2)));
+  }
+
+  @Test
+  public void shouldHandleTrainingNumberDeletedEvent() {
+    TrainingNumberDeletedEvent deletedEvent = new TrainingNumberDeletedEvent(trainingNumberDto);
+    testObj.handleTrainingNumberDeletedEvent(deletedEvent);
+
+    verify(applicationEventPublisherMock, times(2)).publishEvent(eventArgumentCaptor.capture());
+    List<CurriculumMembershipSavedEvent> events = eventArgumentCaptor.getAllValues();
+
+    List<UUID> pmUuids = events.stream().map(e -> e.getProgrammeMembershipDTO().getUuid())
+        .collect(Collectors.toList());
+    Assert.assertTrue(pmUuids.containsAll(
+        Lists.newArrayList(PROGRAMME_MEMBERSHIP_UUID_1, PROGRAMME_MEMBERSHIP_UUID_2)));
+  }
+}

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListenerTest.java
@@ -74,7 +74,7 @@ public class TrainingNumberElasticSearchEventListenerTest {
     programmeMembership2.setUuid(PROGRAMME_MEMBERSHIP_UUID_2);
     programmeMembership2.setTrainingNumber(trainingNumber);
 
-    when(programmeMembershipRepositoryMock.findByTrainingNumber_Id(TRAININGNUMER_ID)).thenReturn(
+    when(programmeMembershipRepositoryMock.findByTrainingNumberId(TRAININGNUMER_ID)).thenReturn(
         Lists.newArrayList(programmeMembership1, programmeMembership2));
   }
 


### PR DESCRIPTION
The initial refacotring from PM to CM is in this commit: https://github.com/Health-Education-England/TIS-TCS/commit/3fd3540

`TrainingNumber` is deprecated in CM, so we have to change the listener to use PM.

However, there's no entry to modify training numbers on TIS admin UI. And, in tcs-service, I'm not able to find anywhere who sends the `TrainingNumberXXXEvent`. Had a quick discussion with James before, and he also mentioned this functionality would be added in the future.

In this PR, I added a query in `ProgrammeMembershipRepository` as I thought we need it, but the current process doesn't modify the `trainingNumber` in PMs, which needs to be fixed when we start to implement this functionality.

TIS21-2388