### PR TITLE
fix:the programme filter when the user is assigned programmes

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.43.1</version>
+  <version>6.43.2</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
@@ -36,7 +36,6 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.Operator;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.slf4j.Logger;

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/strategy/ProgrammeBasedFilterStrategy.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/strategy/ProgrammeBasedFilterStrategy.java
@@ -3,33 +3,80 @@ package com.transformuk.hee.tis.tcs.service.strategy;
 import com.transformuk.hee.tis.security.model.Programme;
 import com.transformuk.hee.tis.security.model.UserProfile;
 import com.transformuk.hee.tis.security.util.TisSecurityHelper;
+import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipStatus;
+import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ProgrammeBasedFilterStrategy implements RoleBasedFilterStrategy {
 
-  private static final String COLUMN_FILTER = "programmeName";
+  private static final String COLUMN_FILTER = "programmeId";
 
   @Override
-  public Optional<Tuple<String, BoolQueryBuilder>> getFilter() {
+  public Optional<Tuple<String, BoolQueryBuilder>> getFilter(List<ColumnFilter> columnFilters) {
+    MatchQueryBuilder statusMatchQueryBuilder = null;
+    if (columnFilters != null) {
+      Set<ColumnFilter> statusFilters = columnFilters.stream().filter(
+              columnFilter -> StringUtils.equals(columnFilter.getName(), "programmeMembershipStatus"))
+          .collect(
+              Collectors.toSet());
+      if (statusFilters.size() > 0) {
+        ProgrammeMembershipStatus status = ProgrammeMembershipStatus
+            .valueOf(statusFilters.iterator().next().getValues().get(0).toString());
+        statusMatchQueryBuilder = getProgrammeMembershipStatusQueryBuilder(status);
+      }
+    }
+
     UserProfile currentUserProfile = TisSecurityHelper.getProfileFromContext();
     Set<Programme> assignedProgrammes = currentUserProfile.getAssignedProgrammes();
     if (CollectionUtils.isNotEmpty(assignedProgrammes)) {
       BoolQueryBuilder programmeRoleFilter = new BoolQueryBuilder();
-      assignedProgrammes.forEach(programme -> programmeRoleFilter.should(
-          new NestedQueryBuilder("programmeMemberships",
-              new MatchQueryBuilder("programmeMemberships.programmeId", programme.getId()),
-              ScoreMode.None)));
+      for (Programme programme : assignedProgrammes) {
+        if (statusMatchQueryBuilder == null) {
+          programmeRoleFilter.should(
+              new NestedQueryBuilder("programmeMemberships",
+                  new MatchQueryBuilder("programmeMemberships.programmeId", programme.getId()),
+                  ScoreMode.None));
+        } else {
+          programmeRoleFilter.should(
+              new NestedQueryBuilder("programmeMemberships",
+                  new BoolQueryBuilder().should(
+                          new MatchQueryBuilder("programmeMemberships.programmeId", programme.getId()))
+                      .minimumShouldMatch(1)
+                      .should(statusMatchQueryBuilder).minimumShouldMatch(2),
+                  ScoreMode.None));
+        }
+      }
       return Optional.of(new Tuple<>(COLUMN_FILTER, programmeRoleFilter));
     }
     return Optional.empty();
+  }
+
+  public MatchQueryBuilder getProgrammeMembershipStatusQueryBuilder(
+      ProgrammeMembershipStatus status) {
+    MatchQueryBuilder statusQueryBuilder = null;
+    if (status.equals(ProgrammeMembershipStatus.CURRENT)) {
+      statusQueryBuilder = QueryBuilders
+          .matchQuery("programmeMemberships.programmeMembershipStatus", "CURRENT");
+    } else if (status.equals(ProgrammeMembershipStatus.PAST)) {
+      statusQueryBuilder = QueryBuilders
+          .matchQuery("programmeMemberships.programmeMembershipStatus", "PAST");
+    } else if (status.equals(ProgrammeMembershipStatus.FUTURE)) {
+      statusQueryBuilder = QueryBuilders
+          .matchQuery("programmeMemberships.programmeMembershipStatus", "FUTURE");
+    }
+    return statusQueryBuilder;
   }
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/strategy/RoleBasedFilterStrategy.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/strategy/RoleBasedFilterStrategy.java
@@ -1,5 +1,7 @@
 package com.transformuk.hee.tis.tcs.service.strategy;
 
+import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
+import java.util.List;
 import java.util.Optional;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -11,5 +13,5 @@ public interface RoleBasedFilterStrategy {
    *
    * @return The column filter that is to be applied and the name of the group of filters
    */
-  Optional<Tuple<String, BoolQueryBuilder>> getFilter();
+  Optional<Tuple<String, BoolQueryBuilder>> getFilter(List<ColumnFilter> columnFilters);
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/strategy/TrustRoleBasedFilterStrategy.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/strategy/TrustRoleBasedFilterStrategy.java
@@ -3,6 +3,8 @@ package com.transformuk.hee.tis.tcs.service.strategy;
 import com.transformuk.hee.tis.security.model.Trust;
 import com.transformuk.hee.tis.security.model.UserProfile;
 import com.transformuk.hee.tis.security.util.TisSecurityHelper;
+import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
@@ -24,7 +26,7 @@ public class TrustRoleBasedFilterStrategy implements RoleBasedFilterStrategy {
   private static final String COLUMN_FILTER = "trusts.trustId";
 
   @Override
-  public Optional<Tuple<String, BoolQueryBuilder>> getFilter() {
+  public Optional<Tuple<String, BoolQueryBuilder>> getFilter(List<ColumnFilter> columnFilters) {
     UserProfile currentUserProfile = TisSecurityHelper.getProfileFromContext();
     Set<Trust> assignedTrusts = currentUserProfile.getAssignedTrusts();
     if (CollectionUtils.isNotEmpty(assignedTrusts)) {


### PR DESCRIPTION
fix the programme filter when the user is assigned programmes, and refactor `searchForPage` method to remove duplicate codes.

1. added the columnFilter to `RoleBasedFilterStrategy.getFilter`, because when we apply the programmeId filter, we need to check if the programmeMembershipStatus filter is also applied. And currently, on the UI, we can only select either CURRENT or FUTURE, not both of them.
2. resume a `general programmeMembership.status filter` in `searchForPage` method in case no programmeId or programmeName filters are applied
3. tested locally under both scenarios if the user is assgined any programmes or not. I tried to set up some unit tests, but it asked for token in the context. For integration tests, we haven't properly set up an ES, so I finally gave up.

TIS21-6359