### PR TITLE
fix:set currentOnly=true for person validators

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.40.0</version>
+  <version>6.40.1</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidator.java
@@ -56,7 +56,7 @@ public class ContactDetailsValidator {
    */
   public void validate(ContactDetailsDTO dto)
       throws MethodArgumentNotValidException, NoSuchMethodException {
-    final boolean currentOnly = false;
+    final boolean currentOnly = true;
     List<FieldError> fieldErrors = new ArrayList<>();
     fieldErrors.addAll(checkTitle(dto, currentOnly));
     fieldErrors.addAll(checkEmail(dto));

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/GdcDetailsValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/GdcDetailsValidator.java
@@ -44,7 +44,7 @@ public class GdcDetailsValidator {
    */
   public void validate(GdcDetailsDTO gdcDetailsDTO) throws MethodArgumentNotValidException {
 
-    final boolean currentOnly = false;
+    final boolean currentOnly = true;
     List<FieldError> fieldErrors = new ArrayList<>();
 //    fieldErrors.addAll(checkGdcStatus(gdcDetailsDTO));
     fieldErrors.addAll(checkGdcNumber(gdcDetailsDTO));

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidator.java
@@ -42,7 +42,7 @@ public class GmcDetailsValidator {
    */
   public void validate(GmcDetailsDTO gmcDetailsDTO) throws MethodArgumentNotValidException {
 
-    final boolean currentOnly = false;
+    final boolean currentOnly = true;
     List<FieldError> fieldErrors = new ArrayList<>();
 //    fieldErrors.addAll(checkGmcStatus(gmcDetailsDTO));
     fieldErrors.addAll(checkGmcNumber(gmcDetailsDTO));

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonalDetailsValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/PersonalDetailsValidator.java
@@ -44,7 +44,7 @@ public class PersonalDetailsValidator {
    */
   public void validate(PersonalDetailsDTO personalDetailsDTO)
       throws MethodArgumentNotValidException {
-    final boolean currentOnly = false;
+    final boolean currentOnly = true;
     List<FieldError> fieldErrors = new ArrayList<>();
     fieldErrors.addAll(checkGender(personalDetailsDTO, currentOnly));
     fieldErrors.addAll(checkNationality(personalDetailsDTO, currentOnly));

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/GdcDetailsResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/GdcDetailsResourceIntTest.java
@@ -137,7 +137,7 @@ public class GdcDetailsResourceIntTest {
     // Create the GdcDetails
     GdcDetailsDTO gdcDetailsDTO = gdcDetailsMapper.toDto(gdcDetails);
 
-    Mockito.when(referenceService.isValueExists(GdcStatusDTO.class, gdcDetailsDTO.getGdcStatus(), false))
+    Mockito.when(referenceService.isValueExists(GdcStatusDTO.class, gdcDetailsDTO.getGdcStatus(), true))
         .thenReturn(true);
 
     restGdcDetailsMockMvc.perform(post("/api/gdc-details")
@@ -214,7 +214,7 @@ public class GdcDetailsResourceIntTest {
     gdcDetails.setId(1L);
     GdcDetailsDTO gdcDetailsDTO = gdcDetailsMapper.toDto(gdcDetails);
 
-    Mockito.when(referenceService.isValueExists(GdcStatusDTO.class, gdcDetailsDTO.getGdcStatus(), false))
+    Mockito.when(referenceService.isValueExists(GdcStatusDTO.class, gdcDetailsDTO.getGdcStatus(), true))
         .thenReturn(true);
 
     // Gdc details is part of person so the call must succeed
@@ -285,7 +285,7 @@ public class GdcDetailsResourceIntTest {
     updatedGdcDetailsDTO.setGdcNumber(UPDATED_GDC_NUMBER);
     updatedGdcDetailsDTO.setGdcStatus(UPDATED_GDC_STATUS);
 
-    Mockito.when(referenceService.isValueExists(GdcStatusDTO.class, updatedGdcDetailsDTO.getGdcStatus(), false))
+    Mockito.when(referenceService.isValueExists(GdcStatusDTO.class, updatedGdcDetailsDTO.getGdcStatus(), true))
         .thenReturn(true);
 
     restGdcDetailsMockMvc.perform(put("/api/gdc-details")

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/GmcDetailsResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/GmcDetailsResourceIntTest.java
@@ -137,7 +137,7 @@ public class GmcDetailsResourceIntTest {
     // Create the GmcDetails
     GmcDetailsDTO gmcDetailsDTO = gmcDetailsMapper.toDto(gmcDetails);
 
-    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, gmcDetailsDTO.getGmcStatus(), false))
+    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, gmcDetailsDTO.getGmcStatus(), true))
         .thenReturn(true);
 
     restGmcDetailsMockMvc.perform(post("/api/gmc-details")
@@ -216,7 +216,7 @@ public class GmcDetailsResourceIntTest {
     anotherGmcDetailsDTO.setGmcStatus(DEFAULT_GMC_STATUS);
 
     Mockito.when(
-        referenceService.isValueExists(GmcStatusDTO.class, anotherGmcDetailsDTO.getGmcStatus(), false))
+        referenceService.isValueExists(GmcStatusDTO.class, anotherGmcDetailsDTO.getGmcStatus(), true))
         .thenReturn(true);
 
     // Create the GmcDetails
@@ -247,7 +247,7 @@ public class GmcDetailsResourceIntTest {
     //Try to update second gmc details with default gmc number
     anotherGmcDetailsDTO.setGmcNumber(DEFAULT_GMC_NUMBER);
 
-    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, UPDATED_GMC_STATUS, false))
+    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, UPDATED_GMC_STATUS, true))
         .thenReturn(true);
 
     // Create the GmcDetails
@@ -288,7 +288,7 @@ public class GmcDetailsResourceIntTest {
     gmcDetails.setId(1L);
     GmcDetailsDTO gmcDetailsDTO = gmcDetailsMapper.toDto(gmcDetails);
 
-    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, gmcDetailsDTO.getGmcStatus(), false))
+    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, gmcDetailsDTO.getGmcStatus(), true))
         .thenReturn(true);
 
     // GMC details is part of person so the call must succeed
@@ -361,7 +361,7 @@ public class GmcDetailsResourceIntTest {
     updatedGmcDetailsDTO.setGmcStartDate(UPDATED_GMC_START_DATE);
     updatedGmcDetailsDTO.setGmcEndDate(UPDATED_GMC_END_DATE);
 
-    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, UPDATED_GMC_STATUS, false))
+    Mockito.when(referenceService.isValueExists(GmcStatusDTO.class, UPDATED_GMC_STATUS, true))
         .thenReturn(true);
 
     restGmcDetailsMockMvc.perform(put("/api/gmc-details")

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/ContactDetailsValidatorTest.java
@@ -61,7 +61,7 @@ class ContactDetailsValidatorTest {
     ContactDetailsDTO dto = new ContactDetailsDTO();
     dto.setTitle("myTitle");
 
-    when(referenceService.isValueExists(TitleDTO.class, "myTitle", false)).thenReturn(false);
+    when(referenceService.isValueExists(TitleDTO.class, "myTitle", true)).thenReturn(false);
 
     // When.
     MethodArgumentNotValidException thrown =
@@ -84,7 +84,7 @@ class ContactDetailsValidatorTest {
     ContactDetailsDTO dto = new ContactDetailsDTO();
     dto.setTitle("myTitle");
 
-    when(referenceService.isValueExists(TitleDTO.class, "myTitle", false)).thenReturn(true);
+    when(referenceService.isValueExists(TitleDTO.class, "myTitle", true)).thenReturn(true);
 
     // When.
     assertDoesNotThrow(() -> validator.validate(dto));

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/GdcDetailsValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/GdcDetailsValidatorTest.java
@@ -197,7 +197,7 @@ class GdcDetailsValidatorTest {
     // Given.
     when(GdcDetailsDTOMock.getGdcNumber()).thenReturn(DEFAULT_GDC_NUMBER);
     when(GdcDetailsDTOMock.getGdcStatus()).thenReturn(DEFAULT_GDC_STATUS);
-    when(referenceService.isValueExists(GdcStatusDTO.class, DEFAULT_GDC_STATUS, false))
+    when(referenceService.isValueExists(GdcStatusDTO.class, DEFAULT_GDC_STATUS, true))
         .thenReturn(false);
 
     // When.
@@ -220,7 +220,7 @@ class GdcDetailsValidatorTest {
     // Given.
     when(GdcDetailsDTOMock.getGdcNumber()).thenReturn(DEFAULT_GDC_NUMBER);
     when(GdcDetailsDTOMock.getGdcStatus()).thenReturn(DEFAULT_GDC_STATUS);
-    when(referenceService.isValueExists(GdcStatusDTO.class, DEFAULT_GDC_STATUS, false))
+    when(referenceService.isValueExists(GdcStatusDTO.class, DEFAULT_GDC_STATUS, true))
         .thenReturn(true);
 
     // When, then.

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidatorTest.java
@@ -178,7 +178,7 @@ class GmcDetailsValidatorTest {
     // Given.
     when(gmcDetailsDtoMock.getGmcNumber()).thenReturn(DEFAULT_GMC_NUMBER);
     when(gmcDetailsDtoMock.getGmcStatus()).thenReturn(DEFAULT_GMC_STATUS);
-    when(referenceService.isValueExists(GmcStatusDTO.class, DEFAULT_GMC_STATUS, false))
+    when(referenceService.isValueExists(GmcStatusDTO.class, DEFAULT_GMC_STATUS, true))
         .thenReturn(false);
 
     // When.
@@ -201,7 +201,7 @@ class GmcDetailsValidatorTest {
     // Given.
     when(gmcDetailsDtoMock.getGmcNumber()).thenReturn(DEFAULT_GMC_NUMBER);
     when(gmcDetailsDtoMock.getGmcStatus()).thenReturn(DEFAULT_GMC_STATUS);
-    when(referenceService.isValueExists(GmcStatusDTO.class, DEFAULT_GMC_STATUS, false))
+    when(referenceService.isValueExists(GmcStatusDTO.class, DEFAULT_GMC_STATUS, true))
         .thenReturn(true);
 
     // When, then.


### PR DESCRIPTION
A bulk upload issue was caused by 2 nationalities found for nationality name `Filipino`, so we set one of them to inactive in Reference. 
However, in PersonDetailValidator.validate(), we don't apply the filter to only get current values. 
And after a chat with James, we believe that `currentOnly=true` should be applied for all of the validators.

https://hee-nhs-tis.slack.com/archives/C03GBMYGZD4/p1713862211313339?thread_ts=1713783032.319379&cid=C03GBMYGZD4

TIS-SHED