### PR TITLE
fix:set null values when last ResultSet col was null and bump verison of tcs-client

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.31.2</version>
+  <version>6.31.3</version>
 
   <dependencies>
     <dependency>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.12.2</version>
+      <version>4.12.3</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PersonServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PersonServiceImpl.java
@@ -920,10 +920,16 @@ public class PersonServiceImpl implements PersonService {
       view.setProgrammeNumber(rs.getString("programmeNumber"));
       view.setTrainingNumber(rs.getString("trainingNumber"));
       view.setGradeId(rs.getLong("gradeId"));
+      if (rs.wasNull()) {
+        view.setGradeId(null);
+      }
       view.setGradeAbbreviation(rs.getString("gradeAbbreviation"));
 
       view.setSiteCode(rs.getString("siteCode"));
       view.setSiteId(rs.getLong("siteId"));
+      if (rs.wasNull()) {
+        view.setSiteId(null);
+      }
       view.setPlacementType(rs.getString("placementType"));
       view.setSpecialty(rs.getString("specialty"));
       view.setRole(rs.getString("role"));

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementRowMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PlacementRowMapper.java
@@ -15,8 +15,14 @@ public class PlacementRowMapper implements RowMapper<PlacementSummaryDTO> {
     dto.setDateTo(rs.getDate("dateTo"));
     dto.setPostId(rs.getLong("postId"));
     dto.setSiteId(rs.getLong("siteId"));
+    if (rs.wasNull()) {
+      dto.setSiteId(null);
+    }
     dto.setPrimarySpecialtyName(rs.getString("primarySpecialtyName"));
     dto.setGradeId(rs.getLong("gradeId"));
+    if (rs.wasNull()) {
+      dto.setGradeId(null);
+    }
     dto.setPlacementType(rs.getString("placementType"));
     dto.setStatus(rs.getString("status"));
     dto.setForenames(rs.getString("forenames"));

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
@@ -788,7 +788,7 @@ public class PostServiceImpl implements PostService {
     if (pageable.getSort() != null) {
       if (pageable.getSort().iterator().hasNext()) {
         Sort.Order order = pageable.getSort().iterator().next();
-        if ("currentTraineeSurname" .equalsIgnoreCase(order.getProperty())) {
+        if ("currentTraineeSurname".equalsIgnoreCase(order.getProperty())) {
           orderByClause.append(" ORDER BY ").append("surnames ").append(order.getDirection())
               .append(" ");
         } else {
@@ -837,7 +837,7 @@ public class PostServiceImpl implements PostService {
     }
   }
 
-  protected class PostViewRowMapper implements RowMapper<PostViewDTO> {
+  private abstract class BasePostRowMapper implements RowMapper<PostViewDTO> {
 
     @Override
     public PostViewDTO mapRow(ResultSet rs, int i) throws SQLException {
@@ -854,14 +854,23 @@ public class PostServiceImpl implements PostService {
       if (rs.wasNull()) {
         view.setPrimarySiteId(null);
       }
-      view.setProgrammeNames(rs.getString("programmes"));
-      view.setFundingType(rs.getString("fundingType"));
       view.setNationalPostNumber(rs.getString("nationalPostNumber"));
       String status = rs.getString("status");
       if (StringUtils.isNotEmpty(status)) {
         view.setStatus(Status.valueOf(status));
       }
       view.setOwner(rs.getString("owner"));
+      return view;
+    }
+  }
+
+  protected class PostViewRowMapper extends BasePostRowMapper {
+
+    @Override
+    public PostViewDTO mapRow(ResultSet rs, int i) throws SQLException {
+      PostViewDTO view = super.mapRow(rs, i);
+      view.setProgrammeNames(rs.getString("programmes"));
+      view.setFundingType(rs.getString("fundingType"));
       view.setIntrepidId(rs.getString("intrepidId"));
       view.setCurrentTraineeSurname(rs.getString("surnames"));
       view.setCurrentTraineeForenames(rs.getString("forenames"));
@@ -869,30 +878,11 @@ public class PostServiceImpl implements PostService {
     }
   }
 
-  private class PostViewSearchMapper implements RowMapper<PostViewDTO> {
+  private class PostViewSearchMapper extends BasePostRowMapper {
 
     @Override
     public PostViewDTO mapRow(ResultSet rs, int i) throws SQLException {
-      PostViewDTO view = new PostViewDTO();
-      view.setId(rs.getLong("id"));
-      view.setApprovedGradeId(rs.getLong("approvedGradeId"));
-      if (rs.wasNull()) {
-        view.setApprovedGradeId(null);
-      }
-      view.setPrimarySpecialtyId(rs.getLong("primarySpecialtyId"));
-      view.setPrimarySpecialtyCode(rs.getString("primarySpecialtyCode"));
-      view.setPrimarySpecialtyName(rs.getString("primarySpecialtyName"));
-      view.setPrimarySiteId(rs.getLong("primarySiteId"));
-      if (rs.wasNull()) {
-        view.setPrimarySiteId(null);
-      }
-      view.setNationalPostNumber(rs.getString("nationalPostNumber"));
-      String status = rs.getString("status");
-      if (StringUtils.isNotEmpty(status)) {
-        view.setStatus(Status.valueOf(status));
-      }
-      view.setOwner(rs.getString("owner"));
-      return view;
+      return super.mapRow(rs, i);
     }
   }
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
@@ -68,6 +68,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -839,6 +840,7 @@ public class PostServiceImpl implements PostService {
 
   private abstract class BasePostRowMapper implements RowMapper<PostViewDTO> {
 
+    @NonNull
     @Override
     public PostViewDTO mapRow(ResultSet rs, int i) throws SQLException {
       PostViewDTO view = new PostViewDTO();
@@ -864,6 +866,9 @@ public class PostServiceImpl implements PostService {
     }
   }
 
+  /**
+   * Creates a @link{PostViewDTO} with more detail that the summary for search results.
+   */
   protected class PostViewRowMapper extends BasePostRowMapper {
 
     @Override
@@ -878,11 +883,5 @@ public class PostServiceImpl implements PostService {
     }
   }
 
-  private class PostViewSearchMapper extends BasePostRowMapper {
-
-    @Override
-    public PostViewDTO mapRow(ResultSet rs, int i) throws SQLException {
-      return super.mapRow(rs, i);
-    }
-  }
+  private class PostViewSearchMapper extends BasePostRowMapper {}
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
@@ -844,10 +844,16 @@ public class PostServiceImpl implements PostService {
       PostViewDTO view = new PostViewDTO();
       view.setId(rs.getLong("id"));
       view.setApprovedGradeId(rs.getLong("approvedGradeId"));
+      if (rs.wasNull()) {
+        view.setApprovedGradeId(null);
+      }
       view.setPrimarySpecialtyId(rs.getLong("primarySpecialtyId"));
       view.setPrimarySpecialtyCode(rs.getString("primarySpecialtyCode"));
       view.setPrimarySpecialtyName(rs.getString("primarySpecialtyName"));
       view.setPrimarySiteId(rs.getLong("primarySiteId"));
+      if (rs.wasNull()) {
+        view.setPrimarySiteId(null);
+      }
       view.setProgrammeNames(rs.getString("programmes"));
       view.setFundingType(rs.getString("fundingType"));
       view.setNationalPostNumber(rs.getString("nationalPostNumber"));
@@ -870,10 +876,16 @@ public class PostServiceImpl implements PostService {
       PostViewDTO view = new PostViewDTO();
       view.setId(rs.getLong("id"));
       view.setApprovedGradeId(rs.getLong("approvedGradeId"));
+      if (rs.wasNull()) {
+        view.setApprovedGradeId(null);
+      }
       view.setPrimarySpecialtyId(rs.getLong("primarySpecialtyId"));
       view.setPrimarySpecialtyCode(rs.getString("primarySpecialtyCode"));
       view.setPrimarySpecialtyName(rs.getString("primarySpecialtyName"));
       view.setPrimarySiteId(rs.getLong("primarySiteId"));
+      if (rs.wasNull()) {
+        view.setPrimarySiteId(null);
+      }
       view.setNationalPostNumber(rs.getString("nationalPostNumber"));
       String status = rs.getString("status");
       if (StringUtils.isNotEmpty(status)) {

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
@@ -314,9 +314,9 @@ public class PostResourceIntTest {
     postRepository.saveAndFlush(post);
     String colFilters = new URLCodec().encode("{\"status\":[\"CURRENT\"]}");
     restPostMockMvc.perform(
-        get("/api/posts?page=0&size=100&sort=nationalPostNumber,asc&sort=id&columnFilters="
-            + colFilters)
-            .contentType(MediaType.APPLICATION_JSON))
+            get("/api/posts?page=0&size=100&sort=nationalPostNumber,asc&sort=id&columnFilters="
+                + colFilters)
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.[*].nationalPostNumber").value(TEST_POST_NUMBER))
         .andExpect(jsonPath("$.[*].fundingType").value(contains("TRUST, TARIFF")));
   }
@@ -328,8 +328,8 @@ public class PostResourceIntTest {
     PostDTO postDTO = new PostDTO();
     //when & then
     restPostMockMvc.perform(post("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[*].field").
@@ -345,8 +345,8 @@ public class PostResourceIntTest {
     postDTO.setId(1L);
     //when & then
     restPostMockMvc.perform(put("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[*].field").
@@ -362,14 +362,14 @@ public class PostResourceIntTest {
     postDTO.setId(-1L);
     //when & then
     restPostMockMvc.perform(post("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("id"));
   }
 
-  @Ignore
+  @Ignore("Purpose unclear, we might modify by adding specialties to the DTO")
   @Test
   @Transactional
   public void shouldAllowMMultipleOtherSpecialties() throws Exception {
@@ -391,8 +391,8 @@ public class PostResourceIntTest {
     PostDTO postDTO = postMapper.postToPostDTO(updatedPost);
     //when & then
     restPostMockMvc.perform(put("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isOk());
     Post dbUpdatedPost = postRepository.findById(post.getId()).orElse(null);
     assertThat(dbUpdatedPost.getSpecialties().iterator().next().getPostSpecialtyType())
@@ -406,7 +406,8 @@ public class PostResourceIntTest {
     // the Post needs a Primary specialty as well, otherwise it wouldn't be possible to set a
     // sub_specialty
     post = createEntity();
-    PostSpecialty primaryPostSpecialty = createPostSpecialty(specialty, PostSpecialtyType.PRIMARY, post);
+    PostSpecialty primaryPostSpecialty = createPostSpecialty(specialty, PostSpecialtyType.PRIMARY,
+        post);
     post.setSpecialties(new HashSet<>(Arrays.asList(primaryPostSpecialty)));
     postRepository.saveAndFlush(post);
 
@@ -425,21 +426,23 @@ public class PostResourceIntTest {
 
     PostSpecialty subspecialtyPostSpecialty = createPostSpecialty(notASubspecialty,
         PostSpecialtyType.SUB_SPECIALTY, post);
-    post.getSpecialties().stream().findFirst().ifPresent(ps -> primaryPostSpecialty.setId(ps.getId()));
-    updatedPost.setSpecialties(new HashSet<>(Arrays.asList(primaryPostSpecialty, subspecialtyPostSpecialty)));
+    post.getSpecialties().stream().findFirst()
+        .ifPresent(ps -> primaryPostSpecialty.setId(ps.getId()));
+    updatedPost.setSpecialties(
+        new HashSet<>(Arrays.asList(primaryPostSpecialty, subspecialtyPostSpecialty)));
 
     PostDTO updatedPostDto = postMapper.postToPostDTO(updatedPost);
 
     restPostMockMvc.perform(put("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(updatedPostDto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(updatedPostDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("specialties"));
 
     Post postAfterUpdate = postRepository.findById(post.getId()).orElse(null);
     Set<PostSpecialty> updatedPostSpecialtySet = postAfterUpdate.getSpecialties();
-    List <PostSpecialty> addedSubspecialties = updatedPostSpecialtySet.stream()
+    List<PostSpecialty> addedSubspecialties = updatedPostSpecialtySet.stream()
         .filter(ps -> ps.getPostSpecialtyType().equals(PostSpecialtyType.SUB_SPECIALTY))
         .collect(Collectors.toList());
 
@@ -454,7 +457,8 @@ public class PostResourceIntTest {
     // the Post needs a Primary specialty as well, otherwise it wouldn't be possible to set a
     // sub_specialty
     post = createEntity();
-    PostSpecialty primaryPostSpecialty = createPostSpecialty(specialty, PostSpecialtyType.PRIMARY, post);
+    PostSpecialty primaryPostSpecialty = createPostSpecialty(specialty, PostSpecialtyType.PRIMARY,
+        post);
     post.setSpecialties(new HashSet<>(Arrays.asList(primaryPostSpecialty)));
     postRepository.saveAndFlush(post);
 
@@ -473,19 +477,21 @@ public class PostResourceIntTest {
 
     PostSpecialty subspecialtyPostSpecialty = createPostSpecialty(aSubspecialty,
         PostSpecialtyType.SUB_SPECIALTY, post);
-    post.getSpecialties().stream().findFirst().ifPresent(ps -> primaryPostSpecialty.setId(ps.getId()));
-    updatedPost.setSpecialties(new HashSet<>(Arrays.asList(primaryPostSpecialty, subspecialtyPostSpecialty)));
+    post.getSpecialties().stream().findFirst()
+        .ifPresent(ps -> primaryPostSpecialty.setId(ps.getId()));
+    updatedPost.setSpecialties(
+        new HashSet<>(Arrays.asList(primaryPostSpecialty, subspecialtyPostSpecialty)));
 
     PostDTO updatedPostDto = postMapper.postToPostDTO(updatedPost);
 
     restPostMockMvc.perform(put("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(updatedPostDto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(updatedPostDto)))
         .andExpect(status().isOk());
 
     Post resultingUpdatedPost = postRepository.findById(post.getId()).orElse(null);
     Set<PostSpecialty> updatedPostSpecialtySet = resultingUpdatedPost.getSpecialties();
-    List <PostSpecialty> addedSubspecialties = updatedPostSpecialtySet.stream()
+    List<PostSpecialty> addedSubspecialties = updatedPostSpecialtySet.stream()
         .filter(ps -> ps.getPostSpecialtyType().equals(PostSpecialtyType.SUB_SPECIALTY))
         .collect(Collectors.toList());
 
@@ -517,8 +523,8 @@ public class PostResourceIntTest {
     PostDTO postDto = postMapper.postToPostDTO(post);
 
     restPostMockMvc.perform(post("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("error.validation"))
         .andExpect(jsonPath("$.fieldErrors[0].field").value("specialties"));
@@ -551,8 +557,8 @@ public class PostResourceIntTest {
     PostDTO postDto = postMapper.postToPostDTO(post);
 
     restPostMockMvc.perform(post("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDto)))
         .andExpect(status().isCreated());
 
     List<Post> postList = postRepository.findAll();
@@ -569,8 +575,8 @@ public class PostResourceIntTest {
     PostDTO postDTO = postMapper.postToPostDTO(anotherPost);
     // An entity with an existing ID cannot be created, so this API call must fail
     restPostMockMvc.perform(post("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isBadRequest());
     // Validate the Alice in the database
     List<Post> postList = postRepository.findAll();
@@ -645,7 +651,9 @@ public class PostResourceIntTest {
   @Test
   @Transactional
   public void shouldSearchByNationalPostNumber() throws Exception {
+    Post post = new Post();
     post.setNationalPostNumber(TEST_POST_NUMBER);
+    post.setStatus(Status.CURRENT);
     postRepository.saveAndFlush(post);
     restPostMockMvc.perform(get("/api/findByNationalPostNumber?searchQuery=TESTPOST"))
         .andExpect(status().isOk())
@@ -664,7 +672,7 @@ public class PostResourceIntTest {
     postRepository.saveAndFlush(post);
     String colFilters = new URLCodec().encode("{\"status\":[\"CURRENT\"]}");
     restPostMockMvc.perform(
-        get("/api/findByNationalPostNumber?searchQuery=TESTPOST&columnFilters=" + colFilters))
+            get("/api/findByNationalPostNumber?searchQuery=TESTPOST&columnFilters=" + colFilters))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$.[*].id").value(hasItem(post.getId().intValue())))
@@ -686,7 +694,7 @@ public class PostResourceIntTest {
     post3.setNationalPostNumber(npns.get(2));
     postRepository.saveAndFlush(post3);
     restPostMockMvc.perform(get("/api/posts?page=0&size=100&sort=nationalPostNumber,desc")
-        .contentType(MediaType.APPLICATION_JSON))
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$[0].nationalPostNumber").value("npn-03"))
         .andExpect(jsonPath("$[1].nationalPostNumber").value("npn-02"))
         .andExpect(jsonPath("$[2].nationalPostNumber").value("npn-01"))
@@ -706,9 +714,8 @@ public class PostResourceIntTest {
     Post post33 = createEntity();
     post33.setNationalPostNumber(npns1.get(2));
     postRepository.saveAndFlush(post33);
-    List<Post> posts = postRepository.findAll();
     restPostMockMvc.perform(get("/api/posts?page=0&size=100&sort=nationalPostNumber,asc")
-        .contentType(MediaType.APPLICATION_JSON))
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$[0].nationalPostNumber").value("AAAAAAAAAA"))
         .andExpect(jsonPath("$[1].nationalPostNumber").value("npn-01"))
         .andExpect(jsonPath("$[2].nationalPostNumber").value("npn-02"))
@@ -728,7 +735,7 @@ public class PostResourceIntTest {
         OWNER + "\"]}");
     // Get all the programmeList
     restPostMockMvc.perform(get("/api/posts?sort=id,desc&columnFilters=" +
-        colFilters))
+            colFilters))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.[*].status").value("INACTIVE"))
         .andExpect(jsonPath("$.[*].owner").value(hasItem(OWNER)));
@@ -744,7 +751,7 @@ public class PostResourceIntTest {
             OWNER + "\"]}");
     // Get all the programmeList
     restPostMockMvc.perform(get("/api/posts?sort=id,desc&columnFilters=" +
-        colFilters))
+            colFilters))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.[*].primarySiteId").value(hasItem(siteId.intValue())))
         .andExpect(jsonPath("$.[*].owner").value(hasItem(OWNER)));
@@ -760,7 +767,7 @@ public class PostResourceIntTest {
             OWNER + "\"]}");
     // Get all the programmeList
     restPostMockMvc.perform(get("/api/posts?sort=id,desc&columnFilters=" +
-        colFilters))
+            colFilters))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.[*].approvedGradeId").value(hasItem(gradeId.intValue())))
         .andExpect(jsonPath("$.[*].owner").value(hasItem(OWNER)));
@@ -774,7 +781,7 @@ public class PostResourceIntTest {
     String colFilters = new URLCodec().encode("{\"primarySpecialtyId\":[\"" + specialtyId + "\"]}");
     // Get all the programmeList
     restPostMockMvc.perform(get("/api/posts?sort=id,desc&columnFilters=" +
-        colFilters))
+            colFilters))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.[*].primarySpecialtyId").value(hasItem(specialtyId.intValue())))
         .andExpect(jsonPath("$.[*].owner").value(hasItem(OWNER)));
@@ -801,7 +808,7 @@ public class PostResourceIntTest {
         OWNER + "\"]}");
     // Get all the programmeList
     restPostMockMvc.perform(get("/api/posts?sort=id,desc&searchQuery=TEST&columnFilters=" +
-        colFilters))
+            colFilters))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.[*].status").value("INACTIVE"));
   }
@@ -832,7 +839,7 @@ public class PostResourceIntTest {
     postRepository.saveAndFlush(post);
     // Get the post
     restPostMockMvc.perform(get("/api/posts/in/{nationalPostNumbers}",
-        URLEncoder.encode(nationalPostNumberWithSpecialCharacters, "UTF-8")))
+            URLEncoder.encode(nationalPostNumberWithSpecialCharacters, "UTF-8")))
         .andExpect(status().isFound())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$.[0].id").value(post.getId().intValue()))
@@ -876,8 +883,8 @@ public class PostResourceIntTest {
         .localPostNumber(UPDATED_LOCAL_POST_NUMBER);
     PostDTO postDTO = postMapper.postToPostDTO(updatedPost);
     restPostMockMvc.perform(put("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isOk());
     // Validate the Post in the database
     List<Post> postList = postRepository.findAll();
@@ -905,8 +912,8 @@ public class PostResourceIntTest {
     PostDTO postDTO = postMapper.postToPostDTO(post);
     // If the entity doesn't have an ID, it will be created instead of just being updated
     restPostMockMvc.perform(put("/api/posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isBadRequest());
     // Validate the Post in the database
     List<Post> postList = postRepository.findAll();
@@ -920,7 +927,7 @@ public class PostResourceIntTest {
     int databaseSizeBeforeDelete = postRepository.findAll().size();
     // Get the post
     restPostMockMvc.perform(delete("/api/posts/{id}", post.getId())
-        .accept(MediaType.APPLICATION_JSON))
+            .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
     // Validate the database is empty
     List<Post> postList = postRepository.findAll();
@@ -954,8 +961,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkCreate = databaseSizeBeforeBulkCreate + 2;
     List<PostDTO> payload = Lists.newArrayList(postDTO, anotherPostDTO);
     restPostMockMvc.perform(post("/api/bulk-posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk());
     // Validate that both Post are in the database
     List<Post> postList = postRepository.findAll();
@@ -993,8 +1000,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList(postDTO, anotherPostDTO);
     restPostMockMvc.perform(put("/api/bulk-posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1034,8 +1041,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-new-old-posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1048,8 +1055,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList();
     restPostMockMvc.perform(patch("/api/bulk-patch-new-old-posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1064,8 +1071,8 @@ public class PostResourceIntTest {
     postDTO.setTrainingDescription("RANDOM DATA");
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-new-old-posts")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1080,15 +1087,13 @@ public class PostResourceIntTest {
     Post oldPost = createEntity();
     oldPost.setIntrepidId(POST_INTREPID_ID);
     em.persist(oldPost);
-    PostSiteDTO postSiteDTO = new PostSiteDTO();
-    postSiteDTO.setPostSiteType(PostSiteType.PRIMARY);
-    postSiteDTO.setSiteId(NEW_SITE_ID);
+    PostSiteDTO postSiteDTO = new PostSiteDTO(null, NEW_SITE_ID, PostSiteType.PRIMARY);
     postDTO.setSites(Sets.newHashSet(postSiteDTO));
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-sites")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1101,8 +1106,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList();
     restPostMockMvc.perform(patch("/api/bulk-patch-post-sites")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1117,8 +1122,8 @@ public class PostResourceIntTest {
     postDTO.setTrainingDescription("RANDOM DATA");
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-sites")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1130,15 +1135,13 @@ public class PostResourceIntTest {
   public void bulkPatchPostGradesShouldSucceedWhenDataIsValid() throws Exception {
     PostDTO postDTO = new PostDTO()
         .intrepidId(DEFAULT_INTREPID_ID);
-    PostGradeDTO postGradeDTO = new PostGradeDTO();
-    postGradeDTO.setPostGradeType(PostGradeType.APPROVED);
-    postGradeDTO.setGradeId(NEW_GRADE_ID);
+    PostGradeDTO postGradeDTO = new PostGradeDTO(null, NEW_GRADE_ID, PostGradeType.APPROVED);
     postDTO.setGrades(Sets.newHashSet(postGradeDTO));
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-grades")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1151,8 +1154,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList();
     restPostMockMvc.perform(patch("/api/bulk-patch-post-grades")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1167,8 +1170,8 @@ public class PostResourceIntTest {
     postDTO.setTrainingDescription("RANDOM DATA");
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-grades")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1190,8 +1193,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-programmes")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$.[*].programmes").isArray())
@@ -1208,8 +1211,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList();
     restPostMockMvc.perform(patch("/api/bulk-patch-post-programmes")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1224,8 +1227,8 @@ public class PostResourceIntTest {
     postDTO.setTrainingDescription("RANDOM DATA");
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-programmes")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1237,17 +1240,17 @@ public class PostResourceIntTest {
   public void bulkPatchPostSpecialtiesShouldSucceedWhenDataIsValid() throws Exception {
     PostDTO postDTO = new PostDTO()
         .intrepidId(DEFAULT_INTREPID_ID);
-    PostSpecialtyDTO postSpecialtyDTO = new PostSpecialtyDTO();
-    postSpecialtyDTO.setPostSpecialtyType(PostSpecialtyType.PRIMARY);
     SpecialtyDTO specialtyDTO = new SpecialtyDTO();
+    PostSpecialtyDTO postSpecialtyDTO = new PostSpecialtyDTO(null, specialtyDTO,
+        PostSpecialtyType.PRIMARY);
     specialtyDTO.setId(specialty.getId());
     postSpecialtyDTO.setSpecialty(specialtyDTO);
     postDTO.setSpecialties(Sets.newHashSet(postSpecialtyDTO));
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-specialties")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$.[*].specialties.[*].id").isArray())
@@ -1267,8 +1270,8 @@ public class PostResourceIntTest {
     int expectedDatabaseSizeAfterBulkUpdate = postRepository.findAll().size();
     List<PostDTO> payload = Lists.newArrayList();
     restPostMockMvc.perform(patch("/api/bulk-patch-post-specialties")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1283,8 +1286,8 @@ public class PostResourceIntTest {
     postDTO.setTrainingDescription("RANDOM DATA");
     List<PostDTO> payload = Lists.newArrayList(postDTO);
     restPostMockMvc.perform(patch("/api/bulk-patch-post-specialties")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(payload)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(payload)))
         .andExpect(status().isBadRequest());
     // Validate that both Post are still in the database
     List<Post> postList = postRepository.findAll();
@@ -1326,8 +1329,8 @@ public class PostResourceIntTest {
         .thenReturn(Collections.singletonList(fundingTypeDto));
 
     restPostMockMvc.perform(patch("/api/post/fundings")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(postDTO)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(postDTO)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$.[0].messageList", hasSize(0)))
@@ -1340,9 +1343,9 @@ public class PostResourceIntTest {
   public void shouldFilterPostsByDeaneryNumbers() throws Exception {
     List<String> npns = preparePostRecords();
     restPostMockMvc.perform(post("/api/posts/filter/deanery")
-        .contentType(MediaType.APPLICATION_JSON)
-        .param("size", "2")
-        .content(TestUtil.convertObjectToJsonBytes(npns)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("size", "2")
+            .content(TestUtil.convertObjectToJsonBytes(npns)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$").isArray())
@@ -1354,9 +1357,9 @@ public class PostResourceIntTest {
   public void shouldFilterPostsByDeaneryNumbersAndHonorsPageSize() throws Exception {
     List<String> npns = preparePostRecords();
     restPostMockMvc.perform(post("/api/posts/filter/deanery")
-        .contentType(MediaType.APPLICATION_JSON)
-        .param("size", "10")
-        .content(TestUtil.convertObjectToJsonBytes(npns)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("size", "10")
+            .content(TestUtil.convertObjectToJsonBytes(npns)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$").isArray())
@@ -1392,7 +1395,8 @@ public class PostResourceIntTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$", hasSize(1)))
-        .andExpect(jsonPath("$.[*].gradeAbbreviation").value(hasItem(DEFAULT_TRAINEE_GRADE_ABBREVIATION)))
+        .andExpect(
+            jsonPath("$.[*].gradeAbbreviation").value(hasItem(DEFAULT_TRAINEE_GRADE_ABBREVIATION)))
         .andExpect(jsonPath("$.[*].email").value(hasItem(DEFAULT_TRAINEE_EMAIL)))
         .andExpect(jsonPath("$.[*].forenames").value(hasItem(DEFAULT_TRAINEE_FORENAMES)))
         .andExpect(jsonPath("$.[*].surname").value(hasItem(DEFAULT_TRAINEE_SURNAME)))


### PR DESCRIPTION
1. bump version of tcs-client to lower the log level

2.  set null value when real value of getLong() was NULL, including:

-  PersonServiceImpl: mapper is used when `enableES` is false to decorate person views in the person list. As `enableES` is true in every environment, so I think this is not used, but it's a better-to-fix

- PlacementRowMapper: mapper is used in Peron details -> Placement Summary list. This fix will affect the UI:

Before (currently on Prod): 
![image](https://github.com/Health-Education-England/TIS-TCS/assets/33690649/0dbaaf28-5d60-484f-bd3f-4ff52b59ba38)

After (tested locally):
![image](https://github.com/Health-Education-England/TIS-TCS/assets/33690649/acdca1b5-a4a5-48d7-be4f-ad1dc80caf81)
As shown above, "0" site id will be removed from the placement summary list, leaving a pair of brackets there.

- PostViewRowMapper: mapper is used in PostView list. The fix will remove all "0" values from the parameters in the request to get the reference data, and it doesn't affect the UI.

- PostViewSearchMapper: only can be invoked via the endpoint "/api/findByNationalPostNumber", and the following decorator also shows the null values have to be removed: https://github.com/Health-Education-England/TIS-TCS/blob/10762eed0fcff7a44762b236858e9df15f3dd5cd/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/decorator/PostViewDecorator.java#L37

TIS21-4739