### PR TITLE
fix: catch additional exceptions

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.36.1</version>
+  <version>6.36.2</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
@@ -78,7 +78,7 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
       entity = repository.save(mapper.toEntity(dto));
     } catch (NonTransientDataAccessException e) {
       throw new IllegalArgumentException(
-          String.format("Unable to save Conditions of Joining for  %s.", id), e);
+          String.format("Unable to save Conditions of Joining %s.", id), e);
     }
     LOG.info("Saved Conditions of Joining for Programme Membership with UUID {}.",
         programmeMembershipUuid);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.NonTransientDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +60,10 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
           StringUtils.isNumeric(id.toString()) ? curriculumMembershipRepository
               .getOne(Long.parseLong(id.toString())).getProgrammeMembership()
               : programmeMembershipRepository.getOne(UUID.fromString(id.toString()));
+      if (programmeMembership == null) {
+        throw new IllegalArgumentException(String.format("No Programme Membership for %s.", id));
+      }
+      LOG.debug("Found ProgrammeMembership {}", programmeMembership);
     } catch (EntityNotFoundException e) {
       throw new IllegalArgumentException(String.format("Programme Membership %s not found.", id),
           e);
@@ -68,7 +73,13 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
     dto.setProgrammeMembershipUuid(programmeMembershipUuid);
     LOG.info("Saving Conditions of Joining for Programme Membership with UUID {}.",
         programmeMembershipUuid);
-    ConditionsOfJoining entity = repository.save(mapper.toEntity(dto));
+    ConditionsOfJoining entity;
+    try {
+      entity = repository.save(mapper.toEntity(dto));
+    } catch (NonTransientDataAccessException e) {
+      throw new IllegalArgumentException(
+          String.format("Unable to save Conditions of Joining for  %s.", id), e);
+    }
     LOG.info("Saved Conditions of Joining for Programme Membership with UUID {}.",
         programmeMembershipUuid);
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
@@ -24,6 +24,7 @@ import javax.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
+import org.springframework.dao.DataIntegrityViolationException;
 
 class ConditionsOfJoiningServiceImplTest {
 
@@ -69,6 +70,17 @@ class ConditionsOfJoiningServiceImplTest {
     assertThrows(IllegalArgumentException.class,
         () -> conditionsOfJoiningService.save(PROGRAMME_MEMBERSHIP_UUID, coj));
     verify(repository, never()).save(any());
+  }
+
+  @Test
+  void saveShouldThrowExceptionWhenCojConstraintFails() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setUuid(UUID.randomUUID());
+    when(programmeMembershipRepository.getOne(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(pm);
+    when(repository.save(any())).thenThrow(new DataIntegrityViolationException("expected"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> conditionsOfJoiningService.save(PROGRAMME_MEMBERSHIP_UUID, coj));
   }
 
   @Test


### PR DESCRIPTION
This is very belt and braces because of it shouldn't have happened. We should not have ended up with a  DataAccessEXception. We catch that but also check the returned ProgrammeMembership.

NO-CARD: Catch-up time