### PR TITLE
feat:add validation to PostFunding Update

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.35.0</version>
+  <version>6.36.0</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PostFundingResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PostFundingResource.java
@@ -3,11 +3,13 @@ package com.transformuk.hee.tis.tcs.service.api;
 import com.transformuk.hee.tis.tcs.api.dto.PostFundingDTO;
 import com.transformuk.hee.tis.tcs.service.api.util.HeaderUtil;
 import com.transformuk.hee.tis.tcs.service.api.util.PaginationUtil;
+import com.transformuk.hee.tis.tcs.service.api.validation.PostFundingValidator;
 import com.transformuk.hee.tis.tcs.service.service.PostFundingService;
 import io.github.jhipster.web.util.ResponseUtil;
 import io.jsonwebtoken.lang.Collections;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -40,9 +42,12 @@ public class PostFundingResource {
   private static final String ENTITY_NAME = "postFunding";
   private final Logger log = LoggerFactory.getLogger(PostFundingResource.class);
   private final PostFundingService postFundingService;
+  private final PostFundingValidator postFundingValidator;
 
-  public PostFundingResource(PostFundingService postFundingService) {
+  public PostFundingResource(PostFundingService postFundingService,
+      PostFundingValidator postFundingValidator) {
     this.postFundingService = postFundingService;
+    this.postFundingValidator = postFundingValidator;
   }
 
   /**
@@ -86,10 +91,14 @@ public class PostFundingResource {
     if (postFundingDTO.getId() == null) {
       return createPostFunding(postFundingDTO);
     }
-    PostFundingDTO result = postFundingService.save(postFundingDTO);
+    PostFundingDTO returnedPostFundingDto =
+        postFundingValidator.validateFundingType(Arrays.asList(postFundingDTO)).get(0);
+    if (returnedPostFundingDto.getMessageList().isEmpty()) {
+      returnedPostFundingDto = postFundingService.save(postFundingDTO);
+    }
     return ResponseEntity.ok()
         .headers(HeaderUtil.createEntityUpdateAlert(ENTITY_NAME, postFundingDTO.getId().toString()))
-        .body(result);
+        .body(returnedPostFundingDto);
   }
 
   /**

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidator.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,8 +22,11 @@ public class PostFundingValidator {
   protected static final String FUNDING_SUB_TYPE_NOT_FOUND =
       "Funding sub type not found for this funding type";
 
-  @Autowired
   private ReferenceServiceImpl referenceService;
+
+  public PostFundingValidator(ReferenceServiceImpl referenceService) {
+    this.referenceService = referenceService;
+  }
 
   public List<PostFundingDTO> validateFundingType(List<PostFundingDTO> checkList) {
     if (checkList.isEmpty()) {


### PR DESCRIPTION
The following PR is https://github.com/Health-Education-England/TIS-GENERIC-UPLOAD/pull/236

1. I couldn't find any clue the endpoints `/post-fundings/XXX` are used in the frontend UI.
2. In person validator, we separate the endpoint for bulk upload to a patch API, and for frontend endpoints we return a `MethodArgumentNotValidException`. But we didn't do this way in that way. I'm not very sure if I should create a new endpoin like what we did for person validator.

TIS21-5384