### PR TITLE
test: add tests for reusing cm

### DIFF
--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -38,9 +38,6 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
   List<ProgrammeMembership> findAllProgrammeMembershipInDescOrderByTraineeId(
       @Param("traineeId") Long traineeId);
 
-  @Query("SELECT pm FROM ProgrammeMembership pm JOIN pm.curriculumMemberships cm WHERE cm.id = :cmId")
-  Optional<ProgrammeMembership> findByCurriculumMembershipId(@Param("cmId") Long cmId);
-
   @Query(value = "SELECT pm "
       + "FROM ProgrammeMembership pm "
       + "WHERE pm.programme.id = :programmeId")

--- a/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
+++ b/tcs-persistence/src/main/java/com/transformuk/hee/tis/tcs/service/repository/ProgrammeMembershipRepository.java
@@ -38,6 +38,9 @@ public interface ProgrammeMembershipRepository extends JpaRepository<ProgrammeMe
   List<ProgrammeMembership> findAllProgrammeMembershipInDescOrderByTraineeId(
       @Param("traineeId") Long traineeId);
 
+  @Query("SELECT pm FROM ProgrammeMembership pm JOIN pm.curriculumMemberships cm WHERE cm.id = :cmId")
+  Optional<ProgrammeMembership> findByCurriculumMembershipId(@Param("cmId") Long cmId);
+
   @Query(value = "SELECT pm "
       + "FROM ProgrammeMembership pm "
       + "WHERE pm.programme.id = :programmeId")

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.53.2</version>
+  <version>6.53.3</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/DuplicateCurriculumMembershipException.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/DuplicateCurriculumMembershipException.java
@@ -1,5 +1,11 @@
 package com.transformuk.hee.tis.tcs.service.exception;
 
+/**
+ * Exception thrown to indicate that an attempt was made to create a duplicate
+ * curriculum membership.
+ *
+ * <p>This is an unchecked exception extending {@link RuntimeException}.</p>
+ */
 public class DuplicateCurriculumMembershipException extends RuntimeException {
   public DuplicateCurriculumMembershipException(String message) {
     super(message);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/DuplicateCurriculumMembershipException.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/DuplicateCurriculumMembershipException.java
@@ -1,0 +1,7 @@
+package com.transformuk.hee.tis.tcs.service.exception;
+
+public class DuplicateCurriculumMembershipException extends RuntimeException {
+  public DuplicateCurriculumMembershipException(String message) {
+    super(message);
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/ExceptionTranslator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/ExceptionTranslator.java
@@ -59,9 +59,9 @@ public class ExceptionTranslator {
   }
 
   /**
-   * This exception occurs if we have an enum in a DTO such as {@link
-   * com.transformuk.hee.tis.tcs.api.dto.ProgrammeDTO#status} and the REST request coming in does
-   * not provide the proper ENUM value.
+   * This exception occurs if we have an enum in a DTO such as
+   * {@link com.transformuk.hee.tis.tcs.api.dto.ProgrammeDTO#status} and the REST request coming in
+   * does not provide the proper ENUM value.
    *
    * @param ex the exception to intercept
    * @return the error object to return to the user
@@ -160,7 +160,8 @@ public class ExceptionTranslator {
   }
 
   @ExceptionHandler(DuplicateCurriculumMembershipException.class)
-  public ResponseEntity<ErrorVM> handleDuplicateCurriculumMembership(DuplicateCurriculumMembershipException ex) {
+  public ResponseEntity<ErrorVM> handleDuplicateCurriculumMembership(
+      DuplicateCurriculumMembershipException ex) {
     log.error("Duplicate curriculum membership error", ex);
     return ResponseEntity.badRequest().body(new ErrorVM(ex.getMessage()));
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/ExceptionTranslator.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/exception/ExceptionTranslator.java
@@ -158,4 +158,10 @@ public class ExceptionTranslator {
   public ErrorVM accessUnauthorisedException(AccessUnauthorisedException ex) {
     return new ErrorVM(ErrorConstants.ERR_ACCESS_DENIED, ex.getMessage());
   }
+
+  @ExceptionHandler(DuplicateCurriculumMembershipException.class)
+  public ResponseEntity<ErrorVM> handleDuplicateCurriculumMembership(DuplicateCurriculumMembershipException ex) {
+    log.error("Duplicate curriculum membership error", ex);
+    return ResponseEntity.badRequest().body(new ErrorVM(ex.getMessage()));
+  }
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -129,15 +129,10 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
 
           // check if this CM is already attached to another ProgrammeMembership
           ProgrammeMembership existingPm = existingCm.getProgrammeMembership();
-          if (existingPm != null
-              && (programmeMembershipDto.getUuid() == null
-              || !programmeMembershipDto.getUuid().equals(existingPm.getUuid()))) {
-            throw new DuplicateCurriculumMembershipException(
-                "Curriculum membership already assigned. Please reload the page.");
-          }
 
-          // attach the managed CM entity to the programme membership
-          programmeMembership.getCurriculumMemberships().add(existingCm);
+          if (!existingPm.getUuid().equals(programmeMembershipDto.getUuid())) {
+            throw new DuplicateCurriculumMembershipException("Please reload the page.");
+          }
         }
       }
     }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -12,6 +12,7 @@ import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.api.validation.ProgrammeMembershipValidator;
 import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipDeletedEvent;
 import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipSavedEvent;
+import com.transformuk.hee.tis.tcs.service.exception.DuplicateCurriculumMembershipException;
 import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
@@ -123,14 +124,15 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
       for (CurriculumMembershipDTO cmDto : programmeMembershipDto.getCurriculumMemberships()) {
         if (cmDto.getId() != null) {
           CurriculumMembership existingCm = curriculumMembershipRepository.findById(cmDto.getId())
-              .orElseThrow(() -> new RuntimeException("Curriculum membership not found: " + cmDto.getId()));
+              .orElseThrow(
+                  () -> new RuntimeException("Curriculum membership not found: " + cmDto.getId()));
 
           // check if this CM is already attached to another ProgrammeMembership
           ProgrammeMembership existingPm = existingCm.getProgrammeMembership();
-          if (existingPm != null &&
-              (programmeMembershipDto.getUuid() == null ||
-                  !programmeMembershipDto.getUuid().equals(existingPm.getUuid()))) {
-            throw new RuntimeException(
+          if (existingPm != null
+              && (programmeMembershipDto.getUuid() == null
+              || !programmeMembershipDto.getUuid().equals(existingPm.getUuid()))) {
+            throw new DuplicateCurriculumMembershipException(
                 "Curriculum membership already assigned. Please reload the page.");
           }
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -119,6 +119,30 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
     ProgrammeMembership programmeMembership
         = programmeMembershipMapper.toEntity(programmeMembershipDto);
 
+    if (programmeMembershipDto.getCurriculumMemberships() != null) {
+      for (CurriculumMembershipDTO cmDto : programmeMembershipDto.getCurriculumMemberships()) {
+        if (cmDto.getId() != null) {
+          CurriculumMembership existingCm = curriculumMembershipRepository.findById(cmDto.getId())
+              .orElseThrow(() -> new RuntimeException("Curriculum membership not found: " + cmDto.getId()));
+
+          // check if this CM is already attached to another ProgrammeMembership
+          Optional<ProgrammeMembership> existingPmOpt = programmeMembershipRepository.findByCurriculumMembershipId(existingCm.getId());
+          if (existingPmOpt.isPresent()) {
+            ProgrammeMembership existingPm = existingPmOpt.get();
+
+            // if the existing PM is different from the one we're trying to save, throw error
+            if (programmeMembershipDto.getUuid() == null ||
+                !programmeMembershipDto.getUuid().equals(existingPm.getUuid())) {
+              throw new RuntimeException("Curriculum membership already assigned. Please reload the page.");
+            }
+          }
+
+          // attach the managed CM entity to the programme membership
+          programmeMembership.getCurriculumMemberships().add(existingCm);
+        }
+      }
+    }
+
     programmeMembership = programmeMembershipRepository.save(programmeMembership);
 
     ProgrammeMembershipDTO programmeMembershipSavedDto

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImpl.java
@@ -126,15 +126,12 @@ public class ProgrammeMembershipServiceImpl implements ProgrammeMembershipServic
               .orElseThrow(() -> new RuntimeException("Curriculum membership not found: " + cmDto.getId()));
 
           // check if this CM is already attached to another ProgrammeMembership
-          Optional<ProgrammeMembership> existingPmOpt = programmeMembershipRepository.findByCurriculumMembershipId(existingCm.getId());
-          if (existingPmOpt.isPresent()) {
-            ProgrammeMembership existingPm = existingPmOpt.get();
-
-            // if the existing PM is different from the one we're trying to save, throw error
-            if (programmeMembershipDto.getUuid() == null ||
-                !programmeMembershipDto.getUuid().equals(existingPm.getUuid())) {
-              throw new RuntimeException("Curriculum membership already assigned. Please reload the page.");
-            }
+          ProgrammeMembership existingPm = existingCm.getProgrammeMembership();
+          if (existingPm != null &&
+              (programmeMembershipDto.getUuid() == null ||
+                  !programmeMembershipDto.getUuid().equals(existingPm.getUuid()))) {
+            throw new RuntimeException(
+                "Curriculum membership already assigned. Please reload the page.");
           }
 
           // attach the managed CM entity to the programme membership

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.transformuk.hee.tis.tcs.service.service.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -698,7 +700,7 @@ public class ProgrammeMembershipServiceImplTest {
     verify(personRepositoryMock, never()).getOne(any());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void shouldThrowExceptionWhenCurriculumMembershipNotFoundInTheRepo() {
     UUID pmUuid = UUID.randomUUID();
 
@@ -713,12 +715,11 @@ public class ProgrammeMembershipServiceImplTest {
 
     when(curriculumMembershipRepositoryMock.findById(999L)).thenReturn(Optional.empty());
 
-    try {
-      testObj.save(dto);
-    } catch (RuntimeException ex) {
-      assertTrue(ex.getMessage().contains("Curriculum membership not found: 999"));
-      throw ex;
-    }
+    RuntimeException ex = Assert.assertThrows(
+        RuntimeException.class,
+        () -> testObj.save(dto)
+    );
+    assertThat(ex.getMessage(), containsString("Curriculum membership not found: 999"));
   }
 
   @Test

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -610,15 +610,10 @@ public class ProgrammeMembershipServiceImplTest {
         .thenReturn(programmeMembership1);
     when(personRepositoryMock.getOne(anyLong())).thenReturn(person);
 
-    CurriculumMembership cm1 = new CurriculumMembership();
-    cm1.setId(CURRICULUM_MEMBERSHIP_ID_1);
-    CurriculumMembership cm2 = new CurriculumMembership();
-    cm2.setId(CURRICULUM_MEMBERSHIP_ID_2);
-
     when(curriculumMembershipRepositoryMock.findById(CURRICULUM_MEMBERSHIP_ID_1))
-        .thenReturn(Optional.of(cm1));
+        .thenReturn(Optional.of(curriculumMembership1));
     when(curriculumMembershipRepositoryMock.findById(CURRICULUM_MEMBERSHIP_ID_2))
-        .thenReturn(Optional.of(cm2));
+        .thenReturn(Optional.of(curriculumMembership2));
 
     //when
     ProgrammeMembershipDTO programmeMembershipDTO = testObj.save(programmeMembershipDto1);
@@ -779,11 +774,15 @@ public class ProgrammeMembershipServiceImplTest {
     Assert.assertEquals(1, returnDto.getMessageList().size());
   }
 
-  @Ignore("Ignored for now, will fix once the new logic works out")
   @Test
   public void shouldPatchProgrammeMembership() {
     ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
     dto.setUuid(PROGRAMME_MEMBERSHIP_ID_1);
+
+    when(curriculumMembershipRepositoryMock.findById(CURRICULUM_MEMBERSHIP_ID_1))
+       .thenReturn(Optional.of(curriculumMembership1));
+    when(curriculumMembershipRepositoryMock.findById(CURRICULUM_MEMBERSHIP_ID_2))
+        .thenReturn(Optional.of(curriculumMembership2));
 
     when(programmeMembershipRepositoryMock.findByUuid(PROGRAMME_MEMBERSHIP_ID_1))
         .thenReturn(Optional.of(programmeMembership1));

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -698,55 +698,8 @@ public class ProgrammeMembershipServiceImplTest {
     verify(personRepositoryMock, never()).getOne(any());
   }
 
-  @Test
-  public void givenCmWithId_whenSaving_thenExistingCmIsFetched() {
-    // Arrange
-    UUID pmUuid = UUID.randomUUID();
-
-    ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
-    dto.setUuid(pmUuid);
-    //dto.setPerson(new PersonDTO());
-    dto.setPerson(personDto);
-    //dto.getPerson().setId(42L);
-
-    CurriculumMembershipDTO cmDto = new CurriculumMembershipDTO();
-    cmDto.setId(100L); // non-null id
-    dto.setCurriculumMemberships(Collections.singletonList(cmDto));
-
-    ProgrammeMembership mappedEntity = new ProgrammeMembership();
-    mappedEntity.setUuid(pmUuid);
-
-    CurriculumMembership existingCm = new CurriculumMembership();
-    ProgrammeMembership attachedPm = new ProgrammeMembership();
-    attachedPm.setUuid(pmUuid);
-    existingCm.setProgrammeMembership(attachedPm);
-
-    // Stubbing
-//    when(programmeMembershipMapper.toEntity(dto)).thenReturn(mappedEntity);
-    when(curriculumMembershipRepositoryMock.findById(100L)).thenReturn(Optional.of(existingCm));
-    //when(curriculumMembershipRepositoryMock.save(mappedEntity)).thenReturn(mappedEntity);
-    when(programmeMembershipRepositoryMock.save(any()))
-        .thenAnswer(inv -> inv.getArgument(0));
-//    when(programmeMembershipMapper.toDto(mappedEntity)).thenReturn(dto);
-
-    Person managedPerson = new Person();
-    managedPerson.setId(personDto.getId());
-    managedPerson.setStatus(Status.CURRENT);
-    when(personRepositoryMock.getOne(personDto.getId()))
-        .thenReturn(managedPerson);
-
-    // Act
-    ProgrammeMembershipDTO result = testObj.save(dto);
-
-    // Assert
-    assertNotNull(result);
-    verify(curriculumMembershipRepositoryMock).findById(100L); // ensure repository was hit
-    verify(programmeMembershipRepositoryMock).save(mappedEntity);
-  }
-
   @Test(expected = RuntimeException.class)
-  public void givenCmWithId_whenCurriculumMembershipNotFound_thenThrowRuntimeException() {
-    // Arrange
+  public void shouldThrowExceptionWhenCurriculumMembershipNotFoundInTheRepo() {
     UUID pmUuid = UUID.randomUUID();
 
     ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
@@ -755,23 +708,16 @@ public class ProgrammeMembershipServiceImplTest {
     dto.getPerson().setId(42L);
 
     CurriculumMembershipDTO cmDto = new CurriculumMembershipDTO();
-    cmDto.setId(999L); // non-null id, but not found
+    cmDto.setId(999L);
     dto.setCurriculumMemberships(Collections.singletonList(cmDto));
 
-    //ProgrammeMembership mappedEntity = new ProgrammeMembership();
-    //mappedEntity.setUuid(pmUuid);
-
-    // Stubbing
-    //when(programmeMembershipMapper.toEntity(dto)).thenReturn(mappedEntity);
     when(curriculumMembershipRepositoryMock.findById(999L)).thenReturn(Optional.empty());
 
     try {
-      // Act
       testObj.save(dto);
     } catch (RuntimeException ex) {
-      // Assert
       assertTrue(ex.getMessage().contains("Curriculum membership not found: 999"));
-      throw ex; // rethrow so JUnit's expected = RuntimeException sees it
+      throw ex;
     }
   }
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,6 +26,7 @@ import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import com.transformuk.hee.tis.tcs.service.api.validation.ProgrammeMembershipValidator;
 import com.transformuk.hee.tis.tcs.service.event.CurriculumMembershipDeletedEvent;
+import com.transformuk.hee.tis.tcs.service.exception.DuplicateCurriculumMembershipException;
 import com.transformuk.hee.tis.tcs.service.model.Curriculum;
 import com.transformuk.hee.tis.tcs.service.model.CurriculumMembership;
 import com.transformuk.hee.tis.tcs.service.model.Person;
@@ -64,7 +64,6 @@ import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -689,7 +688,7 @@ public class ProgrammeMembershipServiceImplTest {
     when(curriculumMembershipRepositoryMock.findById(cmId))
         .thenReturn(Optional.of(existingCm));
 
-    RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+    RuntimeException ex = assertThrows(DuplicateCurriculumMembershipException.class, () -> {
       testObj.save(requestDto);
     });
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/impl/ProgrammeMembershipServiceImplTest.java
@@ -2,6 +2,7 @@ package com.transformuk.hee.tis.tcs.service.service.impl;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -486,7 +487,7 @@ public class ProgrammeMembershipServiceImplTest {
 
     Optional<ProgrammeMembershipCurriculaDTO> any = result.stream()
         .filter(pmc -> pmc.getProgrammeStartDate().equals(dateFrom)).findAny();
-    Assert.assertTrue(any.isPresent());
+    assertTrue(any.isPresent());
     ProgrammeMembershipCurriculaDTO programmeMembershipCurriculaDTO = any.get();
     Assert.assertEquals(2,
         programmeMembershipCurriculaDTO.getCurriculumMemberships().size());
@@ -692,9 +693,86 @@ public class ProgrammeMembershipServiceImplTest {
       testObj.save(requestDto);
     });
 
-    assertEquals("Curriculum membership already assigned. Please reload the page.", ex.getMessage());
+    assertEquals("Please reload the page.", ex.getMessage());
     verify(programmeMembershipRepositoryMock, never()).save(any());
     verify(personRepositoryMock, never()).getOne(any());
+  }
+
+  @Test
+  public void givenCmWithId_whenSaving_thenExistingCmIsFetched() {
+    // Arrange
+    UUID pmUuid = UUID.randomUUID();
+
+    ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
+    dto.setUuid(pmUuid);
+    //dto.setPerson(new PersonDTO());
+    dto.setPerson(personDto);
+    //dto.getPerson().setId(42L);
+
+    CurriculumMembershipDTO cmDto = new CurriculumMembershipDTO();
+    cmDto.setId(100L); // non-null id
+    dto.setCurriculumMemberships(Collections.singletonList(cmDto));
+
+    ProgrammeMembership mappedEntity = new ProgrammeMembership();
+    mappedEntity.setUuid(pmUuid);
+
+    CurriculumMembership existingCm = new CurriculumMembership();
+    ProgrammeMembership attachedPm = new ProgrammeMembership();
+    attachedPm.setUuid(pmUuid);
+    existingCm.setProgrammeMembership(attachedPm);
+
+    // Stubbing
+//    when(programmeMembershipMapper.toEntity(dto)).thenReturn(mappedEntity);
+    when(curriculumMembershipRepositoryMock.findById(100L)).thenReturn(Optional.of(existingCm));
+    //when(curriculumMembershipRepositoryMock.save(mappedEntity)).thenReturn(mappedEntity);
+    when(programmeMembershipRepositoryMock.save(any()))
+        .thenAnswer(inv -> inv.getArgument(0));
+//    when(programmeMembershipMapper.toDto(mappedEntity)).thenReturn(dto);
+
+    Person managedPerson = new Person();
+    managedPerson.setId(personDto.getId());
+    managedPerson.setStatus(Status.CURRENT);
+    when(personRepositoryMock.getOne(personDto.getId()))
+        .thenReturn(managedPerson);
+
+    // Act
+    ProgrammeMembershipDTO result = testObj.save(dto);
+
+    // Assert
+    assertNotNull(result);
+    verify(curriculumMembershipRepositoryMock).findById(100L); // ensure repository was hit
+    verify(programmeMembershipRepositoryMock).save(mappedEntity);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void givenCmWithId_whenCurriculumMembershipNotFound_thenThrowRuntimeException() {
+    // Arrange
+    UUID pmUuid = UUID.randomUUID();
+
+    ProgrammeMembershipDTO dto = new ProgrammeMembershipDTO();
+    dto.setUuid(pmUuid);
+    dto.setPerson(new PersonDTO());
+    dto.getPerson().setId(42L);
+
+    CurriculumMembershipDTO cmDto = new CurriculumMembershipDTO();
+    cmDto.setId(999L); // non-null id, but not found
+    dto.setCurriculumMemberships(Collections.singletonList(cmDto));
+
+    //ProgrammeMembership mappedEntity = new ProgrammeMembership();
+    //mappedEntity.setUuid(pmUuid);
+
+    // Stubbing
+    //when(programmeMembershipMapper.toEntity(dto)).thenReturn(mappedEntity);
+    when(curriculumMembershipRepositoryMock.findById(999L)).thenReturn(Optional.empty());
+
+    try {
+      // Act
+      testObj.save(dto);
+    } catch (RuntimeException ex) {
+      // Assert
+      assertTrue(ex.getMessage().contains("Curriculum membership not found: 999"));
+      throw ex; // rethrow so JUnit's expected = RuntimeException sees it
+    }
   }
 
   @Test


### PR DESCRIPTION
- Implemented the ACs mentioned in the ticket
- Added two tests for reusing curriculum memberships. 
- All the comments in the draft pr are considered
- Input and Output data have been checked
- Different combinations of PM and CMs were tested locally
- patch test is also considered

TIS21-7457