### PR TITLE
feat: get GMC by id

### DIFF
--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -698,6 +698,12 @@ public class TcsServiceImpl extends AbstractClientService {
     return responseEntity.getBody();
   }
 
+  public GmcDetailsDTO getGmcDetailsById(Long id) {
+    log.debug("calling getGmcDetailsById with {}", id);
+    String url = serviceUrl + API_GMC_DETAILS + id.toString();
+    return tcsRestTemplate.getForEntity(url, GmcDetailsDTO.class).getBody();
+  }
+
   public List<PostDTO> findPostsByNationalPostNumbersIn(List<String> npns) {
     String url = serviceUrl + API_POSTS_IN + getIdsAsUrlEncodedCSVs(npns);
     ResponseEntity<List<PostDTO>> responseEntity = tcsRestTemplate.

--- a/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
+++ b/tcs-client/src/main/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImpl.java
@@ -690,6 +690,12 @@ public class TcsServiceImpl extends AbstractClientService {
     return responseEntity.getBody();
   }
 
+  /**
+   * Retrieve the list of GMC details having GMC numbers in the provided list.
+   *
+   * @param gmcIds The GMC numbers to search for.
+   * @return The list of matching GMC details.
+   */
   public List<GmcDetailsDTO> findGmcDetailsIn(List<String> gmcIds) {
     String url = serviceUrl + API_GMC_DETAILS_IN + getIdsAsUrlEncodedCSVs(gmcIds);
     ResponseEntity<List<GmcDetailsDTO>> responseEntity = tcsRestTemplate.
@@ -698,6 +704,12 @@ public class TcsServiceImpl extends AbstractClientService {
     return responseEntity.getBody();
   }
 
+  /**
+   * Retrieve the 'id' GMC details.
+   *
+   * @param id The ID of the GMC details to retrieve. (This is the ID of the person with these GMC details.)
+   * @return The GMC details, or null if not found.
+   */
   public GmcDetailsDTO getGmcDetailsById(Long id) {
     log.debug("calling getGmcDetailsById with {}", id);
     String url = serviceUrl + API_GMC_DETAILS + id.toString();

--- a/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplTest.java
+++ b/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplTest.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Maps;
 import com.transformuk.hee.tis.tcs.api.dto.AbsenceDTO;
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
+import com.transformuk.hee.tis.tcs.api.dto.GmcDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
@@ -377,5 +378,28 @@ public class TcsServiceImplTest {
     verify(restTemplate).exchange(url, HttpMethod.POST, httpEntity,
         new ParameterizedTypeReference<CurriculumMembershipDTO>() {
         });
+  }
+
+  @Test
+  public void getGmcDetailsByIdShouldFindGmcDto() {
+    GmcDetailsDTO gmc = new GmcDetailsDTO();
+    gmc.setId(20L);
+
+    String url = "http://localhost:9999/tcs/api/gmc-details/20";
+
+    ResponseEntity responseEntity = new ResponseEntity(gmc, HttpStatus.OK);
+    doReturn(responseEntity).when(restTemplate).getForEntity(url, GmcDetailsDTO.class);
+
+    GmcDetailsDTO result = testObj.getGmcDetailsById(20L);
+    assertThat("Unexpected result", result, is(gmc));
+    verify(restTemplate).getForEntity(url, GmcDetailsDTO.class);
+  }
+
+  @Test
+  public void getGmcDetailsByIdShouldThrowErrorWhenNotFound() {
+    exceptionRule.expect(HttpClientErrorException.class);
+    exceptionRule.expectMessage("404 Not Found");
+    // RestTemplate hasn't been set up to find any GMC, so should throw exception
+    testObj.getGmcDetailsById(20L);
   }
 }


### PR DESCRIPTION
Since findGmcDetailsIn() actually uses GMC numbers to search by, not ids. tis-sync PR to use this new client function to follow.

TIS21-6639