### PR TITLE
fix:make fundingType case insensitive in PostFundingValidator

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.36.2</version>
+  <version>6.36.3</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidator.java
@@ -59,10 +59,13 @@ public class PostFundingValidator {
   private FundingTypeDTO checkFundingTypeExists(PostFundingDTO pfDto,
       List<FundingTypeDTO> fundingTypeDtos) {
     List<FundingTypeDTO> filteredFundingTypeDtos = fundingTypeDtos.stream().filter(
-            fundingTypeDto -> StringUtils.equals(fundingTypeDto.getLabel(), pfDto.getFundingType()))
-        .collect(Collectors.toList());
+        fundingTypeDto -> StringUtils.equalsIgnoreCase(fundingTypeDto.getLabel(),
+            pfDto.getFundingType())).collect(Collectors.toList());
     if (filteredFundingTypeDtos.size() == 1) {
-      return filteredFundingTypeDtos.get(0);
+      FundingTypeDTO matchedFundingTypeDto = filteredFundingTypeDtos.get(0);
+      // When fundingType is verified, use the label from reference object
+      pfDto.setFundingType(matchedFundingTypeDto.getLabel());
+      return matchedFundingTypeDto;
     } else if (filteredFundingTypeDtos.isEmpty()) {
       pfDto.getMessageList().add(FUNDING_TYPE_NOT_FOUND_ERROR);
     } else {

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PostFundingValidatorTest.java
@@ -154,9 +154,16 @@ public class PostFundingValidatorTest {
 
   @Test
   public void testValidateSuccessfully() {
+    validDTO.setFundingType(FUNDING_TYPE_LABEL.toUpperCase());
+    when(referenceService.findCurrentFundingTypesByLabelIn(
+        Collections.singleton(FUNDING_TYPE_LABEL.toUpperCase())))
+        .thenReturn(Collections.singletonList(fundingTypeDTO));
     pfDTOs = buildCheckedList(validDTO);
+
     List<PostFundingDTO> result = postFundingValidator.validateFundingType(pfDTOs);
+
     assertThat(result.get(0).getMessageList().isEmpty(), is(true));
+    assertThat(result.get(0).getFundingType(), is(FUNDING_TYPE_LABEL));
   }
 
   @Test


### PR DESCRIPTION
This validator is currently used for bulk upload PostFunding Update validation. And we have to allow user input funding typ to be case insensitive.

TIS21-5384