### PR TITLE
chore:remove old dbc mapper on stage

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.33.3</version>
+  <version>6.33.4</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/DesignatedBodyMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/DesignatedBodyMapper.java
@@ -14,39 +14,6 @@ import java.util.Set;
  */
 public class DesignatedBodyMapper {
 
-  static {
-    String activeProfiles = System.getenv("SPRING_PROFILES_ACTIVE");
-    USE_TEMP_MAPPER = activeProfiles != null && activeProfiles.contains("stage");
-  }
-
-  private static final boolean USE_TEMP_MAPPER;
-
-  /**
-   * Maps between a designated body code and the owners that are considered matches to that code,
-   * please note that London LETBs is considered a match for all london DBC's
-   */
-  private static final Map<String, List<String>> dbToOwnerMap = ImmutableMap.<String, List<String>>builder()
-      //London LETBs match any of the london DBC's
-      .put("1-AIIDR8",
-          Lists.newArrayList("Health Education England Kent, Surrey and Sussex", "London LETBs"))
-      .put("1-AIIDWA",
-          Lists.newArrayList("Health Education England North West London", "London LETBs"))
-      .put("1-AIIDVS", Lists
-          .newArrayList("Health Education England North Central and East London", "London LETBs"))
-      .put("1-AIIDWI", Lists.newArrayList("Health Education England South London", "London LETBs"))
-
-      .put("1-AIIDSA", Lists.newArrayList("Health Education England East Midlands"))
-      .put("1-AIIDWT", Lists.newArrayList("Health Education England East of England"))
-      .put("1-AIIDSI", Lists.newArrayList("Health Education England North East"))
-      .put("1-AIIDH1", Lists.newArrayList("Health Education England Thames Valley"))
-      .put("1-1P9Y9QH", Lists.newArrayList("Health Education England Yorkshire and the Humber"))
-      .put("1-AIIDMY", Lists.newArrayList("Health Education England West Midlands"))
-      .put("1-AIIDMQ", Lists.newArrayList("Health Education England South West"))
-      .put("1-AIIDHJ", Lists.newArrayList("Health Education England Wessex"))
-      .put("1-1P9Y9R1", Lists.newArrayList("Health Education England North West"))
-      .put("1-25U-830", Lists.newArrayList("Northern Ireland Medical and Dental Training Agency"))
-      .build();
-
   /**
    * Maps between a designated body code and the owners that are considered matches to that code,
    * please note that London LETBs is considered a match for all london DBC's
@@ -82,10 +49,9 @@ public class DesignatedBodyMapper {
   public static Set<String> map(Set<String> dbcs) {
     Preconditions.checkNotNull(dbcs);
     Set<String> owners = new HashSet<>();
-    Map<String, List<String>> mapToUse = USE_TEMP_MAPPER ? dbToOwnerMap : heeDbToOwnerMap;
     dbcs.forEach(dbc -> {
-      if (mapToUse.containsKey(dbc)) {
-        owners.addAll(mapToUse.get(dbc));
+      if (heeDbToOwnerMap.containsKey(dbc)) {
+        owners.addAll(heeDbToOwnerMap.get(dbc));
       }
     });
     return owners;
@@ -97,11 +63,7 @@ public class DesignatedBodyMapper {
   public static Set<String> getAllOwners() {
     if (allOwners == null) {
       allOwners = new HashSet<>();
-      if (USE_TEMP_MAPPER) {
-        dbToOwnerMap.values().forEach(v -> allOwners.addAll(v));
-      } else {
-        heeDbToOwnerMap.values().forEach(v -> allOwners.addAll(v));
-      }
+      heeDbToOwnerMap.values().forEach(v -> allOwners.addAll(v));
     }
     return allOwners;
   }
@@ -111,13 +73,11 @@ public class DesignatedBodyMapper {
    * @return the corresponding designated body code
    */
   public static String getDbcByOwner(String owner) {
-    Map<String, List<String>> mapToUse = USE_TEMP_MAPPER ? dbToOwnerMap : heeDbToOwnerMap;
-    for (Entry<String, List<String>> entry : mapToUse.entrySet()) {
+    for (Entry<String, List<String>> entry : heeDbToOwnerMap.entrySet()) {
       if (entry.getValue().contains(owner)) {
         return entry.getKey();
       }
     }
     return null;
   }
-
 }


### PR DESCRIPTION
The old dbc mapper is not needed as the GMC updated their test env using new prod dbcs.

TIS21-4657