### PR TITLE
fix: change specialty type fetch to eager

### DIFF
--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
@@ -48,7 +48,7 @@ public class Specialty implements Serializable {
   @Column(name = "specialtyCode")
   private String specialtyCode;
 
-  @ElementCollection(targetClass = SpecialtyType.class, fetch = FetchType.EAGER)
+  @ElementCollection(targetClass = SpecialtyType.class, fetch = FetchType.LAZY)
   @CollectionTable(name = "SpecialtyTypes", joinColumns = {@JoinColumn(name = "specialtyId")})
   @Column(name = "specialtyType")
   @Enumerated(EnumType.STRING)

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/model/Specialty.java
@@ -48,7 +48,7 @@ public class Specialty implements Serializable {
   @Column(name = "specialtyCode")
   private String specialtyCode;
 
-  @ElementCollection(targetClass = SpecialtyType.class, fetch = FetchType.LAZY)
+  @ElementCollection(targetClass = SpecialtyType.class, fetch = FetchType.EAGER)
   @CollectionTable(name = "SpecialtyTypes", joinColumns = {@JoinColumn(name = "specialtyId")})
   @Column(name = "specialtyType")
   @Enumerated(EnumType.STRING)

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.52.2</version>
+  <version>6.52.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/aop/auditing/AuditHelperService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/aop/auditing/AuditHelperService.java
@@ -1,0 +1,23 @@
+package com.transformuk.hee.tis.tcs.service.aop.auditing;
+
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuditHelperService {
+
+  private final AuditEventRepository auditEventRepository;
+
+  public AuditHelperService(AuditEventRepository auditEventRepository) {
+    this.auditEventRepository = auditEventRepository;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void saveDeleteAudit(AuditEvent auditEvent) {
+    auditEventRepository.add(auditEvent);
+  }
+}
+

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/AuditingAspectConfiguration.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/config/AuditingAspectConfiguration.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.tcs.service.config;
 
 import com.transformuk.hee.tis.audit.repository.TisAuditRepository;
+import com.transformuk.hee.tis.tcs.service.aop.auditing.AuditHelperService;
 import com.transformuk.hee.tis.tcs.service.aop.auditing.AuditingAspect;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.context.annotation.Bean;
@@ -17,7 +18,13 @@ public class AuditingAspectConfiguration {
   }
 
   @Bean
-  public AuditingAspect auditingAspect() {
-    return new AuditingAspect(auditEventRepository());
+  public AuditHelperService auditHelperService(AuditEventRepository auditEventRepository) {
+    return new AuditHelperService(auditEventRepository);
+  }
+
+  @Bean
+  public AuditingAspect auditingAspect(AuditEventRepository auditEventRepository,
+      AuditHelperService auditHelperService) {
+    return new AuditingAspect(auditEventRepository, auditHelperService);
   }
 }


### PR DESCRIPTION
When I was  trying to delete a Post, which is linked to a Specialty, and Specialty has:

@ElementCollection(targetClass = SpecialtyType.class, fetch = FetchType.LAZY)

AuditingAspect tries to access the specialtyTypes set during auditing, Hibernate tries to lazy-load the collection, but the session is already closed or unavailable which causes this error:

"failed to lazily initialize a collection of role: Specialty.specialtyTypes, could not initialize proxy - no Session"

So the FetchType is changed to EAGER. In the DB we have less than 1200 records so performance will not be an issue.

----------------------------------------------------------------------------------------------------------------------------------------------------------------
Audit logs were prohibiting the post delete to go forward by checking the SpecialtyType, which was on FetchType Lazy loading that caused the Hibernate session to expire. (See above)

Introducing an AuditHelperService class and ensuring this helper is annotated @Transactional so that lazy fields are fetched safely. 

Annotate the audit aspect or audit call with @Transactional(propagation = Propagation.REQUIRES_NEW) so that it opens a new Hibernate session for loading lazy fields.



TIS21-7021
