### PR TITLE
fix: delete related post trusts against the post

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.35.0</version>
+  <version>2.35.1</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Post.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Post.java
@@ -88,7 +88,7 @@ public class Post implements Serializable {
   private Set<PostFunding> fundings = new HashSet<>();
   @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
   private Set<Placement> placementHistory = new HashSet<>();
-  @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private Set<PostTrust> associatedTrusts;
   @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private Set<PostEsrEvent> postEsrEvents;

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.52.0</version>
+  <version>6.52.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.35.0</version>
+      <version>2.35.1</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
When we’re trying to delete a row from the Post table, there are related rows in the PostTrust table that have a foreign key reference (postId). It is okay we delete the related rows in the PostTrust table when delete the Post.


TIS21-7021