### PR TITLE
fix: set numeric env var as a string

### DIFF
--- a/.aws/tis-tcs-nimdta.json
+++ b/.aws/tis-tcs-nimdta.json
@@ -211,7 +211,7 @@
         },
         {
           "name": "PROFILE_JWT_CACHE_TTL",
-          "value": 10
+          "value": "10"
         }
       ]
     }

--- a/.aws/tis-tcs-preprod.json
+++ b/.aws/tis-tcs-preprod.json
@@ -211,7 +211,7 @@
         },
         {
           "name": "PROFILE_JWT_CACHE_TTL",
-          "value": 10
+          "value": "10"
         }
       ]
     }

--- a/.aws/tis-tcs-prod.json
+++ b/.aws/tis-tcs-prod.json
@@ -211,7 +211,7 @@
         },
         {
           "name": "PROFILE_JWT_CACHE_TTL",
-          "value": 10
+          "value": "10"
         }
       ]
     }


### PR DESCRIPTION
The raw numeric value is not supported in task definition env vars

TIS21-4943: ESR processing affected by profile availability