### PR TITLE
fix: construct proper exception for GMC validation

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.46.0</version>
+  <version>6.46.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidator.java
@@ -5,10 +5,12 @@ import com.transformuk.hee.tis.reference.client.impl.ReferenceServiceImpl;
 import com.transformuk.hee.tis.tcs.api.dto.GmcDetailsDTO;
 import com.transformuk.hee.tis.tcs.service.model.GmcDetails;
 import com.transformuk.hee.tis.tcs.service.repository.GmcDetailsRepository;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
@@ -51,7 +53,14 @@ public class GmcDetailsValidator {
       BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(gmcDetailsDTO,
           "GmcDetailsDTO");
       fieldErrors.forEach(bindingResult::addError);
-      throw new MethodArgumentNotValidException(null, bindingResult);
+
+      try {
+        Method method = this.getClass().getDeclaredMethod("validate", GmcDetailsDTO.class);
+        throw new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult);
+      } catch (NoSuchMethodException e) {
+        // This should only happen if the method name is changed without updating the code.
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidatorTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/validation/GmcDetailsValidatorTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -50,6 +51,26 @@ class GmcDetailsValidatorTest {
 
   @Mock
   private GmcDetails gmcDetailsMock1, gmcDetailsMock2;
+
+
+  @Test
+  void validateShouldIncludeParameterInThrownException() {
+    // Given.
+    when(gmcDetailsDtoMock_whitespace.getGmcNumber()).thenReturn(WHITESPACE_GMC_NUMBER);
+
+    // When.
+    MethodArgumentNotValidException thrown =
+        assertThrows(MethodArgumentNotValidException.class,
+            () -> validator.validate(gmcDetailsDtoMock_whitespace));
+
+    // Then.
+    MethodParameter parameter = thrown.getParameter();
+    String executableName = parameter.getExecutable().getName();
+
+    assertThat("Unexpected method name.", executableName, is("validate"));
+    assertThat("Unexpected parameter type.", parameter.getParameter().getType(),
+        is(GmcDetailsDTO.class));
+  }
 
   @Test
   void validateShouldThrowExceptionWhenGmcNumberContainsWhitespace() {


### PR DESCRIPTION
The GMCDetailsValidator throws a `MethodArgumentNotValidException` when the validation fails, however the `parameter` field is incorrectly set to `null`.
This results in a `NullPointerException` when later trying to log the exception, which stops the exception being wrapped in a `AmqpRejectAndDontRequeueException`. The failure to wrap the exception means that RabbitMQ cannot send the failure to a DLQ and it is queued indefinitely.

Update the GMCDeailsValidator so that the `MethodParameter` is populated correctly.
A `NoSuchMethodException` must be handled, but will never happen unless the validate method is renamed without updating the declared method name. In this case the new unit test will fail, so it can never go live, but a runtime exception is thrown as a last resort to ensure that the exception is not swallowed.

TIS21-6292
TIS21-6479