### PR TITLE
fix:mute unnecessary error for reval data export

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.31.1</version>
+  <version>6.31.2</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -241,8 +241,6 @@ public class RevalidationServiceImpl implements RevalidationService {
     if (connectionInfoDtos.size() == 1) {
       return connectionInfoDtos.get(0);
     } else {
-      LOG.error("There are {} connectionInfoDtos found for personId: {}",
-          connectionInfoDtos.size(), personId);
       return null;
     }
   }


### PR DESCRIPTION
This logging results in many [Sentry errors](https://health-education-england-9v.sentry.io/issues/4263002213/?project=5752964&query=&referrer=project-issue-stream).

Howeve there're always doctors in TIS don't exist in Reval, and we also exclude doctors whose gmc number == "UNKNOWN" or null, so we should remove this error logging.

no-ticket