### PR TITLE
refactor: extract filtering,

### DIFF
--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResource.java
@@ -177,17 +177,21 @@ public class ProgrammeMembershipResource {
   public ResponseEntity<List<ProgrammeMembershipSummaryDTO>> getProgrammeMembershipSummaryList(
       @RequestParam List<String> ids) {
     List<ProgrammeMembershipSummaryDTO> summaryList = Collections.emptyList();
-    if (!ids.isEmpty()) {
+
+    Set<String> filteredUuids = ids.stream()
+        .filter(id -> {
+          try {
+            UUID.fromString(id);
+            return true;
+          } catch (IllegalArgumentException e) {
+            return false;
+          }
+        })
+        .collect(Collectors.toSet());
+
+    if (!filteredUuids.isEmpty()) {
       try {
-        Set<UUID> uuids = ids.stream()
-            .filter(id -> {
-              try {
-                UUID.fromString(id);
-                return true;
-              } catch (IllegalArgumentException e) {
-                return false;
-              }
-            })
+        Set<UUID> uuids = filteredUuids.stream()
             .map(UUID::fromString)
             .collect(Collectors.toSet());
         summaryList = programmeMembershipService

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/ProgrammeMembershipResourceIntTest.java
@@ -322,11 +322,21 @@ class ProgrammeMembershipResourceIntTest {
             .param("ids", programmeMembershipUuid.toString()))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-        .andExpect(jsonPath("$.[*].programmeMembershipUuid").value(hasItem(filterdUuidList.toString())))
-        .andExpect(jsonPath("$.[*].programmeStartDate").value(hasItem(DEFAULT_PROGRAMME_START_DATE.toString())))
+        .andExpect(jsonPath("$.[*].programmeMembershipUuid")
+            .value(hasItem(filterdUuidList.toString())))
+        .andExpect(jsonPath("$.[*].programmeStartDate")
+            .value(hasItem(DEFAULT_PROGRAMME_START_DATE.toString())))
         .andExpect(jsonPath("$.[*].programmeName").value(hasItem(DEFAULT_PROGRAMME_NAME)))
         .andExpect(jsonPath("$.[*].programmeMembershipUuid").value(not(hasItem("77777"))));
 
+    restProgrammeMembershipMockMvc.perform(get("/api/programme-memberships/summary-list")
+            .param("ids", "333333333333"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(jsonPath("$.[*].programmeMembershipUuid")
+            .value(not(hasItem("333333333333"))))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
 
     restProgrammeMembershipMockMvc.perform(get("/api/programme-memberships/summary-list")
             .param("ids", UUID.randomUUID().toString()))


### PR DESCRIPTION
the filtering being done inside the stream was allowing empty strings if all uuids were invalid, this caused a 404 and broke the display of the forms