### PR TITLE
feat: exclude unknown gmc ids from reval sync and cdc

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.24.0</version>
+  <version>2.25.0</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -14,6 +14,8 @@ from (
   from
     ContactDetails cd
   left join GmcDetails gmc on (gmc.id = cd.id)
+  and gmc.id is not null
+  and not lower(gmc.id) = "unknown"
   left join (
     -- count current PMs with combined programme names for each person
     select
@@ -40,7 +42,6 @@ from (
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   WHERECLAUSE(cd, id)
   ) as ot
-where not lower(gmc.id) = "unknown"
 ORDERBYCLAUSE
 LIMITCLAUSE
 ;

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -14,8 +14,8 @@ from (
   from
     ContactDetails cd
   left join GmcDetails gmc on (gmc.id = cd.id)
-  and gmc.id is not null
-  and not lower(gmc.id) = "unknown"
+  and gmc.gmcNumber is not null
+  and not lower(gmc.gmcNumber) = "unknown"
   left join (
     -- count current PMs with combined programme names for each person
     select

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -13,8 +13,7 @@ from (
     if(currentPmCounts.count_num > 1, NULL, currentPmCounts.owner) as owner
   from
     ContactDetails cd
-  left join GmcDetails gmc on (gmc.id = cd.id)
-  and gmc.gmcNumber is not null
+  inner join GmcDetails gmc on (gmc.id = cd.id)
   and not lower(gmc.gmcNumber) = "unknown"
   left join (
     -- count current PMs with combined programme names for each person

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -14,7 +14,8 @@ from (
   from
     ContactDetails cd
   inner join GmcDetails gmc on (gmc.id = cd.id)
-  and not lower(gmc.gmcNumber) = "unknown"
+   -- note: null values are filtered out by the condition below
+  and lower(gmc.gmcNumber) <> 'unknown'
   left join (
     -- count current PMs with combined programme names for each person
     select

--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -40,6 +40,7 @@ from (
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   WHERECLAUSE(cd, id)
   ) as ot
+where not lower(gmc.id) = "unknown"
 ORDERBYCLAUSE
 LIMITCLAUSE
 ;

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.24.0</version>
+      <version>2.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
TIS21-4555 UNKNOWN doctors should not be in the revalidation system