### PR TITLE
chore: Define max JVM memory

### DIFF
--- a/tcs-service/Dockerfile
+++ b/tcs-service/Dockerfile
@@ -4,4 +4,4 @@ EXPOSE 8093
 
 COPY target/app.jar app.jar
 
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=95", "-jar", "app.jar"]

--- a/tcs-service/Dockerfile
+++ b/tcs-service/Dockerfile
@@ -4,4 +4,4 @@ EXPOSE 8093
 
 COPY target/app.jar app.jar
 
-CMD ["java", "-XX:MaxRAMPercentage=95", "-jar", "app.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=95.0", "-jar", "app.jar"]


### PR DESCRIPTION
Tasks appear to be hitting a ceiling at 42% of RAM available. This has means the earlier memory increase is less effective. Adding the maximum size improves the ability to autoscale on memory.

TIS21-6834: Optimise JVM memory use