### PR TITLE
fix: training number generation throwing error

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.42.1</version>
+  <version>6.42.2</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImpl.java
@@ -139,7 +139,14 @@ public class TrainingNumberServiceImpl implements TrainingNumberService {
 
   @Override
   public void populateTrainingNumbers(List<ProgrammeMembership> programmeMemberships) {
-    programmeMemberships.forEach(this::populateTrainingNumber);
+    programmeMemberships.forEach(pm -> {
+      try {
+        populateTrainingNumber(pm);
+      } catch (RuntimeException e) {
+        // Failure to populate the training number should never block the programme being returned.
+        log.error("Caught and ignoring training number generation runtime error:", e);
+      }
+    });
   }
 
   /**

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImplTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -333,7 +333,8 @@ class TrainingNumberServiceImplTest {
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {" ", "Unknown Organization"})
-  void shouldThrowExceptionPopulatingTrainingNumberWhenParentOrganizationNull(String ownerName) {
+  void shouldNotThrowExceptionPopulatingTrainingNumberWhenParentOrganizationNull(String ownerName,
+      CapturedOutput output) {
     ProgrammeMembership pm = new ProgrammeMembership();
     Person person = createPerson(GMC_NUMBER, null);
     pm.setPerson(person);
@@ -352,11 +353,10 @@ class TrainingNumberServiceImplTest {
     pm.setCurriculumMemberships(Collections.singleton(cm));
 
     List<ProgrammeMembership> pms = Collections.singletonList(pm);
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-        () -> service.populateTrainingNumbers(pms));
+    assertDoesNotThrow(() -> service.populateTrainingNumbers(pms));
 
-    assertThat("Unexpected message.", exception.getMessage(),
-        is("Unable to calculate the parent organization."));
+    assertThat("Unexpected message.", output.getOut(),
+        containsString("Unable to calculate the parent organization."));
   }
 
   @Test


### PR DESCRIPTION
The training number service is throwing an error when the parent organization can not be calculated. When there is any failure it should be caught and ignored so that the programme data can still be returned without the NTN/DRN populated.

TIS21-6375