### PR TITLE
fix: add getPlacementSummaryById

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>6.2.0</version>
+  <version>6.2.1</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -377,6 +377,12 @@ public class TcsServiceImpl extends AbstractClientService {
         }).getBody();
   }
 
+  public PlacementSummaryDTO getPlacementSummaryById(Long id) {
+    return tcsRestTemplate.exchange(serviceUrl + API_PLACEMENTS + id,
+        HttpMethod.GET, null, new ParameterizedTypeReference<PlacementSummaryDTO>() {
+        }).getBody();
+  }
+
   public PostDTO getPostById(Long id) {
     return tcsRestTemplate.exchange(serviceUrl + API_POSTS + id,
         HttpMethod.GET, null, new ParameterizedTypeReference<PostDTO>() {

--- a/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplMockTest.java
+++ b/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplMockTest.java
@@ -222,6 +222,23 @@ public class TcsServiceImplMockTest {
   }
 
   @Test
+  public void getPlacementSummaryByIdShouldReturnResponse() {
+    PlacementSummaryDTO dto = new PlacementSummaryDTO();
+    dto.setPlacementId(1L);
+    dto.setTraineeId(2L);
+
+    ResponseEntity<PlacementSummaryDTO> response = ResponseEntity.ok(dto);
+    when(restTemplateMock.exchange(anyString(), eq(HttpMethod.GET), eq(null), any(
+        ParameterizedTypeReference.class))).thenReturn(response);
+
+    // When.
+    PlacementSummaryDTO returnDto = testObj.getPlacementSummaryById(2L);
+    // Then.
+    assertThat("Unexpected placement ID", returnDto.getPlacementId(), is(1L));
+    assertThat("Unexpected placement trainee ID", returnDto.getTraineeId(), is(2L));
+  }
+
+  @Test
   public void getProgrammeMembershipDetailsByIds() {
     ProgrammeMembershipCurriculaDTO dto = new ProgrammeMembershipCurriculaDTO();
     dto.setId(1L);


### PR DESCRIPTION
Bugfix incompatibility between PlacementDetailsDto and PlacementSummaryDto expected by TIS-SYNC when using getPlacementById().

NO-TICKET