### PR TITLE
feat: add blockIndemnity field to Specialty

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>6.20.2</version>
+  <version>6.21.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/SpecialtyDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/SpecialtyDTO.java
@@ -47,6 +47,8 @@ public class SpecialtyDTO implements Serializable {
       Update.class}, min = 1, max = 100, message = "Name cannot be less than 1 and more than 100 characters")
   private String name;
 
+  private boolean blockIndemnity;
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>6.2.1</version>
+  <version>6.2.2</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.20.1</version>
+      <version>6.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,12 +13,12 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.29.4</version>
+  <version>2.30.0</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.20.2</version>
+      <version>6.21.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
@@ -71,6 +71,9 @@ public class Specialty implements Serializable {
   @OneToMany(mappedBy = "specialty", fetch = FetchType.LAZY)
   private Set<PlacementSpecialty> placementSpecialty;
 
+  @Column(name = "blockIndemnity")
+  private boolean blockIndemnity;
+
   public Specialty status(Status status) {
     this.status = status;
     return this;
@@ -108,6 +111,11 @@ public class Specialty implements Serializable {
 
   public Specialty name(String name) {
     this.name = name;
+    return this;
+  }
+
+  public Specialty blockIndemnity(boolean blockIndemnity) {
+    this.blockIndemnity = blockIndemnity;
     return this;
   }
 

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.36.3</version>
+  <version>6.37.0</version>
 
   <dependencies>
     <dependency>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.29.4</version>
+      <version>2.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/SpecialtyMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/SpecialtyMapper.java
@@ -28,6 +28,7 @@ public class SpecialtyMapper {
       result.setSpecialtyTypes(specialty.getSpecialtyTypes());
       result.setStatus(specialty.getStatus());
       result.setSpecialtyGroup(specialtyGroupToSpecialtyGroupDTO(specialty.getSpecialtyGroup()));
+      result.setBlockIndemnity(specialty.isBlockIndemnity());
     }
     return result;
   }
@@ -54,7 +55,7 @@ public class SpecialtyMapper {
       result.setSpecialtyTypes(specialtyDTO.getSpecialtyTypes());
       result.setStatus(specialtyDTO.getStatus());
       result.setSpecialtyGroup(specialtyGroupDTOToSpecialtyGroup(specialtyDTO.getSpecialtyGroup()));
-
+      result.setBlockIndemnity(specialtyDTO.isBlockIndemnity());
     }
     return result;
   }

--- a/tcs-service/src/main/resources/db/migration/schema/V4.29__add_block_indemnity_to_specialty.sql
+++ b/tcs-service/src/main/resources/db/migration/schema/V4.29__add_block_indemnity_to_specialty.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `Specialty`
+ADD COLUMN `blockIndemnity` BOOLEAN DEFAULT FALSE;

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceIntTest.java
@@ -116,7 +116,8 @@ public class SpecialtyResourceIntTest {
         .specialtyCode(DEFAULT_NHS_SPECIALTY_CODE)
         .specialtyTypes(newHashSet(DEFAULT_SPECIALTY_TYPE))
         .intrepidId(DEFAULT_INTREPID_ID)
-        .name(DEFAULT_NAME);
+        .name(DEFAULT_NAME)
+        .blockIndemnity(true);
   }
 
   public static SpecialtyGroup createSpecialtyGroupEntity() {
@@ -171,6 +172,7 @@ public class SpecialtyResourceIntTest {
     assertThat(testSpecialty.getCollege()).isEqualTo(DEFAULT_COLLEGE);
     assertThat(testSpecialty.getSpecialtyCode()).isEqualTo(DEFAULT_NHS_SPECIALTY_CODE);
     assertThat(testSpecialty.getSpecialtyTypes()).isEqualTo(newHashSet(DEFAULT_SPECIALTY_TYPE));
+    assertThat(testSpecialty.isBlockIndemnity()).isEqualTo(true);
   }
 
   @Test
@@ -301,7 +303,8 @@ public class SpecialtyResourceIntTest {
         .andExpect(jsonPath("$.[*].status").value(hasItem(DEFAULT_STATUS.toString().toUpperCase())))
         .andExpect(jsonPath("$.[*].college").value(hasItem(DEFAULT_COLLEGE)))
         .andExpect(jsonPath("$.[*].specialtyCode").value(hasItem(DEFAULT_NHS_SPECIALTY_CODE)))
-        .andExpect(jsonPath("$.[*].specialtyTypes[0]").value(DEFAULT_SPECIALTY_TYPE.toString()));
+        .andExpect(jsonPath("$.[*].specialtyTypes[0]").value(DEFAULT_SPECIALTY_TYPE.toString()))
+        .andExpect(jsonPath("$.[*].blockIndemnity").value(true));
   }
 
   @Test
@@ -353,7 +356,8 @@ public class SpecialtyResourceIntTest {
         .andExpect(jsonPath("$.college").value(DEFAULT_COLLEGE))
         .andExpect(jsonPath("$.specialtyCode").value(DEFAULT_NHS_SPECIALTY_CODE))
         .andExpect(jsonPath("$.specialtyTypes[0]").value(DEFAULT_SPECIALTY_TYPE.toString()))
-        .andExpect(jsonPath("$.specialtyGroup.id").value(specialtyGroup.getId().intValue()));
+        .andExpect(jsonPath("$.specialtyGroup.id").value(specialtyGroup.getId().intValue()))
+        .andExpect(jsonPath("$.blockIndemnity").value(true));
   }
 
   @Test
@@ -538,7 +542,8 @@ public class SpecialtyResourceIntTest {
         .college(UPDATED_COLLEGE)
         .specialtyCode(UPDATED_NHS_SPECIALTY_CODE)
         .specialtyTypes(newHashSet(UPDATED_SPECIALTY_TYPE))
-        .name(UPDATED_NAME);
+        .name(UPDATED_NAME)
+        .blockIndemnity(false);
     SpecialtyDTO specialtyDTO = linkSpecialtyToSpecialtyGroup(updatedSpecialty,
         specialtyGroupEntity.getId());
 
@@ -555,6 +560,7 @@ public class SpecialtyResourceIntTest {
     assertThat(testSpecialty.getCollege()).isEqualTo(UPDATED_COLLEGE);
     assertThat(testSpecialty.getSpecialtyCode()).isEqualTo(UPDATED_NHS_SPECIALTY_CODE);
     assertThat(testSpecialty.getSpecialtyTypes()).isEqualTo(newHashSet(UPDATED_SPECIALTY_TYPE));
+    assertThat(testSpecialty.isBlockIndemnity()).isEqualTo(false);
 
     // validate if the PostSpecialty still exists and if it's updated
     Optional<PostSpecialty> optionalPostSpecialty =

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/SpecialtyResourceTest.java
@@ -81,6 +81,7 @@ public class SpecialtyResourceTest {
     specialtyDTO.setSpecialtyCode(SPECIALTY_CODE);
     specialtyDTO.setStatus(Status.CURRENT);
     specialtyDTO.setCollege(SPECIALTY_COLLEGE);
+    specialtyDTO.setBlockIndemnity(true);
 
     anotherSpecialtyDTO = new SpecialtyDTO();
     anotherSpecialtyDTO.setId(ANOTHER_SPECIALTY_ID);
@@ -88,6 +89,7 @@ public class SpecialtyResourceTest {
     anotherSpecialtyDTO.setSpecialtyCode(ANOTHER_SPECIALTY_CODE);
     anotherSpecialtyDTO.setStatus(Status.INACTIVE);
     anotherSpecialtyDTO.setCollege(ANOTHER_SPECIALTY_COLLEGE);
+    anotherSpecialtyDTO.setBlockIndemnity(false);
 
   }
 
@@ -115,6 +117,7 @@ public class SpecialtyResourceTest {
         .andExpect(jsonPath("$.content[0].college").value(SPECIALTY_COLLEGE))
         .andExpect(jsonPath("$.content[0].specialtyCode").value(SPECIALTY_CODE))
         .andExpect(jsonPath("$.content[0].name").value(SPECIALTY_NAME))
+        .andExpect(jsonPath("$.content[0].blockIndemnity").value(true))
     ;
 
     verify(specialtyServiceMock).getPagedSpecialtiesForProgrammeId(programmeId, null, page);
@@ -146,6 +149,7 @@ public class SpecialtyResourceTest {
         .andExpect(jsonPath("$.content[0].college").value(SPECIALTY_COLLEGE))
         .andExpect(jsonPath("$.content[0].specialtyCode").value(SPECIALTY_CODE))
         .andExpect(jsonPath("$.content[0].name").value(SPECIALTY_NAME))
+        .andExpect(jsonPath("$.content[0].blockIndemnity").value(true))
     ;
     verify(specialtyServiceMock).getPagedSpecialtiesForProgrammeId(programmeId, query, page);
   }
@@ -173,6 +177,7 @@ public class SpecialtyResourceTest {
             .value(Matchers.hasItems(SPECIALTY_CODE, ANOTHER_SPECIALTY_CODE)))
         .andExpect(
             jsonPath("$.[*].name").value(Matchers.hasItems(SPECIALTY_NAME, ANOTHER_SPECIALTY_NAME)))
+        .andExpect(jsonPath("$.[*].blockIndemnity").value(Matchers.hasItems(true, false)))
     ;
 
     verify(specialtyServiceMock).getSpecialtiesForProgrammeAndPerson(programmeId, personId);


### PR DESCRIPTION
The block indemnity field will be used to set whether a specialty a trainee is in is covered by a block indemnity scheme. Update the specialty to include a new blockIndemnity column/field in the database, model and DTO.

TIS21-5674
TIS21-5802