### PR TITLE
refactor:programme membership

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.28.2</version>
+  <version>6.28.3</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -61,14 +61,14 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   /**
    * Initialise the ProgrammeMembershipService.
    *
-   * @param programmeMembershipRepository   the ProgrammeMembershipRepository
-   * @param curriculumMembershipRepository  the CurriculumMembershipRepository
-   * @param programmeMembershipMapper       the ProgrammeMembershipMapper
-   * @param curriculumMembershipMapper      the CurriculumMembershipMapper
-   * @param curriculumRepository            the CurriculumRepository
-   * @param curriculumMapper                the CurriculumMapper
-   * @param applicationEventPublisher       the ApplicationEventPublisher
-   * @param personRepository                the PersonRepository
+   * @param programmeMembershipRepository  the ProgrammeMembershipRepository
+   * @param curriculumMembershipRepository the CurriculumMembershipRepository
+   * @param programmeMembershipMapper      the ProgrammeMembershipMapper
+   * @param curriculumMembershipMapper     the CurriculumMembershipMapper
+   * @param curriculumRepository           the CurriculumRepository
+   * @param curriculumMapper               the CurriculumMapper
+   * @param applicationEventPublisher      the ApplicationEventPublisher
+   * @param personRepository               the PersonRepository
    */
   public ProgrammeMembershipServiceImpl(
       ProgrammeMembershipRepository programmeMembershipRepository,
@@ -106,12 +106,12 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     ProgrammeMembershipDTO programmeMembershipSavedDto
         = programmeMembershipMapper.toDto(programmeMembership);
 
-    //emit events
+    // update Person status
     updatePersonWhenStatusIsStale(programmeMembershipSavedDto.getPerson().getId());
-    List<ProgrammeMembershipDTO> resultDtos
-        = Collections.singletonList(programmeMembershipSavedDto);
-    emitProgrammeMembershipSavedEvents(resultDtos);
-    return CollectionUtils.isNotEmpty(resultDtos) ? resultDtos.get(0) : null;
+    //emit events
+    emitProgrammeMembershipSavedEvents(Collections.singletonList(programmeMembershipSavedDto));
+
+    return programmeMembershipSavedDto;
   }
 
   /**
@@ -132,10 +132,13 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
       updatePersonWhenStatusIsStale(programmeMembership.getPerson().getId());
     });
 
-    //emit events
     List<ProgrammeMembershipDTO> resultDtos =
         programmeMembershipMapper
             .programmeMembershipsToProgrammeMembershipDTOs(programmeMemberships);
+
+    // update Person status
+    resultDtos.forEach(dto -> updatePersonWhenStatusIsStale(dto.getPerson().getId()));
+    //emit events
     emitProgrammeMembershipSavedEvents(resultDtos);
     return resultDtos;
   }
@@ -180,8 +183,8 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   }
 
   /**
-   * Delete the curriculumMembership by id.
-   * NOTE: this is the curriculumMembership, not the containing programmeMembership
+   * Delete the curriculumMembership by id. NOTE: this is the curriculumMembership, not the
+   * containing programmeMembership
    *
    * @param id the id of the entity
    */
@@ -298,11 +301,11 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     return pmc ->
         Objects.equals(pmc.getProgrammeId(), programmeMembershipCurriculaDto.getProgrammeId())
             && Objects.equals(pmc.getProgrammeMembershipType(),
-                programmeMembershipCurriculaDto.getProgrammeMembershipType())
+            programmeMembershipCurriculaDto.getProgrammeMembershipType())
             && Objects.equals(pmc.getProgrammeStartDate(),
-                programmeMembershipCurriculaDto.getProgrammeStartDate())
+            programmeMembershipCurriculaDto.getProgrammeStartDate())
             && Objects.equals(pmc.getProgrammeEndDate(),
-                programmeMembershipCurriculaDto.getProgrammeEndDate());
+            programmeMembershipCurriculaDto.getProgrammeEndDate());
   }
 
   @Transactional(readOnly = true)

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -117,28 +117,25 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   /**
    * Save a list of programmeMembership.
    *
-   * @param programmeMembershipDto the list of entities to save
+   * @param programmeMembershipDtos the list of entities to save
    * @return the list of persisted entities
    */
   @Override
