### PR TITLE
feat: accept CoJ signed events with id or uuid

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.28.2</version>
+  <version>6.29.0</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/event/ConditionsOfJoiningSignedEvent.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/event/ConditionsOfJoiningSignedEvent.java
@@ -9,17 +9,17 @@ import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
 public class ConditionsOfJoiningSignedEvent {
 
   @JsonProperty("programmeMembershipTisId")
-  private final Long programmeMembershipId;
+  private final Object id; //this may be a long or a UUID
   private final ConditionsOfJoiningDto conditionsOfJoining;
 
-  public ConditionsOfJoiningSignedEvent(Long programmeMembershipId,
+  public ConditionsOfJoiningSignedEvent(Object id,
       ConditionsOfJoiningDto conditionsOfJoining) {
-    this.programmeMembershipId = programmeMembershipId;
+    this.id = id;
     this.conditionsOfJoining = conditionsOfJoining;
   }
 
-  public Long getProgrammeMembershipId() {
-    return programmeMembershipId;
+  public Object getId() {
+    return id;
   }
 
   public ConditionsOfJoiningDto getConditionsOfJoining() {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListener.java
@@ -21,7 +21,7 @@ public class TraineeMessageListener {
   @RabbitListener(queues = "${app.rabbit.trainee.queue.coj.signed}", ackMode = "AUTO")
   public void receiveMessage(final ConditionsOfJoiningSignedEvent event) {
     try {
-      conditionsOfJoiningService.save(event.getProgrammeMembershipId(),
+      conditionsOfJoiningService.save(event.getId(),
           event.getConditionsOfJoining());
     } catch (IllegalArgumentException e) {
       // Do not requeue the message if the event arguments are not valid.

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/ConditionsOfJoiningService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/ConditionsOfJoiningService.java
@@ -8,11 +8,11 @@ import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
 public interface ConditionsOfJoiningService {
 
   /**
-   * Save a Conditions of Joining from its DTO and related programme membership ID.
+   * Save a Conditions of Joining from its DTO and related programme membership ID/UUID.
    *
-   * @param programmeMembershipId the programme membership ID
+   * @param id  the programme membership ID or UUID
    * @param dto the Conditions Of Joining DTO
    * @return the saved Conditions of Joining DTO
    */
-  ConditionsOfJoiningDto save(Long programmeMembershipId, ConditionsOfJoiningDto dto);
+  ConditionsOfJoiningDto save(Object id, ConditionsOfJoiningDto dto);
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/ProgrammeMembershipService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/ProgrammeMembershipService.java
@@ -4,6 +4,7 @@ import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipCurriculaDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -43,6 +44,14 @@ public interface ProgrammeMembershipService {
    * @return the entity
    */
   ProgrammeMembershipDTO findOne(Long id);
+
+  /**
+   * Get the "uuid" programmeMembership.
+   *
+   * @param uuid the uuid of the entity
+   * @return the entity
+   */
+  ProgrammeMembershipDTO findOne(UUID uuid);
 
   /**
    * Delete the "id" programmeMembership.

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
@@ -44,27 +44,12 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
 
   @Override
   public ConditionsOfJoiningDto save(Object id, ConditionsOfJoiningDto dto) {
-    UUID realProgrammeMembershipId = null;
-    Long curriculumMembershipId = null;
     ProgrammeMembershipDTO programmeMembership;
+    LOG.info("Request received to save Conditions of Joining for id {}.", id);
     try {
-      realProgrammeMembershipId = UUID.fromString(id.toString());
-    } catch (IllegalArgumentException e) {
-      try {
-        curriculumMembershipId = (Long) id;
-      } catch (ClassCastException castException) {
-        throw new IllegalArgumentException(
-            String.format("%s is neither Long nor UUID", id));
-      }
-    }
-    if (realProgrammeMembershipId == null) {
-      LOG.info("Request received to save Conditions of Joining for Curriculum Membership {}.",
-          curriculumMembershipId);
-      programmeMembership = programmeMembershipService.findOne(curriculumMembershipId);
-    } else {
-      LOG.info("Request received to save Conditions of Joining for Programme Membership {}.",
-          realProgrammeMembershipId);
-      programmeMembership = programmeMembershipService.findOne(realProgrammeMembershipId);
+      programmeMembership = programmeMembershipService.findOne(Long.parseLong(id.toString()));
+    } catch (NumberFormatException e) {
+      programmeMembership = programmeMembershipService.findOne(UUID.fromString(id.toString()));
     }
 
     if (programmeMembership == null) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
@@ -53,7 +53,8 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
       try {
         curriculumMembershipId = (Long) id;
       } catch (ClassCastException castException) {
-        throw new IllegalArgumentException(id + " is neither Long nor UUID");
+        throw new IllegalArgumentException(
+            String.format("%s is neither Long nor UUID", id));
       }
     }
     if (realProgrammeMembershipId == null) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
@@ -43,16 +43,32 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
   }
 
   @Override
-  public ConditionsOfJoiningDto save(Long programmeMembershipId, ConditionsOfJoiningDto dto) {
-    LOG.info("Request received to save Conditions of Joining for Programme Membership {}.",
-        programmeMembershipId);
-
-    ProgrammeMembershipDTO programmeMembership = programmeMembershipService.findOne(
-        programmeMembershipId);
+  public ConditionsOfJoiningDto save(Object id, ConditionsOfJoiningDto dto) {
+    UUID realProgrammeMembershipId = null;
+    Long curriculumMembershipId = null;
+    ProgrammeMembershipDTO programmeMembership;
+    try {
+      realProgrammeMembershipId = UUID.fromString(id.toString());
+    } catch (IllegalArgumentException e) {
+      try {
+        curriculumMembershipId = (Long) id;
+      } catch (ClassCastException castException) {
+        throw new IllegalArgumentException(id + " is neither Long nor UUID");
+      }
+    }
+    if (realProgrammeMembershipId == null) {
+      LOG.info("Request received to save Conditions of Joining for Curriculum Membership {}.",
+          curriculumMembershipId);
+      programmeMembership = programmeMembershipService.findOne(curriculumMembershipId);
+    } else {
+      LOG.info("Request received to save Conditions of Joining for Programme Membership {}.",
+          realProgrammeMembershipId);
+      programmeMembership = programmeMembershipService.findOne(realProgrammeMembershipId);
+    }
 
     if (programmeMembership == null) {
       throw new IllegalArgumentException(
-          String.format("Programme Membership %s not found.", programmeMembershipId));
+          String.format("Programme Membership %s not found.", id));
     }
 
     UUID programmeMembershipUuid = programmeMembership.getUuid();

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
@@ -177,6 +178,21 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     CurriculumMembership curriculumMembership = curriculumMembershipRepository.findById(id)
         .orElse(null);
     return curriculumMembershipMapper.toDto(curriculumMembership);
+  }
+
+  /**
+   * Get one programmeMembership by uuid.
+   *
+   * @param uuid the uuid of the entity
+   * @return the entity
+   */
+  @Override
+  @Transactional(readOnly = true)
+  public ProgrammeMembershipDTO findOne(UUID uuid) {
+    log.debug("Request to get ProgrammeMembership : {}", uuid);
+    ProgrammeMembership programmeMembership = programmeMembershipRepository.findByUuid(uuid)
+        .orElse(null);
+    return programmeMembershipMapper.toDto(programmeMembership);
   }
 
   /**

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListenerTest.java
@@ -23,18 +23,19 @@ class TraineeMessageListenerTest {
 
   private TraineeMessageListener listener;
   private ConditionsOfJoiningService service;
+  private ConditionsOfJoiningDto dto;
 
   @BeforeEach
   void setUp() {
     service = mock(ConditionsOfJoiningService.class);
     listener = new TraineeMessageListener(service);
+    dto = new ConditionsOfJoiningDto();
+    dto.setSignedAt(SIGNED_AT);
+    dto.setVersion(GoldGuideVersion.GG9);
   }
 
   @Test
   void shouldSaveSignedCojWhenEventValidWithCmId() {
-    ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
-    dto.setSignedAt(SIGNED_AT);
-    dto.setVersion(GoldGuideVersion.GG9);
     ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(
         CURRICULUM_MEMBERSHIP_ID, dto);
 
@@ -45,9 +46,6 @@ class TraineeMessageListenerTest {
 
   @Test
   void shouldSaveSignedCojWhenEventValidWithPmId() {
-    ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
-    dto.setSignedAt(SIGNED_AT);
-    dto.setVersion(GoldGuideVersion.GG9);
     ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(
         PROGRAMME_MEMBERSHIP_ID, dto);
 
@@ -58,9 +56,6 @@ class TraineeMessageListenerTest {
 
   @Test
   void shouldNotRequeueMessageWhenEventArgumentsInvalid() {
-    ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
-    dto.setSignedAt(SIGNED_AT);
-    dto.setVersion(GoldGuideVersion.GG9);
     ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(
         CURRICULUM_MEMBERSHIP_ID, dto);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/message/TraineeMessageListenerTest.java
@@ -10,13 +10,15 @@ import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
 import com.transformuk.hee.tis.tcs.service.event.ConditionsOfJoiningSignedEvent;
 import com.transformuk.hee.tis.tcs.service.service.ConditionsOfJoiningService;
 import java.time.Instant;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 
 class TraineeMessageListenerTest {
 
-  private static final Long ID = 40L;
+  private static final Long CURRICULUM_MEMBERSHIP_ID = 40L;
+  private static final UUID PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID();
   private static final Instant SIGNED_AT = Instant.now();
 
   private TraineeMessageListener listener;
@@ -29,15 +31,29 @@ class TraineeMessageListenerTest {
   }
 
   @Test
-  void shouldSaveSignedCojWhenEventValid() {
+  void shouldSaveSignedCojWhenEventValidWithCmId() {
     ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
     dto.setSignedAt(SIGNED_AT);
     dto.setVersion(GoldGuideVersion.GG9);
-    ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(ID, dto);
+    ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(
+        CURRICULUM_MEMBERSHIP_ID, dto);
 
     listener.receiveMessage(event);
 
-    verify(service).save(ID, dto);
+    verify(service).save(CURRICULUM_MEMBERSHIP_ID, dto);
+  }
+
+  @Test
+  void shouldSaveSignedCojWhenEventValidWithPmId() {
+    ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
+    dto.setSignedAt(SIGNED_AT);
+    dto.setVersion(GoldGuideVersion.GG9);
+    ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(
+        PROGRAMME_MEMBERSHIP_ID, dto);
+
+    listener.receiveMessage(event);
+
+    verify(service).save(PROGRAMME_MEMBERSHIP_ID, dto);
   }
 
   @Test
@@ -45,9 +61,10 @@ class TraineeMessageListenerTest {
     ConditionsOfJoiningDto dto = new ConditionsOfJoiningDto();
     dto.setSignedAt(SIGNED_AT);
     dto.setVersion(GoldGuideVersion.GG9);
-    ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(ID, dto);
+    ConditionsOfJoiningSignedEvent event = new ConditionsOfJoiningSignedEvent(
+        CURRICULUM_MEMBERSHIP_ID, dto);
 
-    when(service.save(ID, dto)).thenThrow(IllegalArgumentException.class);
+    when(service.save(CURRICULUM_MEMBERSHIP_ID, dto)).thenThrow(IllegalArgumentException.class);
 
     assertThrows(AmqpRejectAndDontRequeueException.class, () -> listener.receiveMessage(event));
   }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
@@ -43,7 +43,7 @@ class ConditionsOfJoiningServiceImplTest {
   }
 
   @Test
-  void saveShouldThrowExceptionWhenProgrammeMembershipIdNotFound() {
+  void saveShouldThrowExceptionWhenCurriculumMembershipIdNotFound() {
     ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
     coj.setSignedAt(SIGNED_AT);
     coj.setVersion(GoldGuideVersion.GG9);
@@ -56,7 +56,31 @@ class ConditionsOfJoiningServiceImplTest {
   }
 
   @Test
-  void saveShouldSaveTheConditionsOfJoiningAgainstTheProgrammeMembership() {
+  void saveShouldThrowExceptionWhenProgrammeMembershipIdNotFound() {
+    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
+    coj.setSignedAt(SIGNED_AT);
+    coj.setVersion(GoldGuideVersion.GG9);
+
+    when(programmeMembershipService.findOne(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(null);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> conditionsOfJoiningService.save(PROGRAMME_MEMBERSHIP_UUID, coj));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void saveShouldThrowExceptionWhenInvalidIdProvided() {
+    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
+    coj.setSignedAt(SIGNED_AT);
+    coj.setVersion(GoldGuideVersion.GG9);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> conditionsOfJoiningService.save("not a long or a uuid", coj));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void saveShouldSaveTheConditionsOfJoiningAgainstTheProgrammeMembershipFromCmId() {
     ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
     coj.setSignedAt(SIGNED_AT);
     coj.setVersion(GoldGuideVersion.GG9);
@@ -73,8 +97,33 @@ class ConditionsOfJoiningServiceImplTest {
 
     assertThat("Unexpected programme membership uuid.", savedCoj.getProgrammeMembershipUuid(),
         is(PROGRAMME_MEMBERSHIP_UUID));
-    assertThat("Unexpected programme membership uuid.", savedCoj.getSignedAt(), is(SIGNED_AT));
-    assertThat("Unexpected programme membership uuid.", savedCoj.getVersion(),
+    assertThat("Unexpected programme membership signed at.", savedCoj.getSignedAt(),
+        is(SIGNED_AT));
+    assertThat("Unexpected programme membership version.", savedCoj.getVersion(),
+        is(GoldGuideVersion.GG9));
+  }
+
+  @Test
+  void saveShouldSaveTheConditionsOfJoiningAgainstTheProgrammeMembershipFromPmId() {
+    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
+    coj.setSignedAt(SIGNED_AT);
+    coj.setVersion(GoldGuideVersion.GG9);
+
+    ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
+    programmeMembershipDto.setUuid(PROGRAMME_MEMBERSHIP_UUID);
+
+    when(programmeMembershipService.findOne(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(
+        programmeMembershipDto);
+    when(repository.save(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
+
+    ConditionsOfJoiningDto savedCoj = conditionsOfJoiningService.save(PROGRAMME_MEMBERSHIP_UUID,
+        coj);
+
+    assertThat("Unexpected programme membership uuid.", savedCoj.getProgrammeMembershipUuid(),
+        is(PROGRAMME_MEMBERSHIP_UUID));
+    assertThat("Unexpected programme membership signed at.", savedCoj.getSignedAt(),
+        is(SIGNED_AT));
+    assertThat("Unexpected programme membership version.", savedCoj.getVersion(),
         is(GoldGuideVersion.GG9));
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
@@ -31,6 +31,7 @@ class ConditionsOfJoiningServiceImplTest {
   private ConditionsOfJoiningService conditionsOfJoiningService;
   private ConditionsOfJoiningRepository repository;
   private ProgrammeMembershipService programmeMembershipService;
+  private ConditionsOfJoiningDto coj;
 
   @BeforeEach
   void setUp() {
@@ -40,14 +41,13 @@ class ConditionsOfJoiningServiceImplTest {
 
     conditionsOfJoiningService = new ConditionsOfJoiningServiceImpl(repository, mapper,
         programmeMembershipService);
+    coj = new ConditionsOfJoiningDto();
+    coj.setSignedAt(SIGNED_AT);
+    coj.setVersion(GoldGuideVersion.GG9);
   }
 
   @Test
   void saveShouldThrowExceptionWhenCurriculumMembershipIdNotFound() {
-    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
-    coj.setSignedAt(SIGNED_AT);
-    coj.setVersion(GoldGuideVersion.GG9);
-
     when(programmeMembershipService.findOne(CURRICULUM_MEMBERSHIP_ID)).thenReturn(null);
 
     assertThrows(IllegalArgumentException.class,
@@ -57,10 +57,6 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldThrowExceptionWhenProgrammeMembershipIdNotFound() {
-    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
-    coj.setSignedAt(SIGNED_AT);
-    coj.setVersion(GoldGuideVersion.GG9);
-
     when(programmeMembershipService.findOne(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(null);
 
     assertThrows(IllegalArgumentException.class,
@@ -70,10 +66,6 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldThrowExceptionWhenInvalidIdProvided() {
-    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
-    coj.setSignedAt(SIGNED_AT);
-    coj.setVersion(GoldGuideVersion.GG9);
-
     assertThrows(IllegalArgumentException.class,
         () -> conditionsOfJoiningService.save("not a long or a uuid", coj));
     verify(repository, never()).save(any());
@@ -81,10 +73,6 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldSaveTheConditionsOfJoiningAgainstTheProgrammeMembershipFromCmId() {
-    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
-    coj.setSignedAt(SIGNED_AT);
-    coj.setVersion(GoldGuideVersion.GG9);
-
     ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
     programmeMembershipDto.setUuid(PROGRAMME_MEMBERSHIP_UUID);
 
@@ -105,10 +93,6 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldSaveTheConditionsOfJoiningAgainstTheProgrammeMembershipFromPmId() {
-    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
-    coj.setSignedAt(SIGNED_AT);
-    coj.setVersion(GoldGuideVersion.GG9);
-
     ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
     programmeMembershipDto.setUuid(PROGRAMME_MEMBERSHIP_UUID);
 
@@ -129,7 +113,6 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldReplaceAnyProvidedProgrammeMembershipUuid() {
-    ConditionsOfJoiningDto coj = new ConditionsOfJoiningDto();
     coj.setProgrammeMembershipUuid(UUID.randomUUID());
 
     ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -265,6 +265,20 @@ public class ProgrammeMembershipServiceImplTest {
     Assert.assertEquals(1, result.getCurriculumMemberships().size());
   }
 
+  @Test()
+  public void findOneByUuidShouldReturnProgrammeMembershipDTO() {
+    //given
+    when(programmeMembershipRepositoryMock.findByUuid(PROGRAMME_MEMBERSHIP_ID_1))
+        .thenReturn(Optional.of(programmeMembership1));
+
+    //when
+    ProgrammeMembershipDTO result = testObj.findOne(PROGRAMME_MEMBERSHIP_ID_1);
+
+    //then
+    Assert.assertNotNull(result);
+    Assert.assertEquals(PROGRAMME_ID, result.getProgrammeId().longValue());
+    Assert.assertEquals(2, result.getCurriculumMemberships().size());
+  }
 
   @Test(expected = NullPointerException.class)
   public void findProgrammeMembershipsForTraineeShouldFailWhenTraineeIsNull() {


### PR DESCRIPTION
For a limited time, events may include a curriculum membership id (long) as previously, or the new programme membership uuid. The latter will be the only accepted form after the transition period.

TIS21-4660