### PR TITLE
feat(ntn): populate NTN in PM data

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.41.1</version>
+  <version>6.42.0</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/TrainingNumberService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/TrainingNumberService.java
@@ -2,6 +2,7 @@ package com.transformuk.hee.tis.tcs.service.service;
 
 
 import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -48,4 +49,11 @@ public interface TrainingNumberService {
    * @param id the id of the entity
    */
   void delete(Long id);
+
+  /**
+   * Populate the trainingNumbers for the given programme memberships.
+   *
+   * @param programmeMemberships The programme memberships to generate the training numbers for.
+   */
+  void populateTrainingNumbers(List<ProgrammeMembership> programmeMemberships);
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -20,6 +20,7 @@ import com.transformuk.hee.tis.tcs.service.repository.CurriculumRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
 import com.transformuk.hee.tis.tcs.service.repository.ProgrammeMembershipRepository;
 import com.transformuk.hee.tis.tcs.service.service.ProgrammeMembershipService;
+import com.transformuk.hee.tis.tcs.service.service.TrainingNumberService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.CurriculumMembershipMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.ProgrammeMembershipDtoMapper;
@@ -63,6 +64,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
   private final PersonRepository personRepository;
   private final ProgrammeMembershipValidator programmeMembershipValidator;
   private final ProgrammeMembershipDtoMapper programmeMembershipDtoMapper;
+  private final TrainingNumberService trainingNumberService;
 
   /**
    * Initialise the ProgrammeMembershipService.
@@ -87,7 +89,8 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
       ApplicationEventPublisher applicationEventPublisher,
       PersonRepository personRepository,
       ProgrammeMembershipValidator programmeMembershipValidator,
-      ProgrammeMembershipDtoMapper programmeMembershipDtoMapper) {
+      ProgrammeMembershipDtoMapper programmeMembershipDtoMapper,
+      TrainingNumberService trainingNumberService) {
     this.programmeMembershipRepository = programmeMembershipRepository;
     this.curriculumMembershipRepository = curriculumMembershipRepository;
     this.programmeMembershipMapper = programmeMembershipMapper;
@@ -98,6 +101,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     this.personRepository = personRepository;
     this.programmeMembershipValidator = programmeMembershipValidator;
     this.programmeMembershipDtoMapper = programmeMembershipDtoMapper;
+    this.trainingNumberService = trainingNumberService;
   }
 
   /**
@@ -343,6 +347,7 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
         .findByTraineeId(traineeId);
 
     if (CollectionUtils.isNotEmpty(foundProgrammeMemberships)) {
+      trainingNumberService.populateTrainingNumbers(foundProgrammeMemberships);
       List<ProgrammeMembershipDTO> programmeMembershipDtos = programmeMembershipMapper
           .allEntityToDto(foundProgrammeMemberships);
       return attachCurricula(programmeMembershipDtos);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImpl.java
@@ -1,13 +1,30 @@
 package com.transformuk.hee.tis.tcs.service.service.impl;
 
+import static com.transformuk.hee.tis.tcs.api.enumeration.CurriculumSubType.SUB_SPECIALTY;
+
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
 import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
 import com.transformuk.hee.tis.tcs.service.event.TrainingNumberSavedEvent;
+import com.transformuk.hee.tis.tcs.service.model.GdcDetails;
+import com.transformuk.hee.tis.tcs.service.model.GmcDetails;
+import com.transformuk.hee.tis.tcs.service.model.Person;
+import com.transformuk.hee.tis.tcs.service.model.Programme;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
 import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
 import com.transformuk.hee.tis.tcs.service.repository.TrainingNumberRepository;
+import com.transformuk.hee.tis.tcs.service.service.CurriculumService;
 import com.transformuk.hee.tis.tcs.service.service.TrainingNumberService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.TrainingNumberMapper;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -28,13 +45,15 @@ public class TrainingNumberServiceImpl implements TrainingNumberService {
   private final TrainingNumberRepository trainingNumberRepository;
   private final TrainingNumberMapper trainingNumberMapper;
   private final ApplicationEventPublisher applicationEventPublisher;
+  private final CurriculumService curriculumService;
 
   public TrainingNumberServiceImpl(TrainingNumberRepository trainingNumberRepository,
       TrainingNumberMapper trainingNumberMapper,
-      ApplicationEventPublisher applicationEventPublisher) {
+      ApplicationEventPublisher applicationEventPublisher, CurriculumService curriculumService) {
     this.trainingNumberRepository = trainingNumberRepository;
     this.trainingNumberMapper = trainingNumberMapper;
     this.applicationEventPublisher = applicationEventPublisher;
+    this.curriculumService = curriculumService;
   }
 
   /**
@@ -116,5 +135,294 @@ public class TrainingNumberServiceImpl implements TrainingNumberService {
   public void delete(Long id) {
     log.debug("Request to delete TrainingNumber : {}", id);
     trainingNumberRepository.deleteById(id);
+  }
+
+  @Override
+  public void populateTrainingNumbers(List<ProgrammeMembership> programmeMemberships) {
+    programmeMemberships.forEach(this::populateTrainingNumber);
+  }
+
+  /**
+   * Populate the trainingNumber for the given programme membership.
+   *
+   * @param programmeMembership The programme membership to generate the training number for.
+   */
+  private void populateTrainingNumber(ProgrammeMembership programmeMembership) {
+    log.info("Populating training number for programme membership '{}'.",
+        programmeMembership.getUuid());
+
+    if (isExcluded(programmeMembership)) {
+      return;
+    }
+
+    String parentOrganization = getParentOrganization(programmeMembership);
+    String specialtyConcat = getSpecialtyConcat(programmeMembership);
+    String referenceNumber = getReferenceNumber(programmeMembership.getPerson());
+    String suffix = getSuffix(programmeMembership);
+
+    TrainingNumber trainingNumber = new TrainingNumber();
+    trainingNumber.setTrainingNumber(
+        parentOrganization + "/" + specialtyConcat + "/" + referenceNumber + "/" + suffix);
+    programmeMembership.setTrainingNumber(trainingNumber);
+    log.info("Populated training number: {}.", trainingNumber);
+  }
+
+
+  /**
+   * Get the parent organization for the given programme membership.
+   *
+   * @param programmeMembership The programme membership to calculate the parent organization for.
+   * @return The calculated parent organization.
+   */
+  private String getParentOrganization(ProgrammeMembership programmeMembership) {
+    String managingDeanery = programmeMembership.getProgramme().getOwner();
+    log.info("Calculating parent organization for managing deanery '{}'.", managingDeanery);
+    String parentOrganization = null;
+
+    if (managingDeanery != null) {
+      switch (managingDeanery) {
+        case "Defence Postgraduate Medical Deanery":
+          parentOrganization = "TSD";
+          break;
+        case "Health Education England East Midlands":
+          parentOrganization = "EMD";
+          break;
+        case "Health Education England East of England":
+          parentOrganization = "EAN";
+          break;
+        case "Health Education England Kent, Surrey and Sussex":
+          parentOrganization = "KSS";
+          break;
+        case "Health Education England North Central and East London":
+        case "Health Education England South London":
+        case "Health Education England North West London":
+        case "London LETBs":
+          parentOrganization = "LDN";
+          break;
+        case "Health Education England North East":
+          parentOrganization = "NTH";
+          break;
+        case "Health Education England North West":
+          parentOrganization = "NWE";
+          break;
+        case "Health Education England South West":
+          parentOrganization = "SWN";
+          break;
+        case "Health Education England Thames Valley":
+          parentOrganization = "OXF";
+          break;
+        case "Health Education England Wessex":
+          parentOrganization = "WES";
+          break;
+        case "Health Education England West Midlands":
+          parentOrganization = "WMD";
+          break;
+        case "Health Education England Yorkshire and the Humber":
+          parentOrganization = "YHD";
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (parentOrganization == null) {
+      throw new IllegalArgumentException("Unable to calculate the parent organization.");
+    }
+
+    log.info("Calculated parent organization: '{}'.", parentOrganization);
+    return parentOrganization;
+  }
+
+  /**
+   * Get the concatenated specialty string for the programme membership's training number.
+   *
+   * @param programmeMembership The programme membership to get the specialty string for.
+   * @return The concatenated specialty string.
+   */
+  private String getSpecialtyConcat(ProgrammeMembership programmeMembership) {
+    log.info("Calculating specialty concat.");
+    List<CurriculumDTO> sortedCurricula = filterAndSortCurricula(programmeMembership);
+
+    StringBuilder sb = new StringBuilder();
+
+    for (ListIterator<CurriculumDTO> curriculaIterator = sortedCurricula.listIterator();
+        curriculaIterator.hasNext(); ) {
+      int index = curriculaIterator.nextIndex();
+      CurriculumDTO curriculum = curriculaIterator.next();
+      String specialtyCode = curriculum.getSpecialty().getSpecialtyCode();
+
+      if (index > 0) {
+        if (curriculum.getCurriculumSubType().equals(SUB_SPECIALTY)) {
+          log.info("Appending sub-specialty '{}'.", specialtyCode);
+          sb.append(".");
+        } else {
+          log.info("Appending specialty '{}'.", specialtyCode);
+          sb.append("-");
+        }
+      } else {
+        log.info("Using '{}' as first specialty.", specialtyCode);
+      }
+
+      sb.append(specialtyCode);
+
+      if (index == 0 && Objects.equals(curriculum.getName(), "AFT")) {
+        sb.append("-FND");
+        break;
+      }
+    }
+
+    log.info("Calculated specialty concat: '{}'.", sb);
+    return sb.toString();
+  }
+
+  /**
+   * Get the GMC/GDC reference number for the given person details.
+   *
+   * @param person The person details to get the reference number for.
+   * @return The GMC/GDC number, depending on which is valid.
+   */
+  private String getReferenceNumber(Person person) {
+    GmcDetails gmcDetails = person.getGmcDetails();
+    String gmcNumber = gmcDetails == null ? "" : gmcDetails.getGmcNumber();
+
+    GdcDetails gdcDetails = person.getGdcDetails();
+    String gdcNumber = gdcDetails == null ? null : gdcDetails.getGdcNumber();
+
+    return gmcNumber.matches("\\d{7}") ? gmcNumber : gdcNumber;
+  }
+
+  /**
+   * Get the training number suffix for the given programme membership.
+   *
+   * @param programmeMembership The programme membership to get the suffix for.
+   * @return The calculated suffix for the programme membership's training number.
+   */
+  private String getSuffix(ProgrammeMembership programmeMembership) {
+    log.info("Calculating suffix.");
+    String trainingPathway = programmeMembership.getTrainingPathway();
+    log.info("Using training pathway '{}' to calculate suffix.", trainingPathway);
+
+    String suffix;
+    switch (trainingPathway) {
+      case "CCT":
+        suffix = "C";
+        break;
+      case "CESR":
+        suffix = "CP";
+        break;
+      default:
+        List<CurriculumDTO> sortedCurricula = filterAndSortCurricula(programmeMembership);
+        String firstSpecialtyCode = sortedCurricula.get(0).getSpecialty().getSpecialtyCode();
+        log.info("Using specialty code '{}' to calculate suffix.", trainingPathway);
+
+        suffix = Objects.equals(firstSpecialtyCode, "ACA") ? "C" : "D";
+    }
+
+    log.info("Calculated suffix: '{}'.", suffix);
+    return suffix;
+  }
+
+  /**
+   * Filter a programme membership's curricula and sort them alphanumerically.
+   *
+   * @param programmeMembership The programme membership to filter and sort the curricula of.
+   * @return The valid curricula for this PM, sorted alphanumerically by subtype and code.
+   */
+  private List<CurriculumDTO> filterAndSortCurricula(ProgrammeMembership programmeMembership) {
+    LocalDate startDate = programmeMembership.getProgrammeStartDate();
+    LocalDate now = LocalDate.now();
+    LocalDate filterDate = startDate.isAfter(now) ? startDate : now;
+
+    Set<String> uniqueSpecialtyCodes = new HashSet<>();
+
+    return programmeMembership.getCurriculumMemberships().stream()
+        .filter(cm -> !cm.getCurriculumStartDate().isAfter(filterDate))
+        .filter(cm -> !cm.getCurriculumEndDate().isBefore(filterDate))
+        .map(cm -> curriculumService.findOne(cm.getCurriculumId()))
+        .filter(c -> c.getSpecialty().getSpecialtyCode() != null && !Strings.isBlank(
+            c.getSpecialty().getSpecialtyCode()))
+        .sorted(Comparator
+            .comparing(CurriculumDTO::getCurriculumSubType)
+            .reversed()
+            .thenComparing(c -> c.getSpecialty().getSpecialtyCode())
+            .reversed()
+        )
+        .filter(c -> uniqueSpecialtyCodes.add(c.getSpecialty().getSpecialtyCode()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Check whether the given programme membership is excluded for training number generation.
+   *
+   * @param programmeMembership The programme membership to check.
+   * @return true if training number generated cannot continue, else false.
+   */
+  private boolean isExcluded(ProgrammeMembership programmeMembership) {
+    boolean personExcluded = isExcluded(programmeMembership.getPerson());
+
+    if (personExcluded) {
+      return true;
+    }
+
+    Programme programme = programmeMembership.getProgramme();
+    String programmeNumber = programme.getProgrammeNumber();
+    if (programmeNumber == null || Strings.isBlank(programmeNumber)) {
+      log.info("Skipping training number population as programme number is blank.");
+      return true;
+    }
+
+    String programmeName = programme.getProgrammeName();
+    if (programmeName == null || Strings.isBlank(programmeName)) {
+      log.info("Skipping training number population as programme name is blank.");
+      return true;
+    }
+
+    String lowerProgrammeName = programmeName.toLowerCase();
+    if (lowerProgrammeName.contains("foundation")) {
+      log.info("Skipping training number population as programme name '{}' is excluded.",
+          programme.getProgrammeName());
+      return true;
+    }
+
+    List<CurriculumDTO> validCurricula = filterAndSortCurricula(programmeMembership);
+    if (validCurricula.isEmpty()) {
+      log.info("Skipping training number population as there are no valid curricula.");
+      return true;
+    }
+
+    if (programmeMembership.getTrainingPathway() == null) {
+      log.error("Unable to generate training number as training pathway was null.");
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check whether the given person details excludes training number generation.
+   *
+   * @param person The person details to check.
+   * @return true if training number generated cannot continue, else false.
+   */
+  private boolean isExcluded(Person person) {
+    if (person == null) {
+      log.info("Skipping training number population as person details not available.");
+      return true;
+    }
+
+    GmcDetails gmcDetails = person.getGmcDetails();
+
+    if (gmcDetails == null || gmcDetails.getGmcNumber() == null || !gmcDetails.getGmcNumber()
+        .matches("\\d{7}")) {
+      GdcDetails gdcDetails = person.getGdcDetails();
+
+      if (gdcDetails == null || gdcDetails.getGdcNumber() == null || !gdcDetails.getGdcNumber()
+          .matches("\\d{5}.*")) {
+        log.info("Skipping training number population as reference number not valid.");
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PostValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/PostValidatorTest.java
@@ -45,10 +45,9 @@ import com.transformuk.hee.tis.tcs.service.repository.PostRepository;
 import com.transformuk.hee.tis.tcs.service.repository.ProgrammeRepository;
 import com.transformuk.hee.tis.tcs.service.repository.SpecialtyRepository;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,7 +95,7 @@ class PostValidatorTest {
     PostFundingDTO funding = new PostFundingDTO();
     funding.setStartDate(start);
     funding.setEndDate(end);
-    dto.setFundings(Set.of(funding));
+    dto.setFundings(Collections.singleton(funding));
     MethodArgumentNotValidException exception =
         assertThrows(MethodArgumentNotValidException.class, () -> testObj.validate(dto));
     List<FieldError> errors = exception.getBindingResult().getFieldErrors();
@@ -119,7 +118,7 @@ class PostValidatorTest {
   void shouldFailValidationWhenProgrammesAreInvalid() {
     ProgrammeDTO programme = new ProgrammeDTO();
     programme.setId(999L);
-    dto.setProgrammes(Set.of(programme));
+    dto.setProgrammes(Collections.singleton(programme));
 
     when(programmeRepository.existsById(999L)).thenReturn(false);
 
@@ -133,9 +132,10 @@ class PostValidatorTest {
   @Test
   void shouldFailValidationWhenSitesAreInvalid() {
     PostSiteDTO site = new PostSiteDTO(null, 999L, PostSiteType.PRIMARY);
-    dto.setSites(Set.of(site));
+    dto.setSites(Collections.singleton(site));
 
-    when(referenceService.siteIdExists(List.of(999L))).thenReturn(Map.of(999L, false));
+    when(referenceService.siteIdExists(Collections.singletonList(999L))).thenReturn(
+        Collections.singletonMap(999L, false));
 
     MethodArgumentNotValidException exception =
         assertThrows(MethodArgumentNotValidException.class, () -> testObj.validate(dto));
@@ -147,9 +147,10 @@ class PostValidatorTest {
   @Test
   void shouldFailValidationWhenGradesAreInvalid() {
     PostGradeDTO grade = new PostGradeDTO(null, 999L, PostGradeType.APPROVED);
-    dto.setGrades(Set.of(grade));
+    dto.setGrades(Collections.singleton(grade));
 
-    when(referenceService.gradeIdsExists(List.of(999L))).thenReturn(Map.of(999L, false));
+    when(referenceService.gradeIdsExists(Collections.singletonList(999L))).thenReturn(
+        Collections.singletonMap(999L, false));
 
     MethodArgumentNotValidException exception =
         assertThrows(MethodArgumentNotValidException.class, () -> testObj.validate(dto));
@@ -166,7 +167,7 @@ class PostValidatorTest {
         PostSpecialtyType.PRIMARY);
     specialty.setSpecialty(specialtyDto);
     specialty.setPostSpecialtyType(PostSpecialtyType.PRIMARY);
-    dto.setSpecialties(Set.of(specialty));
+    dto.setSpecialties(Collections.singleton(specialty));
 
     when(specialtyRepository.existsById(999L)).thenReturn(false);
 
@@ -181,7 +182,7 @@ class PostValidatorTest {
   void shouldFailValidationWhenPlacementHistoryIsInvalid() {
     PlacementDTO placement = new PlacementDTO();
     placement.setId(999L);
-    dto.setPlacementHistory(Set.of(placement));
+    dto.setPlacementHistory(Collections.singleton(placement));
 
     when(placementRepository.existsById(999L)).thenReturn(false);
 
@@ -214,7 +215,8 @@ class PostValidatorTest {
     dto.setId(null);
     dto.setBypassNPNGeneration(true);
 
-    when(postRepository.findByNationalPostNumber("npn")).thenReturn(List.of(new Post()));
+    when(postRepository.findByNationalPostNumber("npn")).thenReturn(
+        Collections.singletonList(new Post()));
 
     MethodArgumentNotValidException exception =
         assertThrows(MethodArgumentNotValidException.class, () -> testObj.validate(dto));

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImplTest.java
@@ -1,0 +1,1125 @@
+package com.transformuk.hee.tis.tcs.service.service.impl;
+
+import static com.transformuk.hee.tis.tcs.api.enumeration.CurriculumSubType.MEDICAL_CURRICULUM;
+import static com.transformuk.hee.tis.tcs.api.enumeration.CurriculumSubType.SUB_SPECIALTY;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.CurriculumSubType;
+import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
+import com.transformuk.hee.tis.tcs.service.model.GdcDetails;
+import com.transformuk.hee.tis.tcs.service.model.GmcDetails;
+import com.transformuk.hee.tis.tcs.service.model.Person;
+import com.transformuk.hee.tis.tcs.service.model.Programme;
+import com.transformuk.hee.tis.tcs.service.model.ProgrammeMembership;
+import com.transformuk.hee.tis.tcs.service.model.TrainingNumber;
+import com.transformuk.hee.tis.tcs.service.service.CurriculumService;
+import com.transformuk.hee.tis.tcs.service.service.TrainingNumberService;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+class TrainingNumberServiceImplTest {
+
+  private static final String CURRICULUM_NAME = "curriculumName";
+  private static final String CURRICULUM_SPECIALTY_CODE = "ABC";
+  private static final String GDC_NUMBER = "12345";
+  private static final String GMC_NUMBER = "1234567";
+  private static final String OWNER_NAME = "London LETBs";
+  private static final String PROGRAMME_NAME = "Programme Name";
+  private static final String PROGRAMME_NUMBER = "PROG123";
+  private static final String TRAINING_PATHWAY = "N/A";
+
+  private static final LocalDate NOW = LocalDate.now();
+  private static final LocalDate PAST = NOW.minusYears(1);
+  private static final LocalDate FUTURE = NOW.plusYears(1);
+
+  private TrainingNumberService service;
+  private CurriculumService curriculumService;
+
+  @BeforeEach
+  void setUp() {
+    curriculumService = mock(CurriculumService.class);
+    service = new TrainingNumberServiceImpl(null, null, null, curriculumService);
+  }
+
+  @Test
+  void shouldNotPopulateTrainingNumberWhenNoPersonalDetails(CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setPerson(null);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as person details not available."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "abcd", "1234"})
+  void shouldNotPopulateTrainingNumberWhenNoGmcOrGdcNumber(String referenceNumber,
+      CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(referenceNumber, referenceNumber);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as reference number not valid."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void shouldNotPopulateTrainingNumberWhenNoProgrammeNumber(String programmeNumber,
+      CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(programmeNumber);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as programme number is blank."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void shouldNotPopulateTrainingNumberWhenNoProgrammeName(String programmeName,
+      CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(programmeName);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as programme name is blank."));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "foundation", "FOUNDATION", "prefix foundation", "foundation suffix",
+      "prefix foundation suffix"
+  })
+  void shouldNotPopulateTrainingNumberWhenProgrammeIsFoundation(String programmeName,
+      CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(programmeName);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(), containsString(
+        "Skipping training number population as programme name '" + programmeName
+            + "' is excluded."));
+  }
+
+  @Test
+  void shouldNotPopulateTrainingNumberWhenNoCurricula(CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+    pm.setCurriculumMemberships(new HashSet<>());
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as there are no valid curricula."));
+  }
+
+  @Test
+  void shouldNotPopulateTrainingNumberWhenNoCurrentCurricula(CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership past = createCurriculumMembership(CURRICULUM_NAME, PAST, NOW.minusDays(1),
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    CurriculumMembership future = createCurriculumMembership(CURRICULUM_NAME, NOW.plusDays(1),
+        FUTURE, MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(past, future)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as there are no valid curricula."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void shouldNotPopulateTrainingNumberWhenNoCurriculaSpecialtyCode(String specialtyCode,
+      CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, specialtyCode);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as there are no valid curricula."));
+  }
+
+  @Test
+  void shouldNotPopulateTrainingNumberWhenTrainingPathwayNull(CapturedOutput output) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(null);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Unable to generate training number as training pathway was null."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "Unknown Organization"})
+  void shouldThrowExceptionPopulatingTrainingNumberWhenParentOrganizationNull(String ownerName) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(ownerName);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    List<ProgrammeMembership> pms = Collections.singletonList(pm);
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> service.populateTrainingNumbers(pms));
+
+    assertThat("Unexpected message.", exception.getMessage(),
+        is("Unable to calculate the parent organization."));
+  }
+
+  @Test
+  void shouldPopulateFullTrainingNumberWhenProgrammeIsCurrent() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, "ABC");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, NOW, FUTURE,
+        SUB_SPECIALTY, "123");
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, PAST, NOW, SUB_SPECIALTY,
+        "XYZ");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber.getTrainingNumber(),
+        is("LDN/ABC.XYZ.123/1234567/D"));
+  }
+
+  @Test
+  void shouldPopulateFullTrainingNumberWhenProgrammeIsFuture() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(FUTURE);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, NOW, FUTURE.plusDays(1),
+        MEDICAL_CURRICULUM, "ABC");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, FUTURE,
+        FUTURE.plusDays(1), SUB_SPECIALTY, "123");
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, NOW, FUTURE,
+        SUB_SPECIALTY, "XYZ");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber.getTrainingNumber(),
+        is("LDN/ABC.XYZ.123/1234567/D"));
+  }
+
+  @Test
+  void shouldPopulateTrainingNumbersWhenTraineeProfileHasMultiplePms() {
+    Person person = createPerson(GMC_NUMBER, null);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    ProgrammeMembership pm1 = new ProgrammeMembership();
+    pm1.setPerson(person);
+    pm1.setProgramme(programme);
+    pm1.setTrainingPathway(TRAINING_PATHWAY);
+    pm1.setProgrammeStartDate(PAST);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, "ABC");
+    pm1.setCurriculumMemberships(Collections.singleton(cm1));
+
+    ProgrammeMembership pm2 = new ProgrammeMembership();
+    pm2.setPerson(person);
+    pm2.setProgramme(programme);
+    pm2.setTrainingPathway(TRAINING_PATHWAY);
+    pm2.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, NOW, NOW,
+        MEDICAL_CURRICULUM, "123");
+    pm2.setCurriculumMemberships(Collections.singleton(cm2));
+
+    ProgrammeMembership pm3 = new ProgrammeMembership();
+    pm3.setPerson(person);
+    pm3.setProgramme(programme);
+    pm3.setTrainingPathway(TRAINING_PATHWAY);
+    pm3.setProgrammeStartDate(FUTURE);
+
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, "XYZ");
+    pm3.setCurriculumMemberships(Collections.singleton(cm3));
+
+    service.populateTrainingNumbers(Arrays.asList(pm1, pm2, pm3));
+
+    assertThat("Unexpected training number.", pm1.getTrainingNumber(), nullValue());
+    assertThat("Unexpected training number.", pm2.getTrainingNumber().getTrainingNumber(),
+        is("LDN/123/1234567/D"));
+    assertThat("Unexpected training number.", pm3.getTrainingNumber().getTrainingNumber(),
+        is("LDN/XYZ/1234567/D"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "Defence Postgraduate Medical Deanery                   | TSD",
+      "Health Education England East Midlands                 | EMD",
+      "Health Education England East of England               | EAN",
+      "Health Education England Kent, Surrey and Sussex       | KSS",
+      "Health Education England North Central and East London | LDN",
+      "Health Education England North East                    | NTH",
+      "Health Education England North West                    | NWE",
+      "Health Education England North West London             | LDN",
+      "Health Education England South London                  | LDN",
+      "Health Education England South West                    | SWN",
+      "Health Education England Thames Valley                 | OXF",
+      "Health Education England Wessex                        | WES",
+      "Health Education England West Midlands                 | WMD",
+      "Health Education England Yorkshire and the Humber      | YHD",
+      "London LETBs                                           | LDN"
+  })
+  void shouldPopulateTrainingNumberWithParentOrganizationWhenMappedByOwner(String ownerName,
+      String ownerCode) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(ownerName);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[0], is(ownerCode));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "AAA | ZZZ | 111 | 999 | ZZZ-AAA-999-111",
+      "999 | 111 | ZZZ | AAA | ZZZ-AAA-999-111",
+      "001 | 010 | 100 | 111 | 111-100-010-001"
+  })
+  void shouldPopulateTrainingNumberWithOrderedSpecialtyConcatWhenMultipleSpecialty(
+      String specialty1,
+      String specialty2, String specialty3, String specialty4, String trainingNumberPart) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, specialty1);
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, specialty2);
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, specialty3);
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, specialty4);
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is(trainingNumberPart));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 10})
+  void shouldPopulateTrainingNumberWithDotNotatedSpecialtyConcatWhenHasSubSpecialties(
+      int additionalCurriculaCount) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    Set<CurriculumMembership> cms = new HashSet<>();
+    pm.setCurriculumMemberships(cms);
+
+    CurriculumMembership cm1 = createCurriculumMembership("A sub spec 1", PAST, FUTURE,
+        SUB_SPECIALTY, "888");
+    cms.add(cm1);
+
+    CurriculumMembership cm2 = createCurriculumMembership("A sub spec 2", PAST, FUTURE,
+        SUB_SPECIALTY, "999");
+    cms.add(cm2);
+
+    for (int i = 1; i <= additionalCurriculaCount; i++) {
+      CurriculumMembership additionalCm = createCurriculumMembership("Not sub spec " + i, PAST,
+          FUTURE, MEDICAL_CURRICULUM, String.format("%03d", i));
+      cms.add(additionalCm);
+    }
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], endsWith(".999.888"));
+
+    long dotCount = trainingNumberParts[1].chars().filter(ch -> ch == '.').count();
+    assertThat("Unexpected sub specialty count.", dotCount, is(2L));
+  }
+
+  @Test
+  void shouldPopulateTrainingNumberWithFixedSpecialtyConcatWhenFirstSpecialtyIsAft() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership("AFT", PAST, FUTURE, MEDICAL_CURRICULUM,
+        "ACA");
+    CurriculumMembership cm2 = createCurriculumMembership("Not AFT 2", PAST, FUTURE,
+        MEDICAL_CURRICULUM, "003");
+    CurriculumMembership cm3 = createCurriculumMembership("Not AFT 1", PAST, FUTURE,
+        MEDICAL_CURRICULUM, "777");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is("ACA-FND"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "AAA | ZZZ | 111",
+      "AAA | 111 | ZZZ",
+      "ZZZ | AAA | 111",
+      "ZZZ | 111 | AAA",
+      "111 | AAA | ZZZ",
+      "111 | ZZZ | AAA"
+  })
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndCurriculaEnding(String pastSpecialty,
+      String endingSpecialty, String futureSpecialty) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, pastSpecialty);
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, futureSpecialty);
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, PAST, NOW,
+        MEDICAL_CURRICULUM, endingSpecialty);
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, null);
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is(endingSpecialty));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "AAA | ZZZ | 111",
+      "AAA | 111 | ZZZ",
+      "ZZZ | AAA | 111",
+      "ZZZ | 111 | AAA",
+      "111 | AAA | ZZZ",
+      "111 | ZZZ | AAA"
+  })
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberCurriculaCurrent(String pastSpecialty,
+      String currentSpecialty, String futureSpecialty) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, pastSpecialty);
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, futureSpecialty);
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, currentSpecialty);
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, null);
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is(currentSpecialty));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "AAA | ZZZ | 111",
+      "AAA | 111 | ZZZ",
+      "ZZZ | AAA | 111",
+      "ZZZ | 111 | AAA",
+      "111 | AAA | ZZZ",
+      "111 | ZZZ | AAA"
+  })
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndCurriculaStarting(String pastSpecialty,
+      String startingSpecialty, String futureSpecialty) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, pastSpecialty);
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, futureSpecialty);
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, NOW, FUTURE,
+        MEDICAL_CURRICULUM, startingSpecialty);
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, null);
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is(startingSpecialty));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "AAA | ZZZ | 111",
+      "AAA | 111 | ZZZ",
+      "ZZZ | AAA | 111",
+      "ZZZ | 111 | AAA",
+      "111 | AAA | ZZZ",
+      "111 | ZZZ | AAA"
+  })
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndProgrammeFuture(String currentSpecialty,
+      String futureSpecialty, String farFutureSpecialty) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(FUTURE);
+    pm.setCurriculumMemberships(new HashSet<>());
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, NOW, NOW,
+        MEDICAL_CURRICULUM, currentSpecialty);
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, futureSpecialty);
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, FUTURE.plusDays(1),
+        FUTURE.plusDays(1), MEDICAL_CURRICULUM, farFutureSpecialty);
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, null);
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is(futureSpecialty));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "111 | AAA | AAA",
+      "AAA | 111 | AAA",
+      "AAA | AAA | 111",
+      "AAA | 111 | 111",
+      "111 | AAA | 111",
+      "111 | 111 | AAA"
+  })
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndDuplicateSpecialties(String specialty1,
+      String specialty2, String specialty3) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, NOW, FUTURE,
+        MEDICAL_CURRICULUM, specialty1);
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, NOW, NOW,
+        MEDICAL_CURRICULUM, specialty2);
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, PAST, NOW,
+        MEDICAL_CURRICULUM, specialty3);
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, null);
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected specialty concat.", trainingNumberParts[1], is("AAA-111"));
+  }
+
+  @Test
+  void shouldPopulateTrainingNumberWithGmcNumberWhenValid() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected reference number.", trainingNumberParts[2], is(GMC_NUMBER));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "12345678"})
+  void shouldPopulateTrainingNumberWithGdcNumberWhenValidAndGmcInvalid(String gmcNumber) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(gmcNumber, GDC_NUMBER);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected reference number.", trainingNumberParts[2], is(GDC_NUMBER));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', value = {
+      "CCT  | C",
+      "CESR | CP",
+      "N/A  | D"
+  })
+  void shouldPopulateTrainingNumberWithSuffixWhenMappedByTrainingPathway(String trainingPathway,
+      String suffix) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(trainingPathway);
+    pm.setProgrammeStartDate(NOW);
+    pm.setCurriculumMemberships(new HashSet<>());
+
+    CurriculumMembership cm = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, CURRICULUM_SPECIALTY_CODE);
+    pm.setCurriculumMemberships(Collections.singleton(cm));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is(suffix));
+  }
+
+  @Test
+  void shouldPopulateTrainingNumberWithSuffixWhenSpecialtyIsAcademic() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, "123");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, "ACA");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is("C"));
+  }
+
+  @Test
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaEnding() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, "ACA");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, PAST, NOW,
+        MEDICAL_CURRICULUM, "123");
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, "ACA");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is("D"));
+  }
+
+  @Test
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaCurrent() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, "ACA");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, "123");
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, "ACA");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is("D"));
+  }
+
+  @Test
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaStarting() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, "ACA");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, NOW, FUTURE,
+        MEDICAL_CURRICULUM, "123");
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, "ACA");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is("D"));
+  }
+
+  @Test
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndProgrammeFuture() {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(GMC_NUMBER, null);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(FUTURE);
+    pm.setCurriculumMemberships(new HashSet<>());
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, PAST,
+        MEDICAL_CURRICULUM, "ACA");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, NOW, NOW,
+        MEDICAL_CURRICULUM, "ACA");
+    CurriculumMembership cm3 = createCurriculumMembership(CURRICULUM_NAME, FUTURE, FUTURE,
+        MEDICAL_CURRICULUM, "123");
+    CurriculumMembership cm4 = createCurriculumMembership(CURRICULUM_NAME, FUTURE.plusDays(1),
+        FUTURE.plusDays(1), MEDICAL_CURRICULUM, "ACA");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2, cm3, cm4)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is("D"));
+  }
+
+  /**
+   * Create a person with GMC and GDC details.
+   *
+   * @param gmcNumber The GMC number to use, may be null.
+   * @param gdcNumber The GDC number to use, may be null.
+   * @return The created person.
+   */
+  private Person createPerson(String gmcNumber, String gdcNumber) {
+    Person person = new Person();
+
+    if (gmcNumber != null) {
+      GmcDetails gmcDetails = new GmcDetails();
+      gmcDetails.setGmcNumber(gmcNumber);
+      person.setGmcDetails(gmcDetails);
+    }
+
+    if (gdcNumber != null) {
+      GdcDetails gdcDetails = new GdcDetails();
+      gdcDetails.setGdcNumber(gdcNumber);
+      person.setGdcDetails(gdcDetails);
+    }
+
+    return person;
+  }
+
+  /**
+   * Creates a curriculum membership with mocked response for curriculum and specialty.
+   *
+   * @param startDate     The curriculum start date.
+   * @param endDate       The curriculum end date.
+   * @param subType       The curriculum sub type.
+   * @param specialtyCode The curriculum's specialty code.
+   * @return The created curriculum membership, curriculum lookup will be mocked.
+   */
+  private CurriculumMembership createCurriculumMembership(String name, LocalDate startDate,
+      LocalDate endDate, CurriculumSubType subType, String specialtyCode) {
+    long curriculumId = new Random().nextLong();
+
+    CurriculumMembership cm = new CurriculumMembership();
+    cm.setCurriculumStartDate(startDate);
+    cm.setCurriculumEndDate(endDate);
+    cm.setCurriculumId(curriculumId);
+
+    SpecialtyDTO specialty = new SpecialtyDTO();
+    specialty.setSpecialtyCode(specialtyCode);
+
+    CurriculumDTO curriculum = new CurriculumDTO();
+    curriculum.setId(curriculumId);
+    curriculum.setName(name);
+    curriculum.setCurriculumSubType(subType);
+    curriculum.setSpecialty(specialty);
+
+    when(curriculumService.findOne(curriculumId)).thenReturn(curriculum);
+    return cm;
+  }
+}


### PR DESCRIPTION
The programme membership DTO has a legacy TrainingNumber field which does not get popualted.
Update the TrainingNumberService to allow calculation and population of TrainingNumbers in to a list of programme memberships. Update the ProgrammeMembershipService to call the new TrainingNumber population when fetching PMs to be displayed in Admins UI.

TIS21-6375
TIS21-6378