### PR TITLE
fix:use PM.personId for ConnectionInfo

### DIFF
--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -15,7 +15,7 @@ from (
     ContactDetails cd
   inner join GmcDetails gmc on (gmc.id = cd.id)
    -- note: null values are filtered out by the condition below
-  and lower(gmc.gmcNumber) <> 'unknown'
+    and lower(gmc.gmcNumber) <> 'unknown'
   left join (
     -- count current PMs with combined programme names for each person
     select
@@ -33,15 +33,20 @@ from (
     on pm1.personId = currentPmCounts.personId and currentPmCounts.count_num = 1 and (pm1.programmeStartDate <= current_date() and pm1.programmeEndDate >= current_date())
   left join (
     -- get max curriculumEndDate for every PM
-      select
-        cm.programmeMembershipUuid,
-        max(cm.curriculumEndDate) curriculumEndDate
-      from CurriculumMembership cm
-      WHERECLAUSE(cm, personId)
-      group by cm.programmeMembershipUuid
+    select
+      cm2.programmeMembershipUuid,
+      max(cm2.curriculumEndDate) curriculumEndDate,
+      cm2.personId
+    from (
+        select cm.programmeMembershipUuid, cm.curriculumEndDate, pm2.personId
+        from CurriculumMembership cm
+        join ProgrammeMembership pm2 on cm.programmeMembershipUuid = pm2.uuid
+      ) cm2
+    WHERECLAUSE(cm2, personId)
+    group by cm2.programmeMembershipUuid
   ) latestCm on latestCm.programmeMembershipUuid = pm1.uuid
   WHERECLAUSE(cd, id)
-  ) as ot
+) as ot
 ORDERBYCLAUSE
 LIMITCLAUSE
 ;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -547,7 +547,7 @@ public class RevalidationServiceImplTest {
     String querySql = stringArgCaptor.getValue();
     assertThat(querySql, containsString("where cd.id = " + PERSON_ID));
     assertThat(querySql, containsString("where pm.personId = " + PERSON_ID));
-    assertThat(querySql, containsString("where cm.personId = " + PERSON_ID));
+    assertThat(querySql, containsString("where cm2.personId = " + PERSON_ID));
     assertThat(querySql, not(containsString("ORDERBYCLAUSE")));
     assertThat(querySql, not(containsString("LIMITCLAUSE")));
     assertThat(result, notNullValue());


### PR DESCRIPTION
`personId` will no longer be in CurriculumMembership table.

We have 2 options to fix this in traineeInfoForConnection.sql:
1. just get rid of `WHERECLAUSE(cm, personId)` --> much lower the performance for a single record export (very quickly -> more than 2s)
2. join the ProgrammeMembership table to get personId --> lower the performance for the full sync (at most 2s more than before, and around 10s in total). I think this option is more acceptable.

TIS21-2403