### PR TITLE
chore: remove disused reval queue

### DIFF
--- a/.aws/tis-tcs-nimdta.json
+++ b/.aws/tis-tcs-nimdta.json
@@ -142,10 +142,6 @@
           "valueFrom": "reval-rabbit-exchange-tcs-nimdta"
         },
         {
-          "name": "REVAL_RABBIT_QUEUE",
-          "valueFrom": "reval-rabbit-queue-tcs-nimdta"
-        },
-        {
           "name": "REVAL_RABBIT_SYNC_START_QUEUE",
           "valueFrom": "reval-rabbit-sync-start-queue-tcs-nimdta"
         },

--- a/.aws/tis-tcs-preprod.json
+++ b/.aws/tis-tcs-preprod.json
@@ -142,10 +142,6 @@
           "valueFrom": "reval-rabbit-exchange-tcs-preprod"
         },
         {
-          "name": "REVAL_RABBIT_QUEUE",
-          "valueFrom": "reval-rabbit-queue-tcs-preprod"
-        },
-        {
           "name": "REVAL_RABBIT_SYNC_START_QUEUE",
           "valueFrom": "reval-rabbit-sync-start-queue-tcs-preprod"
         },

--- a/.aws/tis-tcs-prod.json
+++ b/.aws/tis-tcs-prod.json
@@ -142,10 +142,6 @@
           "valueFrom": "reval-rabbit-exchange-tcs-prod"
         },
         {
-          "name": "REVAL_RABBIT_QUEUE",
-          "valueFrom": "reval-rabbit-queue-tcs-prod"
-        },
-        {
           "name": "REVAL_RABBIT_SYNC_START_QUEUE",
           "valueFrom": "reval-rabbit-sync-start-queue-tcs-prod"
         },

--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.57.2</version>
+  <version>6.57.3</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/resources/config/application-local.yml
+++ b/tcs-service/src/main/resources/config/application-local.yml
@@ -49,7 +49,6 @@ app:
       exchange: ${REVAL_RABBIT_EXCHANGE:reval.exchange}
       queue:
         connection:
-          update: ${REVAL_RABBIT_QUEUE:reval.queue.connection.update}
           syncstart: ${REVAL_RABBIT_SYNC_START_QUEUE:reval.queue.connection.syncstart}
           syncdata: ${REVAL_RABBIT_SYNC_DATA_QUEUE:reval.queue.connection.syncdata}
         trainee.update.tcs: ${REVAL_RABBIT_TRAINEE_UPDATE_TCS:reval.queue.trainee.update.tcs}

--- a/tcs-service/src/main/resources/config/application.yml
+++ b/tcs-service/src/main/resources/config/application.yml
@@ -226,7 +226,6 @@ app:
       exchange: ${REVAL_RABBIT_EXCHANGE}
       queue:
         connection:
-          update: ${REVAL_RABBIT_QUEUE}
           syncstart: ${REVAL_RABBIT_SYNC_START_QUEUE}
           syncdata: ${REVAL_RABBIT_SYNC_DATA_QUEUE}
         trainee.update.tcs: ${REVAL_RABBIT_TRAINEE_UPDATE_TCS}

--- a/tcs-service/src/test/resources/config/application.yml
+++ b/tcs-service/src/test/resources/config/application.yml
@@ -121,7 +121,6 @@ app:
       exchange: ${REVAL_RABBIT_EXCHANGE:reval.exchange}
       queue:
         connection:
-          update: ${REVAL_RABBIT_QUEUE:reval.queue.connection.update}
           syncstart: ${REVAL_RABBIT_SYNC_START_QUEUE:reval.queue.connection.syncstart}
           syncdata: ${REVAL_RABBIT_SYNC_DATA_QUEUE:reval.queue.connection.syncdata}
         trainee.update.tcs: ${REVAL_RABBIT_TRAINEE_UPDATE:reval.queue.trainee.update.tcs}


### PR DESCRIPTION
TIS21-8285

Need to remove references to reval.queue.connection.update before removing parameters from TIS-OPS