### PR TITLE
fix:NPE for reval

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.30.0</version>
+  <version>6.30.1</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResource.java
@@ -50,7 +50,12 @@ public class RevalidationResource {
   public ResponseEntity<RevalidationRecordDto> getRevalidationTraineeRecord(
       @PathVariable String gmcId) {
     LOG.debug("REST request to find Revalidation Record: {}", gmcId);
-    return ResponseEntity.ok(revalidationService.findRevalidationByGmcId(gmcId));
+    RevalidationRecordDto recordDto = revalidationService.findRevalidationByGmcId(gmcId);
+    if (recordDto != null) {
+      return ResponseEntity.ok(recordDto);
+    } else {
+      return ResponseEntity.notFound().build();
+    }
   }
 
   @GetMapping(value = {"/revalidation/connection", "/revalidation/connection/{gmcIds}"})

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResource.java
@@ -46,7 +46,7 @@ public class RevalidationResource {
   }
 
   /**
-   * Get doctor with programme detatils by gmcId
+   * Get doctor with programme detatils by gmcId.
    *
    * @param gmcId the gmc number
    * @return doctor details, if not found return 404 not found

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResource.java
@@ -45,6 +45,12 @@ public class RevalidationResource {
     }
   }
 
+  /**
+   * Get doctor with programme detatils by gmcId
+   *
+   * @param gmcId the gmc number
+   * @return doctor details, if not found return 404 not found
+   */
   @GetMapping("/revalidation/trainee/{gmcId}")
   @PreAuthorize("hasPermission('tis:people::person:', 'View')")
   public ResponseEntity<RevalidationRecordDto> getRevalidationTraineeRecord(

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -362,6 +362,9 @@ public class RevalidationServiceImpl implements RevalidationService {
   }
 
   private RevalidationRecordDto buildRevalidationRecord(GmcDetails gmcDetails) {
+    if (gmcDetails == null) {
+      return null;
+    }
     RevalidationRecordDto revalidationRecordDto = new RevalidationRecordDto();
     revalidationRecordDto.setGmcNumber(gmcDetails.getGmcNumber());
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -113,6 +113,9 @@ public class RevalidationServiceImpl implements RevalidationService {
   public RevalidationRecordDto findRevalidationByGmcId(final String gmcId) {
     LOG.debug("GMC No received from Revalidation application: {}", gmcId);
     GmcDetails gmcDetails = gmcDetailsRepository.findGmcDetailsByGmcNumber(gmcId);
+    if (gmcDetails == null) {
+      return null;
+    }
     return buildRevalidationRecord(gmcDetails);
   }
 
@@ -362,9 +365,6 @@ public class RevalidationServiceImpl implements RevalidationService {
   }
 
   private RevalidationRecordDto buildRevalidationRecord(GmcDetails gmcDetails) {
-    if (gmcDetails == null) {
-      return null;
-    }
     RevalidationRecordDto revalidationRecordDto = new RevalidationRecordDto();
     revalidationRecordDto.setGmcNumber(gmcDetails.getGmcNumber());
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResourceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/RevalidationResourceTest.java
@@ -124,6 +124,15 @@ public class RevalidationResourceTest {
   }
 
   @Test
+  public void shouldReturn404FindRevalidationRecordsFromGmcIdNotFound() throws Exception {
+    when(revalidationServiceImplMock.findRevalidationByGmcId(GMC_ID1))
+        .thenReturn(null);
+
+    restRevalidationMock.perform(get("/api/revalidation/trainee/{gmcId}", GMC_ID1))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
   public void shouldFindRevalidationRecordsFromListOfGmcIds() throws Exception {
     final List<String> gmcIds = asList(GMC_ID1, GMC_ID2, GMC_ID3);
     final Map<String, RevalidationRecordDto> revalidationRecordDtoMap = new HashMap<>();

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -200,6 +200,15 @@ public class RevalidationServiceImplTest {
   }
 
   @Test
+  public void findRevalidationRecordByGmcIdShouldRetrieveNullWhenNoDoctorFound() {
+    when(gmcDetailsRepositoryMock.findGmcDetailsByGmcNumber("1000")).thenReturn(null);
+
+    RevalidationRecordDto result = testObj.findRevalidationByGmcId("1000");
+
+    assertThat(result, nullValue());
+  }
+
+  @Test
   public void findRevalidationRecordByGmcIdShouldRetrieveOne() {
     ConnectionInfoDto connectionInfoDto = ConnectionInfoDto.builder()
         .tcsPersonId(PERSON_ID)


### PR DESCRIPTION
fix NullPointerException for "/revalidation/trainee/{gmcId}" when gmcId not found in TCS.

TIS21-4548