### PR TITLE
fix: use machine user to call reference

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.45.0</version>
+  <version>6.45.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/KeycloakConfig.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/KeycloakConfig.java
@@ -1,0 +1,18 @@
+package com.transformuk.hee.tis.tcs.service.config;
+
+import com.transformuk.hee.tis.security.config.KeycloakClientConfig;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for Keycloak.
+ */
+@Configuration
+public class KeycloakConfig extends KeycloakClientConfig {
+
+  @Bean
+  public Keycloak keycloak() {
+    return super.createKeycloak();
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/ReferenceClientProdConfig.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/ReferenceClientProdConfig.java
@@ -1,18 +1,28 @@
 package com.transformuk.hee.tis.tcs.service.config;
 
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * Configuration of the Reference Client.
+ */
 @Configuration
 @Profile({"dev", "stage", "prod", "uidev"})
 public class ReferenceClientProdConfig extends
     com.transformuk.hee.tis.reference.client.config.ReferenceClientConfig {
 
+  /**
+   * Create a rest template for making requests to the reference client. Talks to keycloak to get a
+   * OIDC token before making the request. Logs into KC using the TCS user credentials
+   *
+   * @param keycloak The keycloak client to use.
+   * @return The rest template for the reference client.
+   */
   @Bean
-  public RestTemplate referenceRestTemplate() {
-    return super.prodBrowserInitiatedReferenceRestTemplate();
+  public RestTemplate referenceRestTemplate(Keycloak keycloak) {
+    return super.prodReferenceRestTemplate(keycloak);
   }
-
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/TrustAdminConfig.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/TrustAdminConfig.java
@@ -3,8 +3,6 @@ package com.transformuk.hee.tis.tcs.service.config;
 import com.transformuk.hee.tis.security.client.KeycloakClientRequestFactory;
 import com.transformuk.hee.tis.security.client.KeycloakRestTemplate;
 import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.KeycloakBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
@@ -17,45 +15,18 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class TrustAdminConfig {
 
-  @Value("${kc.realm}")
-  private String realm;
-
-  @Value("${kc.client.id}")
-  private String clientId;
-
-  @Value("${kc.server.url}")
-  private String serverUrl;
-
-  @Value("${kc.username}")
-  private String userName;
-
-  @Value("${kc.password}")
-  private String password;
-
-
   /**
    * Rest template used to communicate with other services. Talks to keycloak to get a OIDC token
    * before making the request. Logs into KC using the TCS user credentials
    *
-   * @return
+   * @param keycloak The keycloak client to use.
+   * @return The rest template.
    */
   @Bean
-  public RestTemplate trustAdminEnabledRestTemplate() {
-    final KeycloakClientRequestFactory keycloakClientRequestFactory = new KeycloakClientRequestFactory(
-        getKc());
+  public RestTemplate trustAdminEnabledRestTemplate(Keycloak keycloak) {
+    final KeycloakClientRequestFactory keycloakClientRequestFactory =
+        new KeycloakClientRequestFactory(keycloak);
     return new KeycloakRestTemplate(keycloakClientRequestFactory);
 
   }
-
-  private Keycloak getKc() {
-    Keycloak kc = KeycloakBuilder.builder()
-        .serverUrl(serverUrl)
-        .realm(realm)
-        .clientId(clientId)
-        .username(userName)
-        .password(password)
-        .build();
-    return kc;
-  }
-
 }


### PR DESCRIPTION
The GMC Validator checks the given GMC status against the reference service to check if the value is valid. However, calls to the erference service use the current user's authentication token. As the new GMC update is received via RabbitMQ there is no authenticated user to provide a token.

Update ReferenceClientProdConfig to use a machine user token instead of requiring an actual user token.

TIS21-6292
TIS21-6479