### PR TITLE
fix: CoJ find-PM code refactor

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.41.0</version>
+  <version>6.41.1</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImpl.java
@@ -56,28 +56,24 @@ public class ConditionsOfJoiningServiceImpl implements ConditionsOfJoiningServic
   public ConditionsOfJoiningDto save(Object id, ConditionsOfJoiningDto dto) {
     Optional<ProgrammeMembership> programmeMembershipOptional = Optional.empty();
     LOG.info("Request received to save Conditions of Joining for id {}.", id);
-    try {
-      // Deprecated structure and will be removed. JIRA - TIS21-2446: ProgrammeMembership refactor
-      if (StringUtils.isNumeric(id.toString())) {
-        Optional<CurriculumMembership> curriculumMembershipOptional
-            = curriculumMembershipRepository.findById(Long.parseLong(id.toString()));
-        if (curriculumMembershipOptional.isPresent()) {
-          programmeMembershipOptional = Optional.of(
-              curriculumMembershipOptional.get().getProgrammeMembership());
-        }
-      } else {
-        programmeMembershipOptional = programmeMembershipRepository.findByUuid(
-            UUID.fromString(id.toString()));
-      }
 
-      if (!programmeMembershipOptional.isPresent()) {
-        throw new IllegalArgumentException(String.format("No Programme Membership for %s.", id));
+    // Deprecated structure and will be removed. JIRA - TIS21-2446: ProgrammeMembership refactor
+    if (StringUtils.isNumeric(id.toString())) {
+      Optional<CurriculumMembership> curriculumMembershipOptional
+          = curriculumMembershipRepository.findById(Long.parseLong(id.toString()));
+      if (curriculumMembershipOptional.isPresent()) {
+        programmeMembershipOptional = Optional.of(
+            curriculumMembershipOptional.get().getProgrammeMembership());
       }
-      LOG.debug("Found ProgrammeMembership {}", programmeMembershipOptional.get());
-    } catch (EntityNotFoundException e) {
-      throw new IllegalArgumentException(String.format("Programme Membership %s not found.", id),
-          e);
+    } else {
+      programmeMembershipOptional = programmeMembershipRepository.findByUuid(
+          UUID.fromString(id.toString()));
     }
+
+    if (!programmeMembershipOptional.isPresent()) {
+      throw new IllegalArgumentException(String.format("No Programme Membership for %s.", id));
+    }
+    LOG.debug("Found ProgrammeMembership {}", programmeMembershipOptional.get());
 
     UUID programmeMembershipUuid = programmeMembershipOptional.get().getUuid();
     dto.setProgrammeMembershipUuid(programmeMembershipUuid);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ConditionsOfJoiningServiceImplTest.java
@@ -19,6 +19,7 @@ import com.transformuk.hee.tis.tcs.service.repository.ProgrammeMembershipReposit
 import com.transformuk.hee.tis.tcs.service.service.ConditionsOfJoiningService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ConditionsOfJoiningMapper;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import javax.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,8 +55,8 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldThrowExceptionWhenCurriculumMembershipIdNotFound() {
-    when(curriculumMembershipRepository.getOne(CURRICULUM_MEMBERSHIP_ID)).thenThrow(
-        new EntityNotFoundException("Expected"));
+    when(curriculumMembershipRepository.findById(CURRICULUM_MEMBERSHIP_ID))
+        .thenReturn(Optional.empty());
 
     assertThrows(IllegalArgumentException.class,
         () -> conditionsOfJoiningService.save(CURRICULUM_MEMBERSHIP_ID, coj));
@@ -64,8 +65,8 @@ class ConditionsOfJoiningServiceImplTest {
 
   @Test
   void saveShouldThrowExceptionWhenProgrammeMembershipIdNotFound() {
-    when(programmeMembershipRepository.getOne(PROGRAMME_MEMBERSHIP_UUID)).thenThrow(
-        new EntityNotFoundException("Expected"));
+    when(programmeMembershipRepository.findByUuid(PROGRAMME_MEMBERSHIP_UUID))
+        .thenReturn(Optional.empty());
 
     assertThrows(IllegalArgumentException.class,
         () -> conditionsOfJoiningService.save(PROGRAMME_MEMBERSHIP_UUID, coj));
@@ -76,7 +77,8 @@ class ConditionsOfJoiningServiceImplTest {
   void saveShouldThrowExceptionWhenCojConstraintFails() {
     ProgrammeMembership pm = new ProgrammeMembership();
     pm.setUuid(UUID.randomUUID());
-    when(programmeMembershipRepository.getOne(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(pm);
+    when(programmeMembershipRepository.findByUuid(PROGRAMME_MEMBERSHIP_UUID))
+        .thenReturn(Optional.of(pm));
     when(repository.save(any())).thenThrow(new DataIntegrityViolationException("expected"));
 
     assertThrows(IllegalArgumentException.class,
@@ -97,8 +99,8 @@ class ConditionsOfJoiningServiceImplTest {
     CurriculumMembership curriculumMembership = new CurriculumMembership();
     curriculumMembership.setProgrammeMembership(programmeMembership);
 
-    when(curriculumMembershipRepository.getOne(CURRICULUM_MEMBERSHIP_ID)).thenReturn(
-        curriculumMembership);
+    when(curriculumMembershipRepository.findById(CURRICULUM_MEMBERSHIP_ID)).thenReturn(
+        Optional.of(curriculumMembership));
     when(repository.save(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
 
     ConditionsOfJoiningDto savedCoj = conditionsOfJoiningService.save(CURRICULUM_MEMBERSHIP_ID,
@@ -117,8 +119,8 @@ class ConditionsOfJoiningServiceImplTest {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setUuid(PROGRAMME_MEMBERSHIP_UUID);
 
-    when(programmeMembershipRepository.getOne(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(
-        programmeMembership);
+    when(programmeMembershipRepository.findByUuid(PROGRAMME_MEMBERSHIP_UUID)).thenReturn(
+        Optional.of(programmeMembership));
     when(repository.save(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
 
     ConditionsOfJoiningDto savedCoj = conditionsOfJoiningService.save(PROGRAMME_MEMBERSHIP_UUID,
@@ -141,8 +143,8 @@ class ConditionsOfJoiningServiceImplTest {
     CurriculumMembership curriculumMembership = new CurriculumMembership();
     curriculumMembership.setProgrammeMembership(programmeMembership);
 
-    when(curriculumMembershipRepository.getOne(CURRICULUM_MEMBERSHIP_ID)).thenReturn(
-        curriculumMembership);
+    when(curriculumMembershipRepository.findById(CURRICULUM_MEMBERSHIP_ID)).thenReturn(
+        Optional.of(curriculumMembership));
     when(repository.save(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
 
     ConditionsOfJoiningDto savedCoj = conditionsOfJoiningService.save(CURRICULUM_MEMBERSHIP_ID,


### PR DESCRIPTION
To fix issue with missing PM causing infinite message processing as described
https://hee-nhs-tis.slack.com/archives/C03G3UK3U82/p1722243933162119

(There are other places in the code that use getOne() but I think in a safe manner because they immediately retrieve the object.)

NO-TICKET