### PR TITLE
feat:use allowDetails to check fundingType

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.33.2</version>
+  <version>6.33.3</version>
 
   <dependencies>
     <dependency>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
-      <version>4.14.0</version>
+      <version>4.14.1</version>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidator.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Component;
 public class PostFundingValidator {
 
   protected static final String FUNDING_TYPE_EMPTY = "funding type is empty";
-  protected static final String FUNDING_TYPE_NOT_OTHER_OR_NOT_ACADEMIC_ERROR =
-      "funding type specified filled although type is not Other or not an academic type.";
+  protected static final String FUNDING_DETAILS_NOT_ALLOWED =
+      "funding details is not allowed for the funding type specified.";
   protected static final String FUNDING_TYPE_NOT_FOUND_ERROR = "funding type does not exist.";
   protected static final String FUNDING_TYPE_MULTIPLE_FOUND_ERROR = "found multiple funding type.";
 
@@ -65,10 +65,9 @@ public class PostFundingValidator {
   }
 
   private void checkInfoForFundingType(PostFundingDTO pfDto, FundingTypeDTO matchedFundingTypeDto) {
-    // Only when fundingType is Other or an academic type, the info(fundingDetails) is enabled.
-    if (!(pfDto.getFundingType().equals("Other") || matchedFundingTypeDto.isAcademic())
-        && pfDto.getInfo() != null) {
-      pfDto.getMessageList().add(FUNDING_TYPE_NOT_OTHER_OR_NOT_ACADEMIC_ERROR);
+    // Should not have fundingDetails populdated when allowDetails in FundingType reference is false
+    if (!matchedFundingTypeDto.isAllowDetails() && pfDto.getInfo() != null) {
+      pfDto.getMessageList().add(FUNDING_DETAILS_NOT_ALLOWED);
     }
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidatorTest.java
@@ -66,7 +66,7 @@ public class PostFundingValidatorTest {
   public void setup() {
     fundingTypeDTO = new FundingTypeDTO();
     fundingTypeDTO.setId(FUNDING_TYPE_ID);
-    fundingTypeDTO.setAcademic(false);
+    fundingTypeDTO.setAllowDetails(false);
     fundingTypeDTO.setLabel(FUNDING_TYPE_LABEL);
 
     multipleFundingTypeDTO = new FundingTypeDTO();
@@ -76,7 +76,7 @@ public class PostFundingValidatorTest {
     academicFundingTypeDto = new FundingTypeDTO();
     academicFundingTypeDto.setId(FUNDING_TYPE_ID);
     academicFundingTypeDto.setLabel(FUNDING_TYPE_LABEL4);
-    academicFundingTypeDto.setAcademic(true);
+    academicFundingTypeDto.setAllowDetails(true);
 
     when(referenceService.findCurrentFundingTypesByLabelIn(
         Collections.singleton(FUNDING_TYPE_LABEL)))
@@ -115,7 +115,7 @@ public class PostFundingValidatorTest {
     List<PostFundingDTO> result = postFundingValidator.validateFundingType(pfDTOs);
     assertThat(
         result.get(0).getMessageList()
-            .contains(PostFundingValidator.FUNDING_TYPE_NOT_OTHER_OR_NOT_ACADEMIC_ERROR),
+            .contains(PostFundingValidator.FUNDING_DETAILS_NOT_ALLOWED),
         is(true));
   }
 


### PR DESCRIPTION
1. FieldR `FundingType.academic` has been renamed to `FundingType.allowDetails` in Reference service.
2. Funding type "Other" has been enabled to allow Details via flyway script in Reference servie.

TIS21-4875

depends on: https://github.com/Health-Education-England/TIS-REFERENCE/pull/309