### PR TITLE
feat: store signed COJ against PM ID

### DIFF
--- a/.aws/tis-tcs-nimdta.json
+++ b/.aws/tis-tcs-nimdta.json
@@ -172,6 +172,10 @@
         {
           "name": "REVAL_RABBIT_CURRENTPM_UPDATE_TCS",
           "valueFrom": "reval-rabbit-currentpm-queue-tcs-nimdta"
+        },
+        {
+          "name": "TRAINEE_RABBIT_COJ_SIGNED_QUEUE",
+          "valueFrom": "trainee-rabbit-coj-signed-queue-tcs-nimdta"
         }
       ],
       "logConfiguration": {

--- a/.aws/tis-tcs-preprod.json
+++ b/.aws/tis-tcs-preprod.json
@@ -172,6 +172,10 @@
         {
           "name": "REVAL_RABBIT_CURRENTPM_UPDATE_TCS",
           "valueFrom": "reval-rabbit-currentpm-queue-tcs-preprod"
+        },
+        {
+          "name": "TRAINEE_RABBIT_COJ_SIGNED_QUEUE",
+          "valueFrom": "trainee-rabbit-coj-signed-queue-tcs-preprod"
         }
       ],
       "logConfiguration": {

--- a/.aws/tis-tcs-prod.json
+++ b/.aws/tis-tcs-prod.json
@@ -172,6 +172,10 @@
         {
           "name": "REVAL_RABBIT_CURRENTPM_UPDATE_TCS",
           "valueFrom": "reval-rabbit-currentpm-queue-tcs-prod"
+        },
+        {
+          "name": "TRAINEE_RABBIT_COJ_SIGNED_QUEUE",
+          "valueFrom": "trainee-rabbit-coj-signed-queue-tcs-prod"
         }
       ],
       "logConfiguration": {

--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>6.16.2</version>
+  <version>6.17.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ConditionsOfJoiningDto.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ConditionsOfJoiningDto.java
@@ -1,0 +1,17 @@
+package com.transformuk.hee.tis.tcs.api.dto;
+
+import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Data;
+
+/**
+ * A DTO representation of a Conditions of Joining.
+ */
+@Data
+public class ConditionsOfJoiningDto {
+
+  private UUID programmeMembershipUuid;
+  private Instant signedAt;
+  private GoldGuideVersion version;
+}

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/enumeration/GoldGuideVersion.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/enumeration/GoldGuideVersion.java
@@ -1,0 +1,8 @@
+package com.transformuk.hee.tis.tcs.api.enumeration;
+
+/**
+ * An enumeration of supported Gold Guide versions.
+ */
+public enum GoldGuideVersion {
+  GG9
+}

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>6.0.2</version>
+  <version>6.0.3</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.16.2</version>
+      <version>6.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,12 +13,12 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.23.3</version>
+  <version>2.24.0</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.16.2</version>
+      <version>6.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ConditionsOfJoining.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ConditionsOfJoining.java
@@ -1,0 +1,26 @@
+package com.transformuk.hee.tis.tcs.service.model;
+
+import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
+import java.time.Instant;
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+
+/**
+ * A persistable representation of a Conditions of Joining.
+ */
+@Data
+@Entity
+public class ConditionsOfJoining {
+
+  @Id
+  @Type(type = "uuid-char")
+  private UUID programmeMembershipUuid;
+  private Instant signedAt;
+  @Enumerated(EnumType.STRING)
+  private GoldGuideVersion version;
+}

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ConditionsOfJoining.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/ConditionsOfJoining.java
@@ -18,7 +18,7 @@ import org.hibernate.annotations.Type;
 public class ConditionsOfJoining {
 
   @Id
-  @Type(type = "uuid-char")
+  @Type(type = "org.hibernate.type.UUIDCharType")
   private UUID programmeMembershipUuid;
   private Instant signedAt;
   @Enumerated(EnumType.STRING)

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ConditionsOfJoiningRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ConditionsOfJoiningRepository.java
@@ -1,0 +1,14 @@
+package com.transformuk.hee.tis.tcs.service.repository;
+
+import com.transformuk.hee.tis.tcs.service.model.ConditionsOfJoining;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * A JPA repository providing Conditions of Joining functionality.
+ */
+@Repository
+public interface ConditionsOfJoiningRepository extends JpaRepository<ConditionsOfJoining, UUID> {
+
+}

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.26.10</version>
+  <version>6.27.0</version>
 
   <dependencies>
     <dependency>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.23.3</version>
+      <version>2.24.0</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/event/ConditionsOfJoiningSignedEvent.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/event/ConditionsOfJoiningSignedEvent.java
@@ -1,0 +1,28 @@
+package com.transformuk.hee.tis.tcs.service.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
+
+/**
+ * An event to be received when a Conditions of Joining is signed.
+ */
+public class ConditionsOfJoiningSignedEvent {
+
+  @JsonProperty("programmeMembershipTisId")
+  private final Long programmeMembershipId;
+  private final ConditionsOfJoiningDto conditionsOfJoining;
+
+  public ConditionsOfJoiningSignedEvent(Long programmeMembershipId,
+      ConditionsOfJoiningDto conditionsOfJoining) {
+    this.programmeMembershipId = programmeMembershipId;
+    this.conditionsOfJoining = conditionsOfJoining;
+  }
+
+  public Long getProgrammeMembershipId() {
+    return programmeMembershipId;
+  }
+
+  public ConditionsOfJoiningDto getConditionsOfJoining() {
+    return conditionsOfJoining;
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
@@ -17,7 +17,7 @@ public class TraineeMessageListener {
     this.conditionsOfJoiningService = conditionsOfJoiningService;
   }
 
-  @RabbitListener(queues = "${app.rabbit.trainee.queue.coj.signed}", ackMode = "NONE")
+  @RabbitListener(queues = "${app.rabbit.trainee.queue.coj.signed}", ackMode = "AUTO")
   public void receiveMessage(final ConditionsOfJoiningSignedEvent event) {
     conditionsOfJoiningService.save(event.getProgrammeMembershipId(),
         event.getConditionsOfJoining());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
@@ -1,0 +1,25 @@
+package com.transformuk.hee.tis.tcs.service.message;
+
+import com.transformuk.hee.tis.tcs.service.event.ConditionsOfJoiningSignedEvent;
+import com.transformuk.hee.tis.tcs.service.service.impl.ConditionsOfJoiningService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * A listener for trainee focused events.
+ */
+@Component
+public class TraineeMessageListener {
+
+  private final ConditionsOfJoiningService conditionsOfJoiningService;
+
+  TraineeMessageListener(ConditionsOfJoiningService conditionsOfJoiningService) {
+    this.conditionsOfJoiningService = conditionsOfJoiningService;
+  }
+
+  @RabbitListener(queues = "${app.rabbit.trainee.queue.coj.signed}", ackMode = "NONE")
+  public void receiveMessage(final ConditionsOfJoiningSignedEvent event) {
+    conditionsOfJoiningService.save(event.getProgrammeMembershipId(),
+        event.getConditionsOfJoining());
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningService.java
@@ -1,0 +1,59 @@
+package com.transformuk.hee.tis.tcs.service.service.impl;
+
+import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
+import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
+import com.transformuk.hee.tis.tcs.service.model.ConditionsOfJoining;
+import com.transformuk.hee.tis.tcs.service.repository.ConditionsOfJoiningRepository;
+import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ConditionsOfJoiningMapper;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * A service providing Conditions of Joining functionality.
+ */
+@Service
+@Transactional
+public class ConditionsOfJoiningService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConditionsOfJoiningService.class);
+
+  private final ConditionsOfJoiningRepository repository;
+  private final ConditionsOfJoiningMapper mapper;
+  private final ProgrammeMembershipService programmeMembershipService;
+
+  @Autowired
+  public ConditionsOfJoiningService(ConditionsOfJoiningRepository repository,
+      ConditionsOfJoiningMapper mapper, ProgrammeMembershipService programmeMembershipService) {
+    this.repository = repository;
+    this.mapper = mapper;
+    this.programmeMembershipService = programmeMembershipService;
+  }
+
+  public ConditionsOfJoiningDto save(Long programmeMembershipId, ConditionsOfJoiningDto dto) {
+    LOG.info("Request received to save Conditions of Joining for Programme Membership {}.",
+        programmeMembershipId);
+
+    ProgrammeMembershipDTO programmeMembership = programmeMembershipService.findOne(
+        programmeMembershipId);
+
+    if (programmeMembership == null) {
+      throw new IllegalArgumentException(
+          String.format("Programme Membership %s not found.", programmeMembershipId));
+    }
+
+    UUID programmeMembershipUuid = programmeMembership.getUuid();
+    dto.setProgrammeMembershipUuid(programmeMembershipUuid);
+    LOG.info("Saving Conditions of Joining for Programme Membership with UUID {}.",
+        programmeMembershipUuid);
+    ConditionsOfJoining entity = repository.save(mapper.toEntity(dto));
+    LOG.info("Saved Conditions of Joining for Programme Membership with UUID {}.",
+        programmeMembershipUuid);
+
+    return mapper.toDto(entity);
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ConditionsOfJoiningMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ConditionsOfJoiningMapper.java
@@ -1,0 +1,16 @@
+package com.transformuk.hee.tis.tcs.service.service.mapper;
+
+import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
+import com.transformuk.hee.tis.tcs.service.model.ConditionsOfJoining;
+import org.mapstruct.Mapper;
+
+/**
+ * A mapper to convert between DTO and Entity representations of Conditions of Joining.
+ */
+@Mapper(componentModel = "spring")
+public interface ConditionsOfJoiningMapper {
+
+  ConditionsOfJoiningDto toDto(ConditionsOfJoining entity);
+
+  ConditionsOfJoining toEntity(ConditionsOfJoiningDto dto);
+}

--- a/tcs-service/src/main/resources/config/application-local.yml
+++ b/tcs-service/src/main/resources/config/application-local.yml
@@ -53,3 +53,4 @@ app:
     reval.routingKey.connection.update: ${REVAL_RABBIT_ROUTING_KEY:reval.connection.update}
     reval.routingKey.connection.syncstart: ${REVAL_RABBIT_SYNCSTART_ROUTING_KEY:reval.connection.syncstart}
     reval.routingKey.connection.syncdata: ${REVAL_RABBIT_SYNCDATA_ROUTING_KEY:reval.connection.syncdata}
+    trainee.queue.coj.signed: ${TRAINEE_RABBIT_COJ_SIGNED_QUEUE:trainee.queue.coj.signed.tcs}

--- a/tcs-service/src/main/resources/config/application.yml
+++ b/tcs-service/src/main/resources/config/application.yml
@@ -230,3 +230,5 @@ app:
     reval.routingKey.connection.update: ${REVAL_RABBIT_ROUTING_KEY}
     reval.routingKey.connection.syncstart: ${REVAL_RABBIT_SYNCSTART_ROUTING_KEY}
     reval.routingKey.connection.syncdata: ${REVAL_RABBIT_SYNCDATA_ROUTING_KEY}
+    trainee.queue.coj.signed: ${TRAINEE_RABBIT_COJ_SIGNED_QUEUE}
+

--- a/tcs-service/src/main/resources/db/migration/schema/V4.25__create_conditions_of_joining_table.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.25__create_conditions_of_joining_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE ConditionsOfJoining (
+  `programmeMembershipUuid` varchar(36) NOT NULL,
+  `signedAt` datetime(3) NOT NULL,
+  `version` enum('GG9') NOT NULL,
+  PRIMARY KEY (`programmeMembershipUuid`),
+  CONSTRAINT `fk_conditions_of_joining_programme_membership_uuid` FOREIGN KEY (`programmeMembershipUuid`) REFERENCES `ProgrammeMembership` (`uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListenerTest.java
@@ -1,0 +1,39 @@
+package com.transformuk.hee.tis.tcs.service.message;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
+import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
+import com.transformuk.hee.tis.tcs.service.event.ConditionsOfJoiningSignedEvent;
+import com.transformuk.hee.tis.tcs.service.service.impl.ConditionsOfJoiningService;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TraineeMessageListenerTest {
+
+  private static final Long ID = 40L;
+  private static final Instant SIGNED_AT = Instant.now();
+
+  private TraineeMessageListener listener;
+  private ConditionsOfJoiningService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(ConditionsOfJoiningService.class);
+    listener = new TraineeMessageListener(service);
+  }
+
+  @Test
+  void shouldSaveSignedCoj() {
+    ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
+    dto.setSignedAt(SIGNED_AT);
+    dto.setVersion(GoldGuideVersion.GG9);
+    ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(ID, dto);
+
+    listener.receiveMessage(event);
+
+    verify(service).save(ID, dto);
+  }
+}

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceTest.java
@@ -1,0 +1,98 @@
+package com.transformuk.hee.tis.tcs.service.service.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
+import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
+import com.transformuk.hee.tis.tcs.service.repository.ConditionsOfJoiningRepository;
+import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ConditionsOfJoiningMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class ConditionsOfJoiningServiceTest {
+
+  private static final Long CURRICULUM_MEMBERSHIP_ID = 40L;
+  private static final UUID PROGRAMME_MEMBERSHIP_UUID = UUID.randomUUID();
+  private static final Instant SIGNED_AT = Instant.now();
+
+  private ConditionsOfJoiningService conditionsOfJoiningService;
+  private ConditionsOfJoiningRepository repository;
+  private ProgrammeMembershipService programmeMembershipService;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(ConditionsOfJoiningRepository.class);
+    ConditionsOfJoiningMapper mapper = Mappers.getMapper(ConditionsOfJoiningMapper.class);
+    programmeMembershipService = mock(ProgrammeMembershipService.class);
+
+    conditionsOfJoiningService = new ConditionsOfJoiningService(repository, mapper,
+        programmeMembershipService);
+  }
+
+  @Test
+  void saveShouldThrowExceptionWhenProgrammeMembershipIdNotFound() {
+    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
+    coj.setSignedAt(SIGNED_AT);
+    coj.setVersion(GoldGuideVersion.GG9);
+
+    when(programmeMembershipService.findOne(CURRICULUM_MEMBERSHIP_ID)).thenReturn(null);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> conditionsOfJoiningService.save(CURRICULUM_MEMBERSHIP_ID, coj));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void saveShouldSaveTheConditionsOfJoiningAgainstTheProgrammeMembership() {
+    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
+    coj.setSignedAt(SIGNED_AT);
+    coj.setVersion(GoldGuideVersion.GG9);
+
+    ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
+    programmeMembershipDto.setUuid(PROGRAMME_MEMBERSHIP_UUID);
+
+    when(programmeMembershipService.findOne(CURRICULUM_MEMBERSHIP_ID)).thenReturn(
+        programmeMembershipDto);
+    when(repository.save(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
+
+    ConditionsOfJoiningDto savedCoj = conditionsOfJoiningService.save(CURRICULUM_MEMBERSHIP_ID,
+        coj);
+
+    assertThat("Unexpected programme membership uuid.", savedCoj.getProgrammeMembershipUuid(),
+        is(PROGRAMME_MEMBERSHIP_UUID));
+    assertThat("Unexpected programme membership uuid.", savedCoj.getSignedAt(), is(SIGNED_AT));
+    assertThat("Unexpected programme membership uuid.", savedCoj.getVersion(),
+        is(GoldGuideVersion.GG9));
+  }
+
+  @Test
+  void saveShouldReplaceAnyProvidedProgrammeMembershipUuid() {
+    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
+    coj.setProgrammeMembershipUuid(UUID.randomUUID());
+
+    ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
+    programmeMembershipDto.setUuid(PROGRAMME_MEMBERSHIP_UUID);
+
+    when(programmeMembershipService.findOne(CURRICULUM_MEMBERSHIP_ID)).thenReturn(
+        programmeMembershipDto);
+    when(repository.save(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
+
+    ConditionsOfJoiningDto savedCoj = conditionsOfJoiningService.save(CURRICULUM_MEMBERSHIP_ID,
+        coj);
+
+    assertThat("Unexpected programme membership uuid.", savedCoj.getProgrammeMembershipUuid(),
+        is(PROGRAMME_MEMBERSHIP_UUID));
+  }
+}

--- a/tcs-service/src/test/resources/config/application.yml
+++ b/tcs-service/src/test/resources/config/application.yml
@@ -125,3 +125,4 @@ app:
     reval.routingKey.connection.update: ${REVAL_RABBIT_ROUTING_KEY:reval.connection.update}
     reval.routingKey.connection.syncstart: ${REVAL_RABBIT_SYNCSTART_ROUTING_KEY:reval.connection.syncstart}
     reval.routingKey.connection.syncdata: ${REVAL_RABBIT_SYNCDATA_ROUTING_KEY:reval.connection.syncdata}
+    trainee.queue.coj.signed: ${TRAINEE_RABBIT_COJ_SIGNED_QUEUE:trainee.queue.coj.signed.tcs}

--- a/tcs-service/src/test/resources/db/migration/schema/V4.25__create_conditions_of_joining_table.sql
+++ b/tcs-service/src/test/resources/db/migration/schema/V4.25__create_conditions_of_joining_table.sql
@@ -1,0 +1,1 @@
+/* The uuid field is not available on ProgrammeMembership, so we cannot test this migration. */


### PR DESCRIPTION
Listener for COJ signed events and persist the `signedAt` timestamp and COJ version against the associated ProgrammeMembership UUID.

Ideally this would be persisted via the ProgrammeMembership itself, however there were issues saving the ProgrammeMembershipDto retrieved from the database.
This approach allows us to capture the signed COJ to avoid losing data, given time to come back and resolve the PM persistence when we add the COJ data to the ProgrammeMembershipDto.

TIS21-4431
TIS21-4375