-  public List<ProgrammeMembershipDTO> save(List<ProgrammeMembershipDTO> programmeMembershipDto) {
-    log.debug("Request to save ProgrammeMembership : {}", programmeMembershipDto);
+  public List<ProgrammeMembershipDTO> save(List<ProgrammeMembershipDTO> programmeMembershipDtos) {
+    log.debug("Request to save ProgrammeMembership : {}", programmeMembershipDtos);
 
     List<ProgrammeMembership> programmeMemberships =
         programmeMembershipMapper
-            .programmeMembershipDTOsToProgrammeMemberships(programmeMembershipDto);
+            .programmeMembershipDTOsToProgrammeMemberships(programmeMembershipDtos);
     programmeMemberships.forEach(programmeMembership -> {
       programmeMembership = programmeMembershipRepository.save(programmeMembership);
       updatePersonWhenStatusIsStale(programmeMembership.getPerson().getId());
     });
 
+    //emit events
     List<ProgrammeMembershipDTO> resultDtos =
         programmeMembershipMapper
             .programmeMembershipsToProgrammeMembershipDTOs(programmeMemberships);
-
-    // update Person status
-    resultDtos.forEach(dto -> updatePersonWhenStatusIsStale(dto.getPerson().getId()));
-    //emit events
     emitProgrammeMembershipSavedEvents(resultDtos);
     return resultDtos;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -1,13 +1,11 @@
 package com.transformuk.hee.tis.tcs.service.service.mapper;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.RotationDTO;
 import com.transformuk.hee.tis.tcs.service.model.ConditionsOfJoining;
-import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
@@ -18,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
@@ -82,7 +79,7 @@ public class ProgrammeMembershipMapper {
    */
   public List<ProgrammeMembershipDTO> allEntityToDto(
       List<ProgrammeMembership> programmeMemberships) {
-    List<ProgrammeMembershipDTO> result = Lists.newArrayList();
+    List<ProgrammeMembershipDTO> result = new ArrayList<>();
 
     programmeMemberships.forEach(
         pm -> pm.getCurriculumMemberships().forEach(cm -> {
@@ -204,7 +201,7 @@ public class ProgrammeMembershipMapper {
         trainingNumberMapper.trainingNumberToTrainingNumberDTO(entity.getTrainingNumber()));
     dto.setPerson(personToPersonDTO(entity.getPerson()));
 
-    dto.setCurriculumMemberships(Lists.newArrayList());
+    dto.setCurriculumMemberships(new ArrayList<>());
 
     if (dto.getUuid() != null) {
       Optional<ConditionsOfJoining> conditionsOfJoiningOptional
@@ -217,17 +214,9 @@ public class ProgrammeMembershipMapper {
 
   private List<CurriculumMembershipDTO> programmeMembershipToCurriculumMembershipDtos(
       ProgrammeMembership programmeMembership) {
-    List<CurriculumMembershipDTO> curriculumMembershipDtos = Lists.newArrayList();
-    Set<CurriculumMembership> curriculumMemberships
-        = programmeMembership.getCurriculumMemberships();
-
-    curriculumMemberships.forEach(cm -> {
-      CurriculumMembershipDTO cmDto =
-          curriculumMembershipMapper.curriculumMembershipToCurriculumMembershipDto(cm);
-      curriculumMembershipDtos.add(cmDto);
-    });
-
-    return curriculumMembershipDtos;
+    return programmeMembership.getCurriculumMemberships().stream()
+        .map(curriculumMembershipMapper::curriculumMembershipToCurriculumMembershipDto)
+        .collect(Collectors.toList());
   }
 
   private PersonDTO personToPersonDTO(Person person) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -6,14 +6,12 @@ import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.RotationDTO;
-import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
 import com.transformuk.hee.tis.tcs.service.model.ConditionsOfJoining;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
 import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.Rotation;
-import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
 import com.transformuk.hee.tis.tcs.service.repository.ConditionsOfJoiningRepository;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -22,8 +20,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Mapper for the entity ProgrammeMembership and its DTO ProgrammeMembershipDTO.
@@ -34,74 +32,92 @@ public class ProgrammeMembershipMapper {
   CurriculumMembershipMapper curriculumMembershipMapper;
   ConditionsOfJoiningMapper conditionsOfJoiningMapper;
   ConditionsOfJoiningRepository conditionsOfJoiningRepository;
+  TrainingNumberMapper trainingNumberMapper;
+  RotationMapper rotationMapper;
 
   /**
    * Initialise the ProgrammeMembership mapper.
    *
-   * @param curriculumMembershipMapper the Curriculum Membership mapper
-   * @param conditionsOfJoiningMapper the Conditions of Joining mapper
+   * @param curriculumMembershipMapper    the Curriculum Membership mapper
+   * @param conditionsOfJoiningMapper     the Conditions of Joining mapper
    * @param conditionsOfJoiningRepository the Conditions of Joining repository
    */
   public ProgrammeMembershipMapper(CurriculumMembershipMapper curriculumMembershipMapper,
       ConditionsOfJoiningMapper conditionsOfJoiningMapper,
-      ConditionsOfJoiningRepository conditionsOfJoiningRepository) {
+      ConditionsOfJoiningRepository conditionsOfJoiningRepository,
+      TrainingNumberMapper trainingNumberMapper,
+      RotationMapper rotationMapper) {
     this.curriculumMembershipMapper = curriculumMembershipMapper;
     this.conditionsOfJoiningMapper = conditionsOfJoiningMapper;
     this.conditionsOfJoiningRepository = conditionsOfJoiningRepository;
+    this.trainingNumberMapper = trainingNumberMapper;
+    this.rotationMapper = rotationMapper;
   }
 
-  public ProgrammeMembershipDTO toDto(ProgrammeMembership programmeMembership) {
-    ProgrammeMembershipDTO result = null;
-    if (programmeMembership != null) {
-      result = programmeMembershipToProgrammeMembershipDTO(programmeMembership);
-      if (CollectionUtils.isEmpty(result.getCurriculumMemberships())) {
-        result.setCurriculumMemberships(Lists.newArrayList());
-      }
-      result.getCurriculumMemberships()
-          .addAll(programmeMembershipToCurriculumMembershipDtos(programmeMembership));
+  /**
+   * Convert a programmeMembership entity to DTO with all currculumMemberships
+   *
+   * @param pm programmeMembership entity
+   * @return pmDto programmeMembership dto
+   */
+  public ProgrammeMembershipDTO toDto(ProgrammeMembership pm) {
+    ProgrammeMembershipDTO pmDto = null;
+    if (pm != null) {
+      pmDto = programmeMembershipToProgrammeMembershipDTO(pm);
+      pmDto.getCurriculumMemberships()
+          .addAll(programmeMembershipToCurriculumMembershipDtos(pm));
     }
-    return result;
+    return pmDto;
   }
 
+  /**
+   * Convert programmeMembership from entities to DTOs, and flatten every curriculumMembership in
+   * programmeMemberships.
+   * <p>
+   * So the returned ProgrammeMembershipDTO list can contain the same programmeMembershipDTOs Under
+   * each of ProgrammeMembershipDTO, there will be only one CurriculumMembershipDTO.
+   *
+   * @param programmeMemberships
+   * @return ProgrammeMembershipDTO list
+   */
   public List<ProgrammeMembershipDTO> allEntityToDto(
       List<ProgrammeMembership> programmeMemberships) {
     List<ProgrammeMembershipDTO> result = Lists.newArrayList();
 
-    for (ProgrammeMembership programmeMembership : programmeMemberships) {
-      for (CurriculumMembership curriculumMembership
-          : programmeMembership.getCurriculumMemberships()) {
-        ProgrammeMembershipDTO programmeMembershipDto
-            = programmeMembershipToProgrammeMembershipDTO(programmeMembership);
-        programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
-        CurriculumMembershipDTO curriculumMembershipDto
-            = curriculumMembershipMapper
-            .curriculumMembershipToCurriculumMembershipDto(curriculumMembership);
-        programmeMembershipDto.getCurriculumMemberships()
-            .add(curriculumMembershipDto);
-        result.add(programmeMembershipDto);
-      }
-    }
+    programmeMemberships.forEach(
+        pm -> pm.getCurriculumMemberships().forEach(cm -> {
+          ProgrammeMembershipDTO pmDto = programmeMembershipToProgrammeMembershipDTO(pm);
+          CurriculumMembershipDTO cmDto
+              = curriculumMembershipMapper.curriculumMembershipToCurriculumMembershipDto(cm);
+          pmDto.getCurriculumMemberships().add(cmDto);
+          result.add(pmDto);
+        }));
 
     return result;
   }
 
+  /**
+   * Convert programmeMembership from entities to DTOS, and roll up curriculumMembership for the
+   * same programmeMembership.
+   * <p>
+   * So the returned ProgrammeMembershipDTO list contains unique ProgrammeMembershipDTOs Under each
+   * of ProgrammeMembershipDTO, there can be multiple CurriculumMembershipDTOs.
+   *
+   * @param programmeMemberships
+   * @return ProgrammeMembershipDTO list
+   */
   public List<ProgrammeMembershipDTO> programmeMembershipsToProgrammeMembershipDTOs(
       List<ProgrammeMembership> programmeMemberships) {
     Map<UUID, ProgrammeMembershipDTO> listMap = Maps.newHashMap();
 
-    for (ProgrammeMembership programmeMembership : programmeMemberships) {
-      ProgrammeMembershipDTO programmeMembershipDto
-          = programmeMembershipToProgrammeMembershipDTO(programmeMembership);
-      if (listMap.containsKey(programmeMembershipDto.getUuid())) {
-        programmeMembershipDto = listMap.get(programmeMembershipDto.getUuid());
+    programmeMemberships.forEach(pm -> {
+      ProgrammeMembershipDTO pmDto = programmeMembershipToProgrammeMembershipDTO(pm);
+      if (listMap.containsKey(pmDto.getUuid())) {
+        pmDto = listMap.get(pmDto.getUuid());
       }
-      if (CollectionUtils.isEmpty(programmeMembershipDto.getCurriculumMemberships())) {
-        programmeMembershipDto.setCurriculumMemberships(Lists.newArrayList());
-      }
-      programmeMembershipDto.getCurriculumMemberships()
-          .addAll(programmeMembershipToCurriculumMembershipDtos(programmeMembership));
-      listMap.put(programmeMembershipDto.getUuid(), programmeMembershipDto);
-    }
+      pmDto.getCurriculumMemberships().addAll(programmeMembershipToCurriculumMembershipDtos(pm));
+      listMap.put(pmDto.getUuid(), pmDto);
+    });
 
     return new ArrayList<>(listMap.values());
   }
@@ -109,91 +125,94 @@ public class ProgrammeMembershipMapper {
   /**
    * Covert a ProgrammeMembershipDTO to a ProgrammeMembership, including its CurriculumMemberships.
    *
-   * @param programmeMembershipDto the ProgrammeMembershipDTO to convert
+   * @param dto the ProgrammeMembershipDTO to convert
    * @return the ProgrammeMembership entity
    */
-  public ProgrammeMembership toEntity(ProgrammeMembershipDTO programmeMembershipDto) {
-    ProgrammeMembership result = new ProgrammeMembership();
+  public ProgrammeMembership toEntity(ProgrammeMembershipDTO dto) {
+    ProgrammeMembership entity = new ProgrammeMembership();
 
-    result.setUuid(programmeMembershipDto.getUuid()); //use real (database) ID
-    result.setProgrammeMembershipType(programmeMembershipDto.getProgrammeMembershipType());
-    result.setProgrammeStartDate(programmeMembershipDto.getProgrammeStartDate());
-    result.setProgrammeEndDate(programmeMembershipDto.getProgrammeEndDate());
-    result.setLeavingReason(programmeMembershipDto.getLeavingReason());
-    result.setTrainingPathway(programmeMembershipDto.getTrainingPathway());
-    result.setAmendedDate(programmeMembershipDto.getAmendedDate());
+    entity.setUuid(dto.getUuid()); //use real (database) ID
+    entity.setProgrammeMembershipType(dto.getProgrammeMembershipType());
+    entity.setProgrammeStartDate(dto.getProgrammeStartDate());
+    entity.setProgrammeEndDate(dto.getProgrammeEndDate());
+    entity.setLeavingReason(dto.getLeavingReason());
+    entity.setTrainingPathway(dto.getTrainingPathway());
+    entity.setAmendedDate(dto.getAmendedDate());
+
     Programme programme = null;
-    if (programmeMembershipDto.getProgrammeId() != null) {
+    if (dto.getProgrammeId() != null) {
       programme = new Programme();
-      programme.setId(programmeMembershipDto.getProgrammeId());
-      programme.setProgrammeName(programmeMembershipDto.getProgrammeName());
-      programme.setOwner(programmeMembershipDto.getProgrammeOwner());
-      programme.setProgrammeNumber(programmeMembershipDto.getProgrammeNumber());
-      result.setRotation(rotationDTOToRotation(programmeMembershipDto.getRotation()));
+      programme.setId(dto.getProgrammeId());
+      programme.setProgrammeName(dto.getProgrammeName());
+      programme.setOwner(dto.getProgrammeOwner());
+      programme.setProgrammeNumber(dto.getProgrammeNumber());
+      entity.setRotation(rotationMapper.toEntity(dto.getRotation()));
     }
-    result.setProgramme(programme);
-    result.setTrainingNumber(
-        trainingNumberDTOToTrainingNumber(programmeMembershipDto.getTrainingNumber()));
-    result.setPerson(personDTOToPerson(programmeMembershipDto.getPerson()));
+    entity.setProgramme(programme);
 
-    if (programmeMembershipDto.getCurriculumMemberships() == null) {
-      result.setCurriculumMemberships(new HashSet<>());
-    }
-    result.getCurriculumMemberships()
-        .addAll(curriculumMembershipMapper.toEntity(programmeMembershipDto));
-    result.getCurriculumMemberships().forEach(cm -> cm.setProgrammeMembership(result));
-    return result;
+    entity.setTrainingNumber(
+        trainingNumberMapper.trainingNumberDTOToTrainingNumber(dto.getTrainingNumber()));
+    entity.setPerson(personDTOToPerson(dto.getPerson()));
+
+    entity.setCurriculumMemberships(new HashSet<>());
+    entity.getCurriculumMemberships()
+        .addAll(curriculumMembershipMapper.toEntity(dto));
+    entity.getCurriculumMemberships().forEach(cm -> cm.setProgrammeMembership(entity));
+    return entity;
   }
 
+  /**
+   * Convert ProgrammeMembership DTOs to entities by using {@link #toEntity(ProgrammeMembershipDTO)}
+   * for each DTO.
+   *
+   * @param pmDtos list of ProgrammeMembershipDTO
+   * @return
+   */
   public List<ProgrammeMembership> programmeMembershipDTOsToProgrammeMemberships(
-      List<ProgrammeMembershipDTO> programmeMembershipDTOs) {
-    List<ProgrammeMembership> result = Lists.newArrayList();
-
-    for (ProgrammeMembershipDTO programmeMembershipDto : programmeMembershipDTOs) {
-      result.add(toEntity(programmeMembershipDto));
-    }
-
-    return result;
+      List<ProgrammeMembershipDTO> pmDtos) {
+    return pmDtos.stream().map(pmDto -> toEntity(pmDto)).collect(Collectors.toList());
   }
 
+  // convert programmeMembership entity to DTO with an empty curriculumMembership list
   private ProgrammeMembershipDTO programmeMembershipToProgrammeMembershipDTO(
-      ProgrammeMembership programmeMembership) {
-    ProgrammeMembershipDTO result = new ProgrammeMembershipDTO();
+      ProgrammeMembership entity) {
+    ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
 
-    if (!programmeMembership.getCurriculumMemberships().isEmpty()) {
-      //Preserve backward-compatibility
-      result.setId(programmeMembership.getCurriculumMemberships().iterator().next().getId());
+    if (!entity.getCurriculumMemberships().isEmpty()) {
+      //Preserve backward-compatibility, set ID in DTO to the ID of the first curriculumMembership
+      dto.setId(entity.getCurriculumMemberships().iterator().next().getId());
     }
-    result.setUuid(programmeMembership.getUuid());
-    result.setProgrammeMembershipType(programmeMembership.getProgrammeMembershipType());
-    result.setProgrammeStartDate(programmeMembership.getProgrammeStartDate());
-    result.setProgrammeEndDate(programmeMembership.getProgrammeEndDate());
-    result.setLeavingReason(programmeMembership.getLeavingReason());
-    result.setAmendedDate(programmeMembership.getAmendedDate());
-    Programme programme = programmeMembership.getProgramme();
+
+    dto.setUuid(entity.getUuid());
+    dto.setProgrammeMembershipType(entity.getProgrammeMembershipType());
+    dto.setProgrammeStartDate(entity.getProgrammeStartDate());
+    dto.setProgrammeEndDate(entity.getProgrammeEndDate());
+    dto.setLeavingReason(entity.getLeavingReason());
+    dto.setAmendedDate(entity.getAmendedDate());
+    dto.setTrainingPathway(entity.getTrainingPathway());
+
+    Programme programme = entity.getProgramme();
     if (programme != null) {
-      result.setProgrammeId(programme.getId());
-      result.setProgrammeOwner(programme.getOwner());
-      result.setProgrammeName(programme.getProgrammeName());
-      result.setProgrammeNumber(programme.getProgrammeNumber());
-      result.setRotation(rotationToRotationDTO(programmeMembership.getRotation(), programme));
+      dto.setProgrammeId(programme.getId());
+      dto.setProgrammeOwner(programme.getOwner());
+      dto.setProgrammeName(programme.getProgrammeName());
+      dto.setProgrammeNumber(programme.getProgrammeNumber());
+      dto.setRotation(rotationToRotationDTO(entity.getRotation(), programme));
     }
-    result.setTrainingNumber(
-        trainingNumberToTrainingNumberDTO(programmeMembership.getTrainingNumber()));
 
-    if (programmeMembership.getPerson() == null) {
-      result.setPerson(null);
-    } else {
-      result.setPerson(personToPersonDTO(programmeMembership.getPerson()));
-    }
-    result.setTrainingPathway(programmeMembership.getTrainingPathway());
-    if (result.getUuid() != null) {
+    dto.setTrainingNumber(
+        trainingNumberMapper.trainingNumberToTrainingNumberDTO(entity.getTrainingNumber()));
+    dto.setPerson(personToPersonDTO(entity.getPerson()));
+
+    dto.setCurriculumMemberships(Lists.newArrayList());
+
+    if (dto.getUuid() != null) {
       Optional<ConditionsOfJoining> conditionsOfJoiningOptional
-          = conditionsOfJoiningRepository.findById(result.getUuid());
-      conditionsOfJoiningOptional.ifPresent(c -> result.setConditionsOfJoining(
+          = conditionsOfJoiningRepository.findById(dto.getUuid());
+      conditionsOfJoiningOptional.ifPresent(c -> dto.setConditionsOfJoining(
           conditionsOfJoiningMapper.toDto(c)));
     }
-    return result;
+    return dto;
   }
 
   private List<CurriculumMembershipDTO> programmeMembershipToCurriculumMembershipDtos(
@@ -203,17 +222,8 @@ public class ProgrammeMembershipMapper {
         = programmeMembership.getCurriculumMemberships();
 
     curriculumMemberships.forEach(cm -> {
-      CurriculumMembershipDTO cmDto = new CurriculumMembershipDTO();
-
-      cmDto.setId(cm.getId());
-      cmDto.setIntrepidId(cm.getIntrepidId());
-      cmDto.setCurriculumStartDate(cm.getCurriculumStartDate());
-      cmDto.setCurriculumEndDate(cm.getCurriculumEndDate());
-      cmDto.setPeriodOfGrace(cm.getPeriodOfGrace());
-      cmDto.setCurriculumCompletionDate(cm.getCurriculumCompletionDate());
-      cmDto.setCurriculumId(cm.getCurriculumId());
-      cmDto.setAmendedDate(cm.getAmendedDate());
-
+      CurriculumMembershipDTO cmDto =
+          curriculumMembershipMapper.curriculumMembershipToCurriculumMembershipDto(cm);
       curriculumMembershipDtos.add(cmDto);
     });
 
@@ -259,28 +269,7 @@ public class ProgrammeMembershipMapper {
     return result;
   }
 
-  private TrainingNumberDTO trainingNumberToTrainingNumberDTO(TrainingNumber trainingNumber) {
-    TrainingNumberDTO result = null;
-    if (trainingNumber != null) {
-      result = new TrainingNumberDTO();
-      result.setId(trainingNumber.getId());
-      result.setIntrepidId(trainingNumber.getIntrepidId());
-      result.setTrainingNumber(trainingNumber.getTrainingNumber());
-    }
-    return result;
-  }
-
-  private TrainingNumber trainingNumberDTOToTrainingNumber(TrainingNumberDTO trainingNumberDTO) {
-    TrainingNumber result = null;
-    if (trainingNumberDTO != null) {
-      result = new TrainingNumber();
-      result.setId(trainingNumberDTO.getId());
-      result.setIntrepidId(trainingNumberDTO.getIntrepidId());
-      result.setTrainingNumber(trainingNumberDTO.getTrainingNumber());
-    }
-    return result;
-  }
-
+  // map rotation entity to DTO with programme details
   private RotationDTO rotationToRotationDTO(Rotation rotation, Programme programme) {
     RotationDTO result = null;
     if (rotation != null) {
@@ -291,18 +280,6 @@ public class ProgrammeMembershipMapper {
       result.setProgrammeName(programme.getProgrammeName());
       result.setProgrammeNumber(programme.getProgrammeNumber());
       result.setStatus(rotation.getStatus());
-    }
-    return result;
-  }
-
-  private Rotation rotationDTOToRotation(RotationDTO rotationDTO) {
-    Rotation result = null;
-    if (rotationDTO != null) {
-      result = new Rotation();
-      result.setId(rotationDTO.getId());
-      result.setProgrammeId(rotationDTO.getProgrammeId());
-      result.setName(rotationDTO.getName());
-      result.setStatus(rotationDTO.getStatus());
     }
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapper.java
@@ -55,7 +55,7 @@ public class ProgrammeMembershipMapper {
   }
 
   /**
-   * Convert a programmeMembership entity to DTO with all currculumMemberships
+   * Convert a programmeMembership entity to DTO with all currculumMemberships.
    *
    * @param pm programmeMembership entity
    * @return pmDto programmeMembership dto
@@ -73,11 +73,11 @@ public class ProgrammeMembershipMapper {
   /**
    * Convert programmeMembership from entities to DTOs, and flatten every curriculumMembership in
    * programmeMemberships.
-   * <p>
-   * So the returned ProgrammeMembershipDTO list can contain the same programmeMembershipDTOs Under
-   * each of ProgrammeMembershipDTO, there will be only one CurriculumMembershipDTO.
    *
-   * @param programmeMemberships
+   * <p>So the returned ProgrammeMembershipDTO list can contain the same programmeMembershipDTOs
+   * under each of ProgrammeMembershipDTO, there will be only one CurriculumMembershipDTO.
+   *
+   * @param programmeMemberships list of programmeMembership entities to convert
    * @return ProgrammeMembershipDTO list
    */
   public List<ProgrammeMembershipDTO> allEntityToDto(
@@ -99,11 +99,11 @@ public class ProgrammeMembershipMapper {
   /**
    * Convert programmeMembership from entities to DTOS, and roll up curriculumMembership for the
    * same programmeMembership.
-   * <p>
-   * So the returned ProgrammeMembershipDTO list contains unique ProgrammeMembershipDTOs Under each
-   * of ProgrammeMembershipDTO, there can be multiple CurriculumMembershipDTOs.
    *
-   * @param programmeMemberships
+   * <p>So the returned ProgrammeMembershipDTO list contains unique ProgrammeMembershipDTOs
+   * under each of ProgrammeMembershipDTO, there can be multiple CurriculumMembershipDTOs.
+   *
+   * @param programmeMemberships list of programmeMembership entities to convert
    * @return ProgrammeMembershipDTO list
    */
   public List<ProgrammeMembershipDTO> programmeMembershipsToProgrammeMembershipDTOs(
@@ -166,11 +166,11 @@ public class ProgrammeMembershipMapper {
    * for each DTO.
    *
    * @param pmDtos list of ProgrammeMembershipDTO
-   * @return
+   * @return the ProgrammeMembership entity list
    */
   public List<ProgrammeMembership> programmeMembershipDTOsToProgrammeMemberships(
       List<ProgrammeMembershipDTO> pmDtos) {
-    return pmDtos.stream().map(pmDto -> toEntity(pmDto)).collect(Collectors.toList());
+    return pmDtos.stream().map(this::toEntity).collect(Collectors.toList());
   }
 
   // convert programmeMembership entity to DTO with an empty curriculumMembership list

--- a/tcs-service/src/main/resources/config/application-local.yml
+++ b/tcs-service/src/main/resources/config/application-local.yml
@@ -21,8 +21,6 @@ spring:
 
 logging:
     file: ${LOG_DIR:${HOME}}/tcs.log
-    level:
-      root: debug
 
 application:
 

--- a/tcs-service/src/main/resources/config/application-local.yml
+++ b/tcs-service/src/main/resources/config/application-local.yml
@@ -21,6 +21,8 @@ spring:
 
 logging:
     file: ${LOG_DIR:${HOME}}/tcs.log
+    level:
+      root: debug
 
 application:
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/TrainingNumberElasticSearchEventListenerTest.java
@@ -17,6 +17,10 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.ConditionsOfJoiningMap
 import com.transformuk.hee.tis.tcs.service.service.mapper.ConditionsOfJoiningMapperImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.RotationMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.RotationMapperImpl;
+import com.transformuk.hee.tis.tcs.service.service.mapper.TrainingNumberMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.TrainingNumberMapperImpl;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -63,10 +67,12 @@ public class TrainingNumberElasticSearchEventListenerTest {
     ConditionsOfJoiningMapper conditionsOfJoiningMapper = new ConditionsOfJoiningMapperImpl();
     CurriculumMembershipMapper curriculumMembershipMapper = new CurriculumMembershipMapper(
         conditionsOfJoiningMapper, conditionsOfJoiningRepositoryMock);
+    TrainingNumberMapper trainingNumberMapper = new TrainingNumberMapperImpl();
+    RotationMapper rotationMapper = new RotationMapperImpl();
 
     ReflectionTestUtils.setField(testObj, "programmeMembershipMapper",
         new ProgrammeMembershipMapper(curriculumMembershipMapper, conditionsOfJoiningMapper,
-            conditionsOfJoiningRepositoryMock));
+            conditionsOfJoiningRepositoryMock, trainingNumberMapper, rotationMapper));
 
     trainingNumberDto = new TrainingNumberDTO();
     trainingNumberDto.setId(TRAININGNUMER_ID);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -33,8 +33,13 @@ import com.transformuk.hee.tis.tcs.service.service.mapper.ConditionsOfJoiningMap
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapperImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMapperImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.RotationMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.RotationMapperImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.SpecialtyMapperImpl;
+import com.transformuk.hee.tis.tcs.service.service.mapper.TrainingNumberMapper;
+import com.transformuk.hee.tis.tcs.service.service.mapper.TrainingNumberMapperImpl;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -86,6 +91,8 @@ public class ProgrammeMembershipServiceImplTest {
   private final Programme programme = new Programme();
   private final PersonDTO personDto = new PersonDTO();
   private final Person person = new Person();
+  @Mock
+  ConditionsOfJoiningRepository conditionsOfJoiningRepositoryMock;
   private ProgrammeMembershipDTO programmeMembershipDto1 = new ProgrammeMembershipDTO();
   private ProgrammeMembershipServiceImpl testObj;
   private ProgrammeMembershipMapper programmeMembershipMapper;
@@ -103,16 +110,20 @@ public class ProgrammeMembershipServiceImplTest {
   private ApplicationEventPublisher applicationEventPublisherMock;
   @Mock
   private PersonRepository personRepositoryMock;
-  @Mock
-  ConditionsOfJoiningRepository conditionsOfJoiningRepositoryMock;
 
   @Before
   public void setup() {
     conditionsOfJoiningMapper = new ConditionsOfJoiningMapperImpl();
     curriculumMembershipMapper = new CurriculumMembershipMapper(conditionsOfJoiningMapper,
         conditionsOfJoiningRepositoryMock);
+    TrainingNumberMapper trainingNumberMapper = new TrainingNumberMapperImpl();
+    ReflectionTestUtils.setField(trainingNumberMapper, "programmeMapper",
+        new ProgrammeMapperImpl());
+    RotationMapper rotationMapper = new RotationMapperImpl();
+
     programmeMembershipMapper = new ProgrammeMembershipMapper(curriculumMembershipMapper,
-        conditionsOfJoiningMapper, conditionsOfJoiningRepositoryMock);
+        conditionsOfJoiningMapper,
+        conditionsOfJoiningRepositoryMock, trainingNumberMapper, rotationMapper);
     CurriculumMapper curriculumMapper = new CurriculumMapperImpl();
     ReflectionTestUtils.setField(curriculumMapper, "specialtyMapper",
         new SpecialtyMapperImpl());

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/mapper/ProgrammeMembershipMapperTest.java
@@ -16,11 +16,13 @@ import java.util.UUID;
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProgrammeMembershipMapperTest {
@@ -36,6 +38,12 @@ public class ProgrammeMembershipMapperTest {
 
   @InjectMocks
   private ProgrammeMembershipMapper testObj;
+
+  @Before
+  public void setup() {
+    ReflectionTestUtils.setField(testObj, "trainingNumberMapper",
+        new TrainingNumberMapperImpl());
+  }
 
   @Test
   public void entityToDtoShouldReturnListOfAllElementsInAsDto() {


### PR DESCRIPTION
This refactoring is mainly about ProgrammeMembershipMapper:
1. use outside mappers instead of private mapers when possible
2. add more comments, and shorten some method variables to make them more readable
3. in private method `programmeMembershipToProgrammeMembershipDTO`, define an empty curriculumMemberhsip list instead of having to define it in outer layers.

TIS21-2403