### PR TITLE
fix: fix audit aspect hibernate session for specialty type

### DIFF
--- a/tcs-api/pom.xml
+++ b/tcs-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-api</artifactId>
-  <version>6.27.0</version>
+  <version>6.27.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/SpecialtyDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/SpecialtyDTO.java
@@ -2,7 +2,6 @@ package com.transformuk.hee.tis.tcs.api.dto;
 
 import com.transformuk.hee.tis.tcs.api.dto.validation.Create;
 import com.transformuk.hee.tis.tcs.api.dto.validation.Update;
-import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import java.io.Serializable;
 import java.util.Objects;
@@ -38,7 +37,7 @@ public class SpecialtyDTO implements Serializable {
   @NotBlank(groups = {Create.class, Update.class}, message = "specialtyCode cannot be blank")
   private String specialtyCode;
 
-  private Set<SpecialtyType> specialtyTypes;
+  private Set<SpecialtyTypeDTO> specialtyTypes;
 
   private SpecialtyGroupDTO specialtyGroup;
 

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/SpecialtyTypeDTO.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/dto/SpecialtyTypeDTO.java
@@ -1,0 +1,46 @@
+package com.transformuk.hee.tis.tcs.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import lombok.Data;
+
+@Data
+public class SpecialtyTypeDTO {
+
+  private String name;
+
+  public SpecialtyTypeDTO() {
+  }
+
+  public SpecialtyTypeDTO(String name) {
+    this.name = name;
+  }
+
+  @JsonCreator
+  public static SpecialtyTypeDTO fromString(String name) {
+    return new SpecialtyTypeDTO(name);
+  }
+
+  @JsonValue
+  public String toValue() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SpecialtyTypeDTO that = (SpecialtyTypeDTO) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/enumeration/SpecialtyType.java
+++ b/tcs-api/src/main/java/com/transformuk/hee/tis/tcs/api/enumeration/SpecialtyType.java
@@ -6,5 +6,20 @@ package com.transformuk.hee.tis.tcs.api.enumeration;
 public enum SpecialtyType {
 
   //Remember to modify the specialtyType column in the SpecialtyTypes table if you change this Enum
-  CURRICULUM, POST, PLACEMENT, SUB_SPECIALTY
+  //CURRICULUM, POST, PLACEMENT, SUB_SPECIALTY
+
+  CURRICULUM("CURRICULUM"),
+  POST("POST"),
+  PLACEMENT("PLACEMENT"),
+  SUB_SPECIALTY("SUB_SPECIALTY");
+
+  private final String name;
+
+  SpecialtyType(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
 }

--- a/tcs-client/pom.xml
+++ b/tcs-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-client</artifactId>
-  <version>6.7.1</version>
+  <version>6.7.2</version>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.27.0</version>
+      <version>6.27.1</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplTest.java
+++ b/tcs-client/src/test/java/com/transformuk/hee/tis/tcs/client/service/impl/TcsServiceImplTest.java
@@ -19,6 +19,7 @@ import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.GmcDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyTypeDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -259,7 +260,7 @@ public class TcsServiceImplTest {
     SpecialtyDTO specialty = new SpecialtyDTO();
     specialty.setName("specialtyName");
     specialty.setSpecialtyTypes(new HashSet<>(
-        Collections.singletonList(SpecialtyType.SUB_SPECIALTY)));
+        Collections.singletonList(new SpecialtyTypeDTO("SUB_SPECIALTY"))));
     specialty.setId(20L);
 
     String encodedParameters = new URLCodec().encode("{\"name\":[\"specialtyName\"],"
@@ -285,7 +286,7 @@ public class TcsServiceImplTest {
     SpecialtyDTO specialty = new SpecialtyDTO();
     specialty.setName("specialtyName");
     specialty.setSpecialtyTypes(new HashSet<>(
-        Collections.singletonList(SpecialtyType.SUB_SPECIALTY)));
+        Collections.singletonList(new SpecialtyTypeDTO("SUB_SPECIALTY"))));
     specialty.setId(20L);
 
     String encodedParametersForSpecialtiesOfTypeSubspecialty = new URLCodec()

--- a/tcs-persistence/pom.xml
+++ b/tcs-persistence/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-api</artifactId>
-      <version>6.27.0</version>
+      <version>6.27.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.52.2</version>
+  <version>6.52.3</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/SpecialtyValidator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/validation/SpecialtyValidator.java
@@ -3,7 +3,7 @@ package com.transformuk.hee.tis.tcs.service.api.validation;
 import com.google.common.collect.Lists;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyGroupDTO;
-import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyTypeDTO;
 import com.transformuk.hee.tis.tcs.service.repository.SpecialtyGroupRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ public class SpecialtyValidator {
     }
   }
 
-  private List<FieldError> checkSpecialtyTypes(Set<SpecialtyType> specialtyTypes) {
+  private List<FieldError> checkSpecialtyTypes(Set<SpecialtyTypeDTO> specialtyTypes) {
     List<FieldError> fieldErrors = Lists.newArrayList();
     if (specialtyTypes == null) {
       fieldErrors

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PostMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PostMapper.java
@@ -10,6 +10,8 @@ import com.transformuk.hee.tis.tcs.api.dto.PostSiteDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostSpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyTypeDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.model.Post;
 import com.transformuk.hee.tis.tcs.service.model.PostFunding;
@@ -20,6 +22,7 @@ import com.transformuk.hee.tis.tcs.service.model.Programme;
 import com.transformuk.hee.tis.tcs.service.model.Specialty;
 import com.transformuk.hee.tis.tcs.service.repository.EsrPostProjection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
@@ -182,9 +185,18 @@ public class PostMapper {
       result = new SpecialtyDTO();
       result.setId(specialty.getId());
       result.setName(specialty.getName());
-      result.setSpecialtyTypes(specialty.getSpecialtyTypes());
       result.setSpecialtyCode(specialty.getSpecialtyCode());
       result.setStatus(specialty.getStatus());
+
+      if (CollectionUtils.isNotEmpty(specialty.getSpecialtyTypes())) {
+        Set<SpecialtyTypeDTO> typeDTOs = specialty.getSpecialtyTypes().stream()
+            .map(type -> {
+              SpecialtyTypeDTO dto = new SpecialtyTypeDTO();
+              dto.setName(type.getName());
+              return dto;
+            }).collect(Collectors.toSet());
+        result.setSpecialtyTypes(typeDTOs);
+      }
     }
     return result;
   }
@@ -304,9 +316,16 @@ public class PostMapper {
       result = new Specialty();
       result.setId(specialtyDTO.getId());
       result.setName(specialtyDTO.getName());
-      result.setSpecialtyTypes(specialtyDTO.getSpecialtyTypes());
       result.setSpecialtyCode(specialtyDTO.getSpecialtyCode());
       result.setStatus(specialtyDTO.getStatus());
+
+      if (CollectionUtils.isNotEmpty(specialtyDTO.getSpecialtyTypes())) {
+        Set<SpecialtyType> types = specialtyDTO.getSpecialtyTypes().stream()
+            .filter(Objects::nonNull)
+            .map(dto -> SpecialtyType.valueOf(dto.getName()))
+            .collect(Collectors.toSet());
+        result.setSpecialtyTypes(types);
+      }
     }
     return result;
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/SpecialtyGroupMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/SpecialtyGroupMapper.java
@@ -2,12 +2,16 @@ package com.transformuk.hee.tis.tcs.service.service.mapper;
 
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyGroupDTO;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyTypeDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import com.transformuk.hee.tis.tcs.service.model.Specialty;
 import com.transformuk.hee.tis.tcs.service.model.SpecialtyGroup;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
 
@@ -91,7 +95,13 @@ public class SpecialtyGroupMapper {
       result.setId(specialtyDTO.getId());
       result.setUuid(specialtyDTO.getUuid());
       result.setName(specialtyDTO.getName());
-      result.setSpecialtyTypes(specialtyDTO.getSpecialtyTypes());
+      if (CollectionUtils.isNotEmpty(specialtyDTO.getSpecialtyTypes())) {
+        Set<SpecialtyType> types = specialtyDTO.getSpecialtyTypes().stream()
+            .filter(Objects::nonNull)
+            .map(dto -> SpecialtyType.valueOf(dto.getName()))
+            .collect(Collectors.toSet());
+        result.setSpecialtyTypes(types);
+      }
       result.setSpecialtyCode(specialtyDTO.getSpecialtyCode());
       result.setStatus(specialtyDTO.getStatus());
       result.setIntrepidId(specialtyDTO.getIntrepidId());
@@ -107,7 +117,16 @@ public class SpecialtyGroupMapper {
       result.setId(specialty.getId());
       result.setUuid(specialty.getUuid());
       result.setName(specialty.getName());
-      result.setSpecialtyTypes(specialty.getSpecialtyTypes());
+
+      if (CollectionUtils.isNotEmpty(specialty.getSpecialtyTypes())) {
+        Set<SpecialtyTypeDTO> typeDTOs = specialty.getSpecialtyTypes().stream()
+            .map(type -> {
+              SpecialtyTypeDTO dto = new SpecialtyTypeDTO();
+              dto.setName(type.getName());
+              return dto;
+            }).collect(Collectors.toSet());
+        result.setSpecialtyTypes(typeDTOs);
+      }
       result.setSpecialtyCode(specialty.getSpecialtyCode());
       result.setStatus(specialty.getStatus());
       result.setIntrepidId(specialty.getIntrepidId());

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/SpecialtyMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/SpecialtyMapper.java
@@ -2,10 +2,16 @@ package com.transformuk.hee.tis.tcs.service.service.mapper;
 
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyGroupDTO;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyTypeDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import com.transformuk.hee.tis.tcs.service.model.Specialty;
 import com.transformuk.hee.tis.tcs.service.model.SpecialtyGroup;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
 import org.mapstruct.Mapper;
 
 /**
@@ -25,7 +31,16 @@ public class SpecialtyMapper {
       result.setCollege(specialty.getCollege());
       result.setIntrepidId(specialty.getIntrepidId());
       result.setSpecialtyCode(specialty.getSpecialtyCode());
-      result.setSpecialtyTypes(specialty.getSpecialtyTypes());
+
+      if (CollectionUtils.isNotEmpty(specialty.getSpecialtyTypes())) {
+        Set<SpecialtyTypeDTO> typeDTOs = specialty.getSpecialtyTypes().stream()
+            .map(type -> {
+              SpecialtyTypeDTO dto = new SpecialtyTypeDTO();
+              dto.setName(type.getName());
+              return dto;
+            }).collect(Collectors.toSet());
+        result.setSpecialtyTypes(typeDTOs);
+      }
       result.setStatus(specialty.getStatus());
       result.setSpecialtyGroup(specialtyGroupToSpecialtyGroupDTO(specialty.getSpecialtyGroup()));
       result.setBlockIndemnity(specialty.isBlockIndemnity());
@@ -52,7 +67,14 @@ public class SpecialtyMapper {
       result.setCollege(specialtyDTO.getCollege());
       result.setIntrepidId(specialtyDTO.getIntrepidId());
       result.setSpecialtyCode(specialtyDTO.getSpecialtyCode());
-      result.setSpecialtyTypes(specialtyDTO.getSpecialtyTypes());
+
+      if (CollectionUtils.isNotEmpty(specialtyDTO.getSpecialtyTypes())) {
+        Set<SpecialtyType> types = specialtyDTO.getSpecialtyTypes().stream()
+            .filter(Objects::nonNull)
+            .map(dto -> SpecialtyType.valueOf(dto.getName()))
+            .collect(Collectors.toSet());
+        result.setSpecialtyTypes(types);
+      }
       result.setStatus(specialtyDTO.getStatus());
       result.setSpecialtyGroup(specialtyGroupDTOToSpecialtyGroup(specialtyDTO.getSpecialtyGroup()));
       result.setBlockIndemnity(specialtyDTO.isBlockIndemnity());

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/SpecialtyServiceImplTest.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyGroupDTO;
+import com.transformuk.hee.tis.tcs.api.dto.SpecialtyTypeDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.SpecialtyType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.model.Specialty;
@@ -67,7 +68,7 @@ public class SpecialtyServiceImplTest {
     specialtyDTO = new SpecialtyDTO();
     specialtyDTO.setSpecialtyGroup(new SpecialtyGroupDTO());
     specialtyDTO.setIntrepidId(INTREPID_ID);
-    specialtyDTO.setSpecialtyTypes(Sets.newHashSet(SUB_SPECIALTY));
+    specialtyDTO.setSpecialtyTypes(Sets.newHashSet(new SpecialtyTypeDTO("SUB_SPECIALTY")));
     specialtyDTO.setSpecialtyCode(NHS_CODE);
     specialtyDTO.setCollege(COLLEGE);
     specialtyDTO.setStatus(Status.INACTIVE);


### PR DESCRIPTION
Aspect Oriented Programming: Auditing Aspect's hibernate session expiry was found eventually at the mappers, i.e. PostMapper and SpecialtyMapper where specialty dtos and entities setting specialty types. result.setSpecialtyTypes()

TIS21-7021

