### PR TITLE
feat: GET programme memberships accepts UUID

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>6.0.3</version>
+  <version>6.1.0</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.EncoderException;
 import org.apache.commons.codec.net.URLCodec;
@@ -460,6 +461,14 @@ public class TcsServiceImpl extends AbstractClientService {
         }).getBody();
   }
 
+  public ProgrammeMembershipDTO getProgrammeMembershipByUuid(UUID uuid) {
+    return tcsRestTemplate
+        .exchange(serviceUrl + API_PROGRAMME_MEMBERSHIPS + uuid, HttpMethod.GET, null,
+            new ParameterizedTypeReference<ProgrammeMembershipDTO>() {
+            })
+        .getBody();
+  }
+
   public ProgrammeMembershipDTO createProgrammeMembership(
       ProgrammeMembershipDTO programmeMembershipDTO) {
     HttpHeaders headers = new HttpHeaders();
@@ -525,7 +534,7 @@ public class TcsServiceImpl extends AbstractClientService {
    *
    * @param name          the name of the Specialty
    * @param specialtyType the SpecialtyType to filter specialties by
-   * @return              list of all specialties matching the parameters
+   * @return list of all specialties matching the parameters
    */
   @Cacheable("specialty")
   public List<SpecialtyDTO> getSpecialtyByName(String name, SpecialtyType specialtyType) {
@@ -534,8 +543,8 @@ public class TcsServiceImpl extends AbstractClientService {
         .exchange(
             serviceUrl + API_CURRENT_SPECIALTIES_COLUMN_FILTERS
                 + specialtyJsonQuerystringAndSpecialtyTypeURLEncoded
-                    .replace("PARAMETER_NAME", urlEncode(name))
-                    .replace("PARAMETER_TYPE", urlEncode(specialtyType.name())), HttpMethod.GET,
+                .replace("PARAMETER_NAME", urlEncode(name))
+                .replace("PARAMETER_TYPE", urlEncode(specialtyType.name())), HttpMethod.GET,
             null,
             new ParameterizedTypeReference<List<SpecialtyDTO>>() {
             })

--- a/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplMockTest.java
+++ b/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplMockTest.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.tcs.client.service.impl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -17,11 +18,13 @@ import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementSummaryDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipCurriculaDTO;
+import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainerApprovalDTO;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -218,5 +221,32 @@ public class TcsServiceImplMockTest {
     // Then.
     assertThat("Unexpected number of patched DTOs.", returnDtos.size(), is(1));
     assertThat("Unexpected patched DTOs.", returnDtos.get(0), is(dto));
+  }
+
+  @Test
+  public void shouldGetProgrammeMembershipbyUuidWhenFound() {
+    UUID uuid = UUID.randomUUID();
+
+    ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
+    dto.setUuid(uuid);
+
+    ResponseEntity<ProgrammeMembershipDTO> response = ResponseEntity.ok(dto);
+    when(restTemplateMock.exchange(anyString(), eq(HttpMethod.GET), eq(null), any(
+        ParameterizedTypeReference.class))).thenReturn(response);
+
+    ProgrammeMembershipDTO returnDto = testObj.getProgrammeMembershipByUuid(uuid);
+    assertThat("Unexpected dto.", returnDto, is(dto));
+  }
+
+  @Test
+  public void shouldReturnNullWhenProgrammeMembershipNotFoundByUuid() {
+    UUID uuid = UUID.randomUUID();
+
+    ResponseEntity<ProgrammeMembershipDTO> response = ResponseEntity.notFound().build();
+    when(restTemplateMock.exchange(anyString(), eq(HttpMethod.GET), eq(null), any(
+        ParameterizedTypeReference.class))).thenReturn(response);
+
+    ProgrammeMembershipDTO returnDto = testObj.getProgrammeMembershipByUuid(uuid);
+    assertThat("Unexpected dto.", returnDto, nullValue());
   }
 }

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.29.2</version>
+  <version>6.30.0</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.apache.commons.collections4.CollectionUtils;
@@ -146,9 +147,16 @@ public class ProgrammeMembershipResource {
    */
   @GetMapping("/programme-memberships/{id}")
   @PreAuthorize("hasPermission('tis:people::person:', 'View')")
-  public ResponseEntity<ProgrammeMembershipDTO> getProgrammeMembership(@PathVariable Long id) {
+  public ResponseEntity<ProgrammeMembershipDTO> getProgrammeMembership(@PathVariable String id) {
     log.debug("REST request to get ProgrammeMembership : {}", id);
-    ProgrammeMembershipDTO programmeMembershipDto = programmeMembershipService.findOne(id);
+    ProgrammeMembershipDTO programmeMembershipDto;
+
+    try {
+      programmeMembershipDto = programmeMembershipService.findOne(UUID.fromString(id));
+    } catch (IllegalArgumentException e) {
+      programmeMembershipDto = programmeMembershipService.findOne(Long.parseLong(id));
+    }
+
     return ResponseUtil.wrapOrNotFound(Optional.ofNullable(programmeMembershipDto));
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceTest.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.tcs.service.api;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,6 +21,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -200,5 +202,21 @@ public class ProgrammeMembershipResourceTest {
 
     verify(programmeMembershipServiceMock).delete(CURRICULUM_ID1);
     verify(programmeMembershipServiceMock).delete(CURRICULUM_ID2);
+  }
+
+  @Test
+  public void shouldGetProgrammeMembershipByUuidWhenIdParamIsAUuid()
+      throws Exception {
+    mockMvc.perform(get("/api/programme-memberships/" + UUID.randomUUID()));
+
+    verify(programmeMembershipServiceMock).findOne(any(UUID.class));
+  }
+
+  @Test
+  public void shouldGetProgrammeMembershipByIdWhenIdParamIsNotAUuid()
+      throws Exception {
+    mockMvc.perform(get("/api/programme-memberships/" + 1L));
+
+    verify(programmeMembershipServiceMock).findOne(any(Long.class));
   }
 }


### PR DESCRIPTION
The GET endpoint for programme memberships currently only support a `Long` id and performs a lookup via CurriculumMembership id, update the endpoint to allow both a `Long` id using the existing behaviour and a `UUID`, which will perform a direct lookup on
`ProgrammeMembership.uuid`.

Add a method to `TcsServiceImpl` to allow calling of the GET endpoint for programme memberships by UUID.

TIS21-4173
TIS21-2399