### PR TITLE
fix:sending CurriculumMembershipDeletedEvent when curriculumMembership is deleted

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.30.1</version>
+  <version>6.30.2</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/listener/person/CurriculumMembershipEventListener.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/listener/person/CurriculumMembershipEventListener.java
@@ -64,8 +64,7 @@ public class CurriculumMembershipEventListener {
     LOG.info("Received CurriculumMembership deleted event for CurriculumMembership id: [{}]",
         event.getProgrammeMembershipDTO().getId());
     final Long personId = event.getProgrammeMembershipDTO().getPerson().getId();
-    personElasticSearchService.deletePersonDocument(personId);
+    personElasticSearchService.updatePersonDocument(personId);
     revalidationRabbitService.updateReval(revalidationService.buildTcsConnectionInfo(personId));
   }
-
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -8,6 +8,7 @@ import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipCurriculaDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
+import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipDeletedEvent;
 import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipSavedEvent;
 import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
@@ -219,6 +220,8 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     }
 
     updatePersonWhenStatusIsStale(personId);
+    applicationEventPublisher.publishEvent(
+        new CurriculumMembershipDeletedEvent(programmeMembershipMapper.toDto(programmeMembership)));
   }
 
   @Transactional(readOnly = true)

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/CurriculumMembershipEventListenerTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/listener/person/CurriculumMembershipEventListenerTest.java
@@ -72,7 +72,7 @@ public class CurriculumMembershipEventListenerTest {
   @Test
   public void shouldHandleCurriculumMembershipDeletedEvent() {
     testObj.handleCurriculumMembershipDeletedEvent(deletedEvent);
-    verify(personElasticSearchService).deletePersonDocument(PERSONID);
+    verify(personElasticSearchService).updatePersonDocument(PERSONID);
     verify(revalidationRabbitService).updateReval(revalidationService.buildTcsConnectionInfo(PERSONID));
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -16,6 +16,7 @@ import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
+import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipDeletedEvent;
 import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
@@ -593,8 +594,7 @@ public class ProgrammeMembershipServiceImplTest {
 
     verify(programmeMembershipRepositoryMock, times(1))
         .delete(any()); //since the last CM is deleted, so the PM is deleted too
-
+    verify(applicationEventPublisherMock, times(2)).publishEvent(any(
+        CurriculumMembershipDeletedEvent.class));
   }
-
-
 }


### PR DESCRIPTION
In User Research-Revalidation channel, Katy raised a query on 27 June that they updated the programme membership info of a doctor but the doctor was still in the Discrepancy list.

This happened when the curriculum membership was deleted, and no message was sent to Reval to update the programme details.

no-ticket