### PR TITLE
feat: filter dummy trainee role

### DIFF
--- a/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
+++ b/tcs-persistence/src/main/resources/queries/traineeInfoForConnection.sql
@@ -62,6 +62,12 @@ from (
     ) currentGrade on cd.id = currentGrade.traineeId
   WHERECLAUSE(cd, id)
 ) as ot
+-- Filter based on "role" from the "Person" table
+where ot.personId not in (
+  select distinct p.id
+  from Person p
+  where lower(p.role) like '%dummy%' or lower(p.role) like '%placeholder%'
+)
 ORDERBYCLAUSE
 LIMITCLAUSE
 ;


### PR DESCRIPTION
Given that a doctor has a Person Role like ‘%Placeholder%’ or like ‘%Dummy%’
When Reval admin visits the discrepancies  page
Then they should NOT see that doctor

TIS21-4690