### PR TITLE
refactor: add required handling of an empty array

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.47.0</version>
+  <version>6.47.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -177,7 +177,7 @@ public class ProgrammeMembershipResource {
   public ResponseEntity<List<ProgrammeMembershipSummaryDTO>> getProgrammeMembershipSummaryList(
       @RequestParam List<String> ids) {
     List<ProgrammeMembershipSummaryDTO> summaryList = Collections.emptyList();;
-    if(!ids.isEmpty()) {
+    if (!ids.isEmpty()) {
       try {
         Set<UUID> uuids = ids.stream()
             .map(UUID::fromString)

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -176,7 +176,7 @@ public class ProgrammeMembershipResource {
   @PreAuthorize("hasPermission('tis:people::person:', 'View')")
   public ResponseEntity<List<ProgrammeMembershipSummaryDTO>> getProgrammeMembershipSummaryList(
       @RequestParam List<String> ids) {
-    List<ProgrammeMembershipSummaryDTO> summaryList = Collections.emptyList();;
+    List<ProgrammeMembershipSummaryDTO> summaryList = Collections.emptyList();
     if (!ids.isEmpty()) {
       try {
         Set<UUID> uuids = ids.stream()

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -176,22 +176,23 @@ public class ProgrammeMembershipResource {
   @PreAuthorize("hasPermission('tis:people::person:', 'View')")
   public ResponseEntity<List<ProgrammeMembershipSummaryDTO>> getProgrammeMembershipSummaryList(
       @RequestParam List<String> ids) {
-
-    try {
-      Set<UUID> uuids = ids.stream()
-          .map(UUID::fromString)
-          .collect(Collectors.toSet());
-
-      List<ProgrammeMembershipSummaryDTO> summaryList = programmeMembershipService
-          .findProgrammeMembershipSummariesByUuid(uuids);
-
-      if (summaryList.isEmpty()) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.emptyList());
+    List<ProgrammeMembershipSummaryDTO> summaryList = Collections.emptyList();;
+    if(!ids.isEmpty()) {
+      try {
+        Set<UUID> uuids = ids.stream()
+            .map(UUID::fromString)
+            .collect(Collectors.toSet());
+        summaryList = programmeMembershipService
+            .findProgrammeMembershipSummariesByUuid(uuids);
+        if (summaryList.isEmpty()) {
+          return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.emptyList());
+        }
+        return ResponseEntity.ok(summaryList);
+      } catch (IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.emptyList());
       }
-      return ResponseEntity.ok(summaryList);
-    } catch (IllegalArgumentException e) {
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.emptyList());
     }
+    return ResponseEntity.ok(summaryList);
   }
 
   /**

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -333,7 +333,10 @@ class ProgrammeMembershipResourceIntTest {
 
     restProgrammeMembershipMockMvc.perform(get("/api/programme-memberships/summary-list")
             .param("ids", ""))
-        .andExpect(status().isOk());
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
   }
 
   @Test

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -330,6 +330,10 @@ class ProgrammeMembershipResourceIntTest {
     restProgrammeMembershipMockMvc.perform(get("/api/programme-memberships/summary-list")
             .param("ids", "invalid-uuid"))
         .andExpect(status().isBadRequest());
+
+    restProgrammeMembershipMockMvc.perform(get("/api/programme-memberships/summary-list")
+            .param("ids", ""))
+        .andExpect(status().isOk());
   }
 
   @Test


### PR DESCRIPTION
if the trainee has a no linked forms the service will receive an empty array which was causing the app to be unable to load the forms list 