### PR TITLE
feat: add duplicate validation on CurriculumMembershipValidator

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.32.5</version>
+  <version>2.33.0</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepository.java
@@ -1,8 +1,10 @@
 package com.transformuk.hee.tis.tcs.service.repository;
 
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -59,4 +61,17 @@ public interface CurriculumMembershipRepository extends JpaRepository<Curriculum
       + "WHERE pm.personId = :traineeId "
       + "ORDER BY cm.curriculumEndDate DESC LIMIT 1", nativeQuery = true)
   CurriculumMembership findLatestCurriculumByTraineeId(@Param("traineeId") Long traineeId);
+
+  @Query(value = "SELECT * "
+      + "FROM CurriculumMembership "
+      + "WHERE curriculumId = :curriculumId "
+      + "AND programmeMembershipUuid = :programmeMembershipUuid "
+      + "AND curriculumStartDate = :curriculumStartDate "
+      + "AND curriculumEndDate = :curriculumEndDate"
+      , nativeQuery = true
+  )
+  List<CurriculumMembership> findByCurriculumIdAndPmUuidAndDates(
+      Long curriculumId, @Param("programmeMembershipUuid") String programmeMembershipUuid,
+      LocalDate curriculumStartDate, LocalDate curriculumEndDate
+  );
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepositoryIntTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/CurriculumMembershipRepositoryIntTest.java
@@ -86,4 +86,13 @@ public class CurriculumMembershipRepositoryIntTest {
     CurriculumMembership result = testObj.findLatestCurriculumByTraineeId(1L);
     Assert.assertEquals(2L, result.getId().longValue());
   }
+
+  @Transactional
+  @Test
+  public void shouldFindCmByCurriculumIdAndPmUuidAndDates() {
+    List<CurriculumMembership> cmList = testObj.findByCurriculumIdAndPmUuidAndDates(2L,
+        "004c4a2a-80fd-4312-83b4-5e8666db5166",
+        LocalDate.of(2023, 8, 1), LocalDate.of(2027, 9, 4));
+    Assert.assertEquals(1, cmList.size());
+  }
 }

--- a/tcs-persistence/src/test/resources/scripts/curriculumMembership.sql
+++ b/tcs-persistence/src/test/resources/scripts/curriculumMembership.sql
@@ -17,10 +17,15 @@ VALUES
   ('00aca6ce-6e0d-405c-931e-1fcb1aa7a28c', 3, 1, '2022-08-01'),
   ('004c4a2a-80fd-4312-83b4-5e8666db5166', 1, 3, '2027-09-04');
 
-INSERT INTO `CurriculumMembership` (`id`, `programmeMembershipUuid`, `curriculumEndDate`)
+INSERT INTO `Curriculum` (`id`, `status`)
 VALUES
-  (1, '0023f7bc-defa-48b4-8186-5e680e981db4', '2023-07-01'),
-  (2, '0023f7bc-defa-48b4-8186-5e680e981db4', '2023-08-01'),
-  (3, '002e46cf-c966-4ca9-ac2b-ef2e5a2b57f0', '2022-09-07'),
-  (4, '00aca6ce-6e0d-405c-931e-1fcb1aa7a28c', '2022-08-01'),
-  (5, '004c4a2a-80fd-4312-83b4-5e8666db5166', '2027-09-04');
+  (1, 'CURRENT'),
+  (2, 'CURRENT');
+
+INSERT INTO `CurriculumMembership` (`id`, `curriculumId`, `programmeMembershipUuid`, `curriculumStartDate`, `curriculumEndDate`)
+VALUES
+  (1, 1, '0023f7bc-defa-48b4-8186-5e680e981db4', '2023-06-01', '2023-07-01'),
+  (2, 1, '0023f7bc-defa-48b4-8186-5e680e981db4', '2023-07-01', '2023-08-01'),
+  (3, 1, '002e46cf-c966-4ca9-ac2b-ef2e5a2b57f0', '2023-08-01', '2022-09-07'),
+  (4, 2, '00aca6ce-6e0d-405c-931e-1fcb1aa7a28c', '2023-07-01', '2022-08-01'),
+  (5, 2, '004c4a2a-80fd-4312-83b4-5e8666db5166', '2023-08-01', '2027-09-04');

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.48.0</version>
+  <version>6.48.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.32.5</version>
+      <version>2.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
1. Unexpected errors we sometimes have in bulk upload might result in the failure of the whole file. It would be hard to tell which records have already been created. So I added the duplicate validation. When users retry cm bulk create, the errors will tell them all the existing ones.
2. From a business perspective, there is not a case to have the exactly the same CM though (James said at least that he could think of). It would probably be useful to prevent duplicate CMs being created. If we don't, we would then probably need to develop a bulk CM delete

TIS21-3822