### PR TITLE
fix: Generate dentist NTNs more reliably

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.42.4</version>
+  <version>6.42.5</version>
 
   <dependencies>
     <dependency>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImpl.java
@@ -290,7 +290,8 @@ public class TrainingNumberServiceImpl implements TrainingNumberService {
    */
   private String getReferenceNumber(Person person) {
     GmcDetails gmcDetails = person.getGmcDetails();
-    String gmcNumber = gmcDetails == null ? "" : gmcDetails.getGmcNumber();
+    String gmcNumber = gmcDetails == null || gmcDetails.getGmcNumber() == null
+        ? "" : gmcDetails.getGmcNumber();
 
     GdcDetails gdcDetails = person.getGdcDetails();
     String gdcNumber = gdcDetails == null ? null : gdcDetails.getGdcNumber();

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/TrainingNumberServiceImplTest.java
@@ -944,6 +944,35 @@ class TrainingNumberServiceImplTest {
     assertThat("Unexpected suffix.", trainingNumberParts[3], is("C"));
   }
 
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldPopulateTrainingNumberWhenGmcNumberInvalid(String gmcNumber) {
+    ProgrammeMembership pm = new ProgrammeMembership();
+    Person person = createPerson(gmcNumber, GDC_NUMBER);
+    pm.setPerson(person);
+
+    Programme programme = new Programme();
+    programme.setOwner(OWNER_NAME);
+    programme.setProgrammeName(PROGRAMME_NAME);
+    programme.setProgrammeNumber(PROGRAMME_NUMBER);
+
+    pm.setProgramme(programme);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setProgrammeStartDate(NOW);
+
+    CurriculumMembership cm1 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, "123");
+    CurriculumMembership cm2 = createCurriculumMembership(CURRICULUM_NAME, PAST, FUTURE,
+        MEDICAL_CURRICULUM, "ACA");
+    pm.setCurriculumMemberships(new HashSet<>(Arrays.asList(cm1, cm2)));
+
+    service.populateTrainingNumbers(Collections.singletonList(pm));
+
+    TrainingNumber trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.getTrainingNumber().split("/");
+    assertThat("Unexpected suffix.", trainingNumberParts[3], is("C"));
+  }
+
   @Test
   void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaEnding() {
     ProgrammeMembership pm = new ProgrammeMembership();
@@ -1077,17 +1106,13 @@ class TrainingNumberServiceImplTest {
   private Person createPerson(String gmcNumber, String gdcNumber) {
     Person person = new Person();
 
-    if (gmcNumber != null) {
-      GmcDetails gmcDetails = new GmcDetails();
-      gmcDetails.setGmcNumber(gmcNumber);
-      person.setGmcDetails(gmcDetails);
-    }
+    GmcDetails gmcDetails = new GmcDetails();
+    gmcDetails.setGmcNumber(gmcNumber);
+    person.setGmcDetails(gmcDetails);
 
-    if (gdcNumber != null) {
-      GdcDetails gdcDetails = new GdcDetails();
-      gdcDetails.setGdcNumber(gdcNumber);
-      person.setGdcDetails(gdcDetails);
-    }
+    GdcDetails gdcDetails = new GdcDetails();
+    gdcDetails.setGdcNumber(gdcNumber);
+    person.setGdcDetails(gdcDetails);
 
     return person;
   }


### PR DESCRIPTION
There are records for GMC Details where the GMC Number is null. This commit treats GMC Details with a null GMC Number as no GMC Details.

TIS21-6425: Generate NTN for Dentists with a "null" GMC Number