### PR TITLE
Bug fix - clear old and new post id foreign key references

### DIFF
--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -13,7 +13,7 @@
   <description>A module containing the model and persistence layer for TCS</description>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>tcs-persistence</artifactId>
-  <version>2.35.1</version>
+  <version>2.35.2</version>
   <dependencies>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/PostRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/PostRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.query.Procedure;
 import org.springframework.data.repository.query.Param;
@@ -95,4 +96,18 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
       "AND p.status = 'CURRENT'")
   Set<Post> findPostsByProgrammeIdAndSpecialtyId(@Param("programmeId") Long programmeId,
       @Param("specialtyId") Long specialtyId);
+
+  @Modifying
+  @Query("UPDATE Post p SET p.oldPost = null WHERE p.oldPost.id = :id")
+  void clearOldPostReferences(@Param("id") Long id);
+
+  @Modifying
+  @Query("UPDATE Post p SET p.newPost = null WHERE p.newPost.id = :id")
+  void clearNewPostReferences(@Param("id") Long id);
+
+  default void clearPostReferences(Long id) {
+    clearOldPostReferences(id);
+    clearNewPostReferences(id);
+  }
+
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.transformuk.hee.tis.tcs.service.repository;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.TestConfig;
@@ -206,7 +208,7 @@ public class PostRepositoryTest {
     entityManager.clear();
 
     Post updatedPost = entityManager.find(Post.class, post2.getId());
-    Assert.assertNull(updatedPost.getNewPost());
+    assertNull(updatedPost.getNewPost());
   }
 
   @Test
@@ -225,7 +227,18 @@ public class PostRepositoryTest {
     entityManager.clear();
 
     Post updatedPost = entityManager.find(Post.class, post2.getId());
-    Assert.assertNull(updatedPost.getOldPost());
-    Assert.assertNull(updatedPost.getNewPost());
+    assertNull(updatedPost.getOldPost());
+    assertNull(updatedPost.getNewPost());
+  }
+
+  @Test
+  public void testClearPostReferencesShouldCallClearOldAndNewReferences() {
+    Long postId = 1L;
+
+    postRepository.clearPostReferences(postId);
+
+    Optional<Post> oldRefs = postRepository.findById(postId);
+    assertNull(oldRefs.get().getOldPost());
+    assertNull(oldRefs.get().getNewPost());
   }
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
@@ -1,8 +1,5 @@
 package com.transformuk.hee.tis.tcs.service.repository;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.TestConfig;
@@ -191,7 +188,7 @@ public class PostRepositoryTest {
     entityManager.clear();
 
     Post updatedPost2 = entityManager.find(Post.class, post2.getId());
-    assertNull(updatedPost2.getOldPost());
+    Assert.assertNull(updatedPost2.getOldPost());
   }
 
   @Test
@@ -209,7 +206,7 @@ public class PostRepositoryTest {
     entityManager.clear();
 
     Post updatedPost2 = entityManager.find(Post.class, post2.getId());
-    assertNull(updatedPost2.getNewPost());
+    Assert.assertNull(updatedPost2.getNewPost());
   }
 
   @Test
@@ -240,9 +237,9 @@ public class PostRepositoryTest {
     Post updatedPost3 = entityManager.find(Post.class, post3.getId());
 
     // post1.newPost should be cleared
-    assertNull(updatedPost1.getNewPost());
+    Assert.assertNull(updatedPost1.getNewPost());
 
     // post3.oldPost should be cleared
-    assertNull(updatedPost3.getOldPost());
+    Assert.assertNull(updatedPost3.getOldPost());
   }
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
@@ -55,7 +55,6 @@ public class PostRepositoryTest {
   @After
   @Transactional
   public void tearDown() {
-    entityManager.remove(postWithTrusts);
     entityManager.remove(associatedTrust1);
     entityManager.remove(associatedTrust2);
   }
@@ -172,6 +171,61 @@ public class PostRepositoryTest {
               .getForenames()));
 
     }
+  }
 
+  @Test
+  public void testClearOldPostReferencesInPostTableWhenDelete() {
+    Post post1 = new Post();
+    entityManager.persist(post1);
+
+    Post post2 = new Post();
+    post2.setOldPost(post1);
+    entityManager.persist(post2);
+    entityManager.flush();
+
+    postRepository.clearOldPostReferences(post1.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    Post updatedPost = entityManager.find(Post.class, post2.getId());
+    Assert.assertNull(updatedPost.getOldPost());
+  }
+
+  @Test
+  public void testClearNewPostReferencesInPostTableWhenDelete() {
+    Post post1 = new Post();
+    entityManager.persist(post1);
+
+    Post post2 = new Post();
+    post2.setOldPost(post1);
+    entityManager.persist(post2);
+    entityManager.flush();
+
+    postRepository.clearNewPostReferences(post1.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    Post updatedPost = entityManager.find(Post.class, post2.getId());
+    Assert.assertNull(updatedPost.getNewPost());
+  }
+
+  @Test
+  public void testClearPostReferencesForBothOldAndNewPostWhenDelete() {
+    Post post1 = new Post();
+    entityManager.persist(post1);
+
+    Post post2 = new Post();
+    post2.setOldPost(post1);
+    post2.setNewPost(post1);
+    entityManager.persist(post2);
+    entityManager.flush();
+
+    postRepository.clearPostReferences(post1.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    Post updatedPost = entityManager.find(Post.class, post2.getId());
+    Assert.assertNull(updatedPost.getOldPost());
+    Assert.assertNull(updatedPost.getNewPost());
   }
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
@@ -240,9 +240,9 @@ public class PostRepositoryTest {
     Post updatedPost3 = entityManager.find(Post.class, post3.getId());
 
     // post1.newPost should be cleared
-    assertThat(updatedPost1.getNewPost()).isNull();
+    assertNull(updatedPost1.getNewPost());
 
     // post3.oldPost should be cleared
-    assertThat(updatedPost3.getOldPost()).isNull();
+    assertNull(updatedPost3.getOldPost());
   }
 }

--- a/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
+++ b/tcs-persistence/src/test/java/com/transformuk/hee/tis/tcs/service/repository/PostRepositoryTest.java
@@ -199,7 +199,7 @@ public class PostRepositoryTest {
     entityManager.persist(post1);
 
     Post post2 = new Post();
-    post2.setOldPost(post1);
+    post2.setNewPost(post1);
     entityManager.persist(post2);
     entityManager.flush();
 
@@ -218,7 +218,7 @@ public class PostRepositoryTest {
 
     Post post2 = new Post();
     post2.setOldPost(post1);
-    post2.setNewPost(post1);
+    post1.setNewPost(post2);
     entityManager.persist(post2);
     entityManager.flush();
 
@@ -229,16 +229,5 @@ public class PostRepositoryTest {
     Post updatedPost = entityManager.find(Post.class, post2.getId());
     assertNull(updatedPost.getOldPost());
     assertNull(updatedPost.getNewPost());
-  }
-
-  @Test
-  public void testClearPostReferencesShouldCallClearOldAndNewReferences() {
-    Long postId = 1L;
-
-    postRepository.clearPostReferences(postId);
-
-    Optional<Post> oldRefs = postRepository.findById(postId);
-    assertNull(oldRefs.get().getOldPost());
-    assertNull(oldRefs.get().getNewPost());
   }
 }

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.52.1</version>
+  <version>6.52.2</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.35.1</version>
+      <version>2.35.2</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImpl.java
@@ -671,6 +671,7 @@ public class PostServiceImpl implements PostService {
       checkTheLoggedInUserDbSameAsPostOwner(postFromDb);
       Set<Placement> attachedPlacements = postFromDb.getPlacementHistory();
       if (attachedPlacements.isEmpty()) {
+        postRepository.clearPostReferences(id);
         postRepository.deleteById(id);
       } else {
         throw new IllegalStateException("Cannot delete post as it has associated placements.");

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/PostServiceImplTest.java
@@ -439,6 +439,7 @@ class PostServiceImplTest {
         Collections.singleton("1-1RUZV6H"));
 
     testObj.delete(1L);
+    verify(postRepositoryMock).clearPostReferences(1L);
     verify(postRepositoryMock).deleteById(1L);
   }
 


### PR DESCRIPTION
In the Post table we have the following triggers
Target	Post (newPostId → id)
	On Update	RESTRICT
	On Delete	RESTRICT
Target	Post (oldPostId → id)
	On Update	RESTRICT
	On Delete	RESTRICT
So when we try to delete a Post it throws error.

TIS21-7021
