### PR TITLE
fix: do not requeue COJ sign event when invalid

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.27.0</version>
+  <version>6.27.1</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
@@ -2,6 +2,7 @@ package com.transformuk.hee.tis.tcs.service.message;
 
 import com.transformuk.hee.tis.tcs.service.event.ConditionsOfJoiningSignedEvent;
 import com.transformuk.hee.tis.tcs.service.service.impl.ConditionsOfJoiningService;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +20,12 @@ public class TraineeMessageListener {
 
   @RabbitListener(queues = "${app.rabbit.trainee.queue.coj.signed}", ackMode = "AUTO")
   public void receiveMessage(final ConditionsOfJoiningSignedEvent event) {
-    conditionsOfJoiningService.save(event.getProgrammeMembershipId(),
-        event.getConditionsOfJoining());
+    try {
+      conditionsOfJoiningService.save(event.getProgrammeMembershipId(),
+          event.getConditionsOfJoining());
+    } catch (IllegalArgumentException e) {
+      // Do not requeue the message if the event arguments are not valid.
+      throw new AmqpRejectAndDontRequeueException(e);
+    }
   }
 }


### PR DESCRIPTION
If a programme is not found for the signed Conditions of Joining an `IllegalArgumentException` is throw. However, this causes the message to be requeued instead of going to the DLQ.
To ensure that the message correctly goes to the DLQ the exception should be caught and rethrown as a `AmqpRejectAndDontRequeueException`.

TIS21-4551
TIS21-4550