### PR TITLE
fix:remove the outer programmeMembership status filter

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.45.0</version>
+  <version>6.45.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
@@ -136,10 +136,6 @@ public class PersonElasticSearchService {
               continue;
             }
             if (StringUtils.equals(columnFilter.getName(), "programmeMembershipStatus")) {
-              shouldBetweenSameColumnFilter.should(new NestedQueryBuilder("programmeMemberships",
-                  new MatchQueryBuilder("programmeMemberships.programmeMembershipStatus",
-                      value.toString()),
-                  ScoreMode.None));
               continue;
             }
             //because the role column is a comma separated list of roles, we need to do a wildcard 'like' search

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
@@ -118,8 +118,8 @@ public class PersonElasticSearchService {
           BoolQueryBuilder shouldBetweenSameColumnFilter = new BoolQueryBuilder();
 
           for (Object value : columnFilter.getValues()) {
-            if (appliedFilters.contains(columnFilter
-                .getName())) { // skip if we've already applied this type of filter via role based filters
+            if (appliedFilters.contains(columnFilter.getName()) // skip if we've already applied this type of filter via role based filters
+                || StringUtils.equals(columnFilter.getName(), "programmeMembershipStatus")) {
               continue;
             }
             if (StringUtils.equals(columnFilter.getName(), "programmeName")) {
@@ -133,9 +133,6 @@ public class PersonElasticSearchService {
                   ScoreMode.None);
               shouldBetweenSameColumnFilter.should(nested);
               shouldBetweenSameColumnFilter.minimumShouldMatch(1);
-              continue;
-            }
-            if (StringUtils.equals(columnFilter.getName(), "programmeMembershipStatus")) {
               continue;
             }
             //because the role column is a comma separated list of roles, we need to do a wildcard 'like' search

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PersonElasticSearchService.java
@@ -118,7 +118,8 @@ public class PersonElasticSearchService {
           BoolQueryBuilder shouldBetweenSameColumnFilter = new BoolQueryBuilder();
 
           for (Object value : columnFilter.getValues()) {
-            if (appliedFilters.contains(columnFilter.getName()) // skip if we've already applied this type of filter via role based filters
+            // skip if we've already applied this type of filter via role based filters
+            if (appliedFilters.contains(columnFilter.getName())
                 || StringUtils.equals(columnFilter.getName(), "programmeMembershipStatus")) {
               continue;
             }


### PR DESCRIPTION
Previously this filter didn't work, and last iteration we added it back, which resulted in some users who don't have programme admin/observers roles not able to see person records which don't have any active programme memberships. So we decided to take it off as a patch to resume this functionality to be the same as before.

However, the programme membership filter doesn't work well and has to be reviewed in the future.

Tested locally.

TIS21-6359