### PR TITLE
fix: allow unknown properties for CoJ json

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>6.19.0</version>
+  <version>6.19.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ConditionsOfJoiningDto.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/ConditionsOfJoiningDto.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.tcs.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
 import java.io.Serializable;
 import java.time.Instant;
@@ -10,6 +11,7 @@ import lombok.Data;
  * A DTO representation of a Conditions of Joining.
  */
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConditionsOfJoiningDto implements Serializable {
 
   private UUID programmeMembershipUuid;

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.19.0</version>
+      <version>6.19.1</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.19.0</version>
+      <version>6.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.33.0</version>
+  <version>6.33.1</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/mapper/ConditionsOfJoiningMapperTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/mapper/ConditionsOfJoiningMapperTest.java
@@ -1,0 +1,46 @@
+package com.transformuk.hee.tis.tcs.service.mapper;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto;
+import com.transformuk.hee.tis.tcs.api.enumeration.GoldGuideVersion;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.Test;
+
+public class ConditionsOfJoiningMapperTest {
+
+  @Test
+  public void shouldIgnoreUnknownPropertiesWhenDeserializing() throws JsonProcessingException {
+
+    UUID uuid = UUID.randomUUID();
+    Instant signedAt = Instant.now();
+    GoldGuideVersion goldGuideVersion = GoldGuideVersion.GG9;
+
+    String jsonAsString =
+        "{\"programmeMembershipUuid\":\"" + uuid.toString() + "\"," +
+        "\"signedAt\":\"" + signedAt.toString() + "\"," +
+        "\"version\":\"" + goldGuideVersion + "\"," +
+        "\"unknownField\":\"something\"}";
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    ConditionsOfJoiningDto readValue = mapper
+        .readValue(jsonAsString, ConditionsOfJoiningDto.class);
+
+    assertNotNull(readValue);
+    assertThat(readValue.getProgrammeMembershipUuid()).isEqualTo(uuid);
+    assertThat(readValue.getSignedAt()).isEqualTo(signedAt);
+    assertThat(readValue.getVersion()).isEqualTo(goldGuideVersion);
+  }
+}


### PR DESCRIPTION
To prevent errors such as
```
Caused by:
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "syncedAt" (class
com.transformuk.hee.tis.tcs.api.dto.ConditionsOfJoiningDto), not marked as ignorable (3 known properties: "version", "programmeMembershipUuid", "signedAt"])
```

`syncedAt` is used to record when the record is re-synced to TSS, it should always be null en-route to TIS.

TIS21-4714: Sync CoJ back from TIS to TSS