### PR TITLE
feat:export dto to Reval only with tcsPersonId

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.33.1</version>
+  <version>6.33.2</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -243,6 +243,9 @@ public class RevalidationServiceImpl implements RevalidationService {
     } else if (connectionInfoDtos.isEmpty()) {
       return ConnectionInfoDto.builder().tcsPersonId(personId).build();
     } else {
+      LOG.error("Found multiple TIS records via 'traineeInfoForConnection.sql' for personId: {}. "
+              + "Please note: this data update in TIS won't be sent to Reval.",
+          personId);
       return null;
     }
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImpl.java
@@ -240,6 +240,8 @@ public class RevalidationServiceImpl implements RevalidationService {
         .query(query, paramSource, new RevalidationConnectionInfoMapper());
     if (connectionInfoDtos.size() == 1) {
       return connectionInfoDtos.get(0);
+    } else if (connectionInfoDtos.isEmpty()) {
+      return ConnectionInfoDto.builder().tcsPersonId(personId).build();
     } else {
       return null;
     }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -585,6 +585,21 @@ public class RevalidationServiceImplTest {
   }
 
   @Test
+  public void shouldReturnNullWhenSqlReturnsMultiple() {
+    ConnectionInfoDto connectionInfoDto1 = ConnectionInfoDto.builder().build();
+    ConnectionInfoDto connectionInfoDto2 = ConnectionInfoDto.builder().build();
+    when(namedParameterJdbcTemplateMock.query(
+        anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(Lists.newArrayList(connectionInfoDto1, connectionInfoDto2));
+
+    ConnectionInfoDto result = testObj.buildTcsConnectionInfo(PERSON_ID);
+    verify(namedParameterJdbcTemplateMock).query(anyString(),
+        any(MapSqlParameterSource.class), any(RowMapper.class));
+
+    assertThat(result, nullValue());
+  }
+
+  @Test
   public void shouldExtractTraineeConnectionInfo() {
     when(namedParameterJdbcTemplateMock.query(
           anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/RevalidationServiceImplTest.java
@@ -5,6 +5,7 @@ import static com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipTyp
 import static java.time.LocalDate.now;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -568,16 +569,19 @@ public class RevalidationServiceImplTest {
   }
 
   @Test
-  public void shouldReturnNullWhenBuildTcsConnectionInfo() {
+  public void shouldReturnDtoOnlyWithTisPersonIdWhenSqlFilterOutRecord() {
     when(namedParameterJdbcTemplateMock.query(
-          anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
         .thenReturn(Lists.newArrayList());
 
     ConnectionInfoDto result = testObj.buildTcsConnectionInfo(PERSON_ID);
     verify(namedParameterJdbcTemplateMock).query(anyString(),
         any(MapSqlParameterSource.class), any(RowMapper.class));
 
-    assertThat(result, nullValue());
+    assertThat(result, notNullValue());
+    assertThat(result.getTcsPersonId(), equalTo(PERSON_ID));
+    assertThat(result.getGmcReferenceNumber(), nullValue());
+    assertThat(result.getProgrammeName(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
When a record is filtered out by traineeInfoForConnection.sql (null/UNKNOWN/NA gmc number or dummy role), this PR will still export a dto with only tisPersonId to Reval ES (a queue which is listened by Integration service).

The following PR is https://github.com/Health-Education-England/tis-revalidation-integration/pull/443

TIS21-5100