### PR TITLE
feat: add elastic search service and resource

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.58.2</version>
+  <version>6.59.0</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PostResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PostResource.java
@@ -43,7 +43,6 @@ import javax.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -86,7 +85,7 @@ public class PostResource {
   private final PlacementViewMapper placementViewMapper;
   private final PlacementService placementService;
   private final PlacementSummaryDecorator placementSummaryDecorator;
-  private PostElasticSearchService postElasticSearchService;
+  private final PostElasticSearchService postElasticSearchService;
   @Value("${enable.es.search}")
   private boolean enableEsSearch;
 
@@ -95,7 +94,8 @@ public class PostResource {
       PlacementViewDecorator placementViewDecorator,
       PlacementViewMapper placementViewMapper,
       PlacementService placementService,
-      PlacementSummaryDecorator placementSummaryDecorator) {
+      PlacementSummaryDecorator placementSummaryDecorator,
+      PostElasticSearchService postElasticSearchService) {
     this.postService = postService;
     this.postValidator = postValidator;
     this.placementViewRepository = placementViewRepository;
@@ -103,10 +103,6 @@ public class PostResource {
     this.placementViewMapper = placementViewMapper;
     this.placementService = placementService;
     this.placementSummaryDecorator = placementSummaryDecorator;
-  }
-
-  @Autowired
-  public void setPostElasticSearchService(PostElasticSearchService postElasticSearchService) {
     this.postElasticSearchService = postElasticSearchService;
   }
 
@@ -174,19 +170,21 @@ public class PostResource {
   public ResponseEntity<List<PostViewDTO>> getAllPosts(
       Pageable pageable,
       @RequestParam(value = "searchQuery", required = false) String searchQuery,
-      @RequestParam(value = "columnFilters", required = false) String columnFilterJson,
-      @RequestParam(required = false, defaultValue = "false") boolean enableEs)
+      @RequestParam(value = "columnFilters", required = false) String columnFilterJson)
       throws IOException {
     log.debug("REST request to get a page of Posts");
-    searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
-    String searchQueryEs = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()
+    String originalSearchQuery = searchQuery;
+    searchQuery = getConverter(originalSearchQuery).fromJson().decodeUrl().escapeForSql()
+        .toString();
+    String searchQueryEs = getConverter(originalSearchQuery).fromJson().decodeUrl()
+        .escapeForElasticSearch()
         .toString();
     List<Class> filterEnumList = Lists.newArrayList(Status.class, PostSuffix.class,
         PostGradeType.class, PostSpecialtyType.class);
     List<ColumnFilter> columnFilters = ColumnFilterUtil
         .getColumnFilters(columnFilterJson, filterEnumList);
     Page<PostViewDTO> page;
-    if (enableEsSearch || enableEs) {
+    if (enableEsSearch) {
       page = postElasticSearchService.searchForPage(searchQueryEs, columnFilters, pageable);
     } else if (StringUtils.isEmpty(searchQuery) && StringUtils.isEmpty(columnFilterJson)) {
       page = postService.findAll(pageable);

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PostResource.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PostResource.java
@@ -27,6 +27,7 @@ import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
 import com.transformuk.hee.tis.tcs.service.model.PlacementView;
 import com.transformuk.hee.tis.tcs.service.repository.PlacementViewRepository;
 import com.transformuk.hee.tis.tcs.service.service.PlacementService;
+import com.transformuk.hee.tis.tcs.service.service.PostElasticSearchService;
 import com.transformuk.hee.tis.tcs.service.service.PostService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.PlacementViewMapper;
 import io.github.jhipster.web.util.ResponseUtil;
@@ -42,6 +43,8 @@ import javax.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
@@ -83,6 +86,9 @@ public class PostResource {
   private final PlacementViewMapper placementViewMapper;
   private final PlacementService placementService;
   private final PlacementSummaryDecorator placementSummaryDecorator;
+  private PostElasticSearchService postElasticSearchService;
+  @Value("${enable.es.search}")
+  private boolean enableEsSearch;
 
   public PostResource(PostService postService, PostValidator postValidator,
       PlacementViewRepository placementViewRepository,
@@ -97,6 +103,11 @@ public class PostResource {
     this.placementViewMapper = placementViewMapper;
     this.placementService = placementService;
     this.placementSummaryDecorator = placementSummaryDecorator;
+  }
+
+  @Autowired
+  public void setPostElasticSearchService(PostElasticSearchService postElasticSearchService) {
+    this.postElasticSearchService = postElasticSearchService;
   }
 
   /**
@@ -163,20 +174,27 @@ public class PostResource {
   public ResponseEntity<List<PostViewDTO>> getAllPosts(
       Pageable pageable,
       @RequestParam(value = "searchQuery", required = false) String searchQuery,
-      @RequestParam(value = "columnFilters", required = false) String columnFilterJson)
+      @RequestParam(value = "columnFilters", required = false) String columnFilterJson,
+      @RequestParam(required = false, defaultValue = "false") boolean enableEs)
       throws IOException {
     log.debug("REST request to get a page of Posts");
     searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
+    String searchQueryEs = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()
+        .toString();
     List<Class> filterEnumList = Lists.newArrayList(Status.class, PostSuffix.class,
         PostGradeType.class, PostSpecialtyType.class);
     List<ColumnFilter> columnFilters = ColumnFilterUtil
         .getColumnFilters(columnFilterJson, filterEnumList);
     Page<PostViewDTO> page;
-    if (StringUtils.isEmpty(searchQuery) && StringUtils.isEmpty(columnFilterJson)) {
+    if (enableEsSearch || enableEs) {
+      page = postElasticSearchService.searchForPage(searchQueryEs, columnFilters, pageable);
+    } else if (StringUtils.isEmpty(searchQuery) && StringUtils.isEmpty(columnFilterJson)) {
       page = postService.findAll(pageable);
     } else {
       page = postService.advancedSearch(searchQuery, columnFilters, pageable);
     }
+    log.debug("REST request to get a page of Posts completed successfully");
+
     HttpHeaders headers = PaginationUtil.generateBasicPaginationHttpHeaders(page, "/api/posts");
     return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
   }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -98,7 +98,8 @@ public class PostElasticSearchService {
 
   private static final Map<String, String> FIELD_MAPPINGS = Map.of(
       "currentTraineeSurname", CURRENT_TRAINEE_SURNAMES,
-      "fundingType", FUNDING_TYPES
+      "fundingType", FUNDING_TYPES,
+      "programmeName", PROGRAMME_NAMES
   );
 
   private final ElasticsearchOperations elasticsearchOperations;
@@ -209,13 +210,13 @@ public class PostElasticSearchService {
 
     if (StringUtils.isNotEmpty(searchQuery)) {
       searchQuery = StringUtils.remove(searchQuery, '"');
-
       String wildcard = "*" + searchQuery + "*";
 
       shouldQuery
           .should(new WildcardQueryBuilder(NATIONAL_POST_NUMBER, wildcard))
-          .should(new MatchQueryBuilder(PROGRAMME_NAMES, searchQuery))
+          .should(new WildcardQueryBuilder(PROGRAMME_NAMES, wildcard))
           .should(new MatchQueryBuilder(PRIMARY_SPECIALTY_NAME, searchQuery))
+          .should(new WildcardQueryBuilder(FUNDING_TYPES, wildcard))
           .should(new WildcardQueryBuilder(OWNER, wildcard))
           .should(new WildcardQueryBuilder(CURRENT_TRAINEE_SURNAMES, wildcard))
           .should(new WildcardQueryBuilder(CURRENT_TRAINEE_FORENAMES, wildcard));
@@ -290,15 +291,7 @@ public class PostElasticSearchService {
           continue;
         }
 
-        String filterName = columnFilter.getName();
-        if ("currentTraineeSurname".equals(filterName)) {
-          filterName = CURRENT_TRAINEE_SURNAMES;
-        } else if ("programmeName".equals(filterName)) {
-          filterName = PROGRAMME_NAMES;
-        } else if ("fundingType".equals(filterName)) {
-          filterName = FUNDING_TYPES;
-        }
-
+        String filterName = mapFieldName(columnFilter.getName());
         String filterValue = getFilterValue(value);
 
         shouldBetweenSameColumnFilter.should(

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -79,6 +79,7 @@ public class PostElasticSearchService {
   private static final String APPROVED_GRADE_ID = "approvedGradeId";
   private static final String ID = "id";
   private static final String PROGRAMME_IDS = "programmeIds";
+  private static final Long NO_MATCH_ID = -1L;
   private static final Set<String> MATCH_QUERY_FIELDS = Sets.newHashSet(
       CURRENT_TRAINEE_SURNAMES,
       CURRENT_TRAINEE_FORENAMES,
@@ -98,8 +99,7 @@ public class PostElasticSearchService {
 
   private static final Map<String, String> FIELD_MAPPINGS = Map.of(
       "currentTraineeSurname", CURRENT_TRAINEE_SURNAMES,
-      "fundingType", FUNDING_TYPES,
-      "programmeName", PROGRAMME_NAMES
+      "fundingType", FUNDING_TYPES
   );
 
   private final ElasticsearchOperations elasticsearchOperations;
@@ -259,7 +259,7 @@ public class PostElasticSearchService {
       Collection<Long> usersTrustIds = permissionService.getUsersTrustIds();
 
       if (CollectionUtils.isEmpty(usersTrustIds)) {
-        query.must(QueryBuilders.termQuery("_id", "_NO_MATCH_"));
+        query.must(QueryBuilders.termQuery(TRUST_IDS, Collections.singleton(NO_MATCH_ID)));
       } else {
         query.must(QueryBuilders.termsQuery(TRUST_IDS, usersTrustIds));
       }
@@ -269,7 +269,7 @@ public class PostElasticSearchService {
       Collection<Long> usersProgrammeIds = permissionService.getUsersProgrammeIds();
 
       if (CollectionUtils.isEmpty(usersProgrammeIds)) {
-        query.must(QueryBuilders.termQuery("_id", "_NO_MATCH_"));
+        query.must(QueryBuilders.termQuery(PROGRAMME_IDS, Collections.singleton(NO_MATCH_ID)));
       } else {
         query.must(QueryBuilders.termsQuery(PROGRAMME_IDS, usersProgrammeIds));
       }
@@ -314,14 +314,7 @@ public class PostElasticSearchService {
     }
 
     List<Sort.Order> mappedOrders = pageable.getSort().stream()
-        .map(order -> {
-          String mappedProperty = FIELD_MAPPINGS.getOrDefault(
-              order.getProperty(),
-              order.getProperty()
-          );
-
-          return new Sort.Order(order.getDirection(), mappedProperty);
-        })
+        .map(order -> order.withProperty(mapFieldName(order.getProperty())))
         .collect(Collectors.toList());
 
     return PageRequest.of(

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -1,0 +1,356 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.transformuk.hee.tis.tcs.service.service;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.transformuk.hee.tis.tcs.api.dto.PostViewDTO;
+import com.transformuk.hee.tis.tcs.service.api.decorator.PostViewDecorator;
+import com.transformuk.hee.tis.tcs.service.job.post.PostView;
+import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
+import com.transformuk.hee.tis.tcs.service.service.impl.PermissionService;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Elasticsearch service class for searching, sorting and filtering list of posts.
+ */
+@Service
+public class PostElasticSearchService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PostElasticSearchService.class);
+  private static final String TRUST_IDS = "trustIds";
+  private static final String NATIONAL_POST_NUMBER = "nationalPostNumber";
+  private static final String STATUS = "status";
+  private static final String OWNER = "owner";
+  private static final String CURRENT_TRAINEE_SURNAME = "currentTraineeSurnames";
+  private static final String CURRENT_TRAINEE_FORENAMES = "currentTraineeForenames";
+  private static final String PRIMARY_SPECIALTY_CODE = "primarySpecialtyCode";
+  private static final String PRIMARY_SPECIALTY_NAME = "primarySpecialtyName";
+  private static final String PROGRAMME_NAMES = "programmeNames";
+  private static final String FUNDING_TYPE = "fundingType";
+  private static final String PRIMARY_SPECIALTY_ID = "primarySpecialtyId";
+  private static final String PRIMARY_SITE_ID = "primarySiteId";
+  private static final String APPROVED_GRADE_ID = "approvedGradeId";
+  private static final String ID = "id";
+  private static final String PROGRAMME_IDS = "programmeIds";
+  private static final Set<String> MATCH_QUERY_FIELDS = Sets.newHashSet(
+      CURRENT_TRAINEE_SURNAME,
+      CURRENT_TRAINEE_FORENAMES,
+      PRIMARY_SPECIALTY_NAME,
+      PROGRAMME_NAMES
+  );
+  private static final Set<String> TERM_QUERY_FIELDS = Sets.newHashSet(
+      STATUS,
+      OWNER,
+      NATIONAL_POST_NUMBER,
+      PRIMARY_SPECIALTY_CODE,
+      FUNDING_TYPE,
+      PRIMARY_SPECIALTY_ID,
+      PRIMARY_SITE_ID,
+      APPROVED_GRADE_ID
+  );
+
+  private static final Map<String, String> SORT_FIELD_MAPPINGS = Map.of(
+      "currentTraineeSurname", CURRENT_TRAINEE_SURNAME
+  );
+
+  private final ElasticsearchOperations elasticsearchOperations;
+  private final PermissionService permissionService;
+  private final PostViewDecorator postViewDecorator;
+
+  /**
+   * Constructor for Elasticsearch service class.
+   */
+  public PostElasticSearchService(PostViewDecorator postViewDecorator,
+      ElasticsearchOperations elasticsearchOperations,
+      PermissionService permissionService) {
+    this.postViewDecorator = postViewDecorator;
+    this.elasticsearchOperations = elasticsearchOperations;
+    this.permissionService = permissionService;
+  }
+
+  /**
+   * Searches the posts Elasticsearch index using optional free-text search, column filters,
+   * pagination and sorting.
+   *
+   * @param searchQuery   the optional free-text search value entered by the user
+   * @param columnFilters the optional list of column filters selected in the UI
+   * @param pageable      pagination and sorting information from the request
+   * @return a page of PostViewDTO results matching the supplied search criteria
+   */
+  public Page<PostViewDTO> searchForPage(String searchQuery,
+      List<ColumnFilter> columnFilters, Pageable pageable) {
+
+    try {
+      BoolQueryBuilder fullQuery = buildColumnFilterQuery(columnFilters);
+
+      BoolQueryBuilder textSearchQuery = applyTextBasedSearchQuery(searchQuery);
+
+      if (textSearchQuery.hasClauses()) {
+        textSearchQuery.minimumShouldMatch(1);
+        fullQuery.must(textSearchQuery);
+      }
+
+      applyPermissionFilters(fullQuery);
+
+      LOG.debug("Post ES query is: {}", fullQuery);
+
+      pageable = replaceSortById(pageable);
+      pageable = mapSortFields(pageable);
+
+      NativeSearchQuery nativeSearchQuery = new NativeSearchQueryBuilder()
+          .withQuery(fullQuery)
+          .withPageable(pageable)
+          .build();
+
+      SearchHits<PostView> searchHits =
+          elasticsearchOperations.search(nativeSearchQuery, PostView.class);
+
+      List<PostView> postViews = searchHits.getSearchHits().stream()
+          .map(SearchHit::getContent)
+          .collect(Collectors.toList());
+
+      List<PostViewDTO> postViewDtos = convertPostViewToDto(postViews);
+
+      postViewDecorator.decorate(postViewDtos);
+
+      return new PageImpl<>(postViewDtos, pageable, searchHits.getTotalHits());
+
+    } catch (RuntimeException re) {
+      LOG.error("An exception occurred while attempting to do a Post ElasticSearch", re);
+      throw new IllegalStateException(
+          String.format(
+              "Failed to search posts in Elasticsearch. searchQuery=[%s], filters=[%s], page=[%s]",
+              searchQuery, columnFilters, pageable),
+          re
+      );
+    }
+  }
+
+  private String getFilterValue(Object value) {
+    if (value instanceof Enum) {
+      return ((Enum<?>) value).name();
+    }
+
+    return value.toString().trim();
+  }
+
+  private QueryBuilder createColumnFilterQuery(String fieldName, String filterValue) {
+    if (MATCH_QUERY_FIELDS.contains(fieldName)) {
+      return new MatchQueryBuilder(fieldName, filterValue);
+    }
+
+    if (TERM_QUERY_FIELDS.contains(fieldName)) {
+      return new TermQueryBuilder(fieldName, filterValue);
+    }
+
+    throw new IllegalArgumentException(
+        "Filter: [" + fieldName + "] is not a valid field name."
+    );
+  }
+
+  private BoolQueryBuilder applyTextBasedSearchQuery(String searchQuery) {
+    BoolQueryBuilder shouldQuery = new BoolQueryBuilder();
+
+    if (StringUtils.isNotEmpty(searchQuery)) {
+      searchQuery = StringUtils.remove(searchQuery, '"');
+
+      shouldQuery
+          .should(new WildcardQueryBuilder(NATIONAL_POST_NUMBER, "*" + searchQuery + "*"))
+          .should(new MatchQueryBuilder(PROGRAMME_NAMES, searchQuery))
+          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_SURNAME, "*" + searchQuery + "*"))
+          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_FORENAMES, "*" + searchQuery + "*"));
+
+      if (StringUtils.isNumeric(searchQuery)) {
+        shouldQuery
+            .should(new TermQueryBuilder(ID, searchQuery))
+            .should(new TermQueryBuilder(PRIMARY_SITE_ID, searchQuery))
+            .should(new TermQueryBuilder(APPROVED_GRADE_ID, searchQuery))
+            .should(new TermQueryBuilder(PRIMARY_SPECIALTY_ID, searchQuery));
+      }
+    }
+    return shouldQuery;
+  }
+
+  private Pageable replaceSortById(Pageable pageable) {
+    Sort sort = pageable.getSort();
+
+    Iterator<Sort.Order> sortIterator = sort.iterator();
+    List<Sort.Order> sortOrders = Lists.newArrayList();
+
+    while (sortIterator.hasNext()) {
+      Sort.Order order = sortIterator.next();
+
+      if (ID.equals(order.getProperty())) {
+        if (order.isAscending()) {
+          sortOrders.add(Sort.Order.asc(ID));
+        } else if (order.isDescending()) {
+          sortOrders.add(Sort.Order.desc(ID));
+        } else {
+          sortOrders.add(Sort.Order.asc(ID));
+        }
+      } else if (NATIONAL_POST_NUMBER.equals(order.getProperty())) {
+        if (order.isAscending()) {
+          sortOrders.add(Sort.Order.asc(NATIONAL_POST_NUMBER));
+        } else if (order.isDescending()) {
+          sortOrders.add(Sort.Order.desc(NATIONAL_POST_NUMBER));
+        } else {
+          sortOrders.add(Sort.Order.asc(NATIONAL_POST_NUMBER));
+        }
+      } else {
+        sortOrders.add(order);
+      }
+    }
+    return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(sortOrders));
+  }
+
+  private List<PostViewDTO> convertPostViewToDto(List<PostView> content) {
+    return content.stream().map(pv -> {
+      PostViewDTO dto = new PostViewDTO();
+
+      dto.setId(pv.getId());
+
+      dto.setCurrentTraineeSurname(pv.getCurrentTraineeSurnames());
+      dto.setCurrentTraineeForenames(pv.getCurrentTraineeForenames());
+
+      dto.setNationalPostNumber(pv.getNationalPostNumber());
+
+      dto.setPrimarySiteId(pv.getPrimarySiteId());
+
+      dto.setApprovedGradeId(pv.getApprovedGradeId());
+
+      dto.setPrimarySpecialtyId(pv.getPrimarySpecialtyId());
+      dto.setPrimarySpecialtyCode(pv.getPrimarySpecialtyCode());
+      dto.setPrimarySpecialtyName(pv.getPrimarySpecialtyName());
+
+      dto.setProgrammeNames(String.join("; ", pv.getProgrammeNames()));
+      dto.setStatus(pv.getStatus());
+      dto.setFundingType(String.join("; ", pv.getFundingTypes()));
+      dto.setOwner(pv.getOwner());
+
+      return dto;
+    }).collect(Collectors.toList());
+  }
+
+  private void applyPermissionFilters(BoolQueryBuilder query) {
+    if (permissionService.isUserTrustAdmin()) {
+      Collection<Long> usersTrustIds = permissionService.getUsersTrustIds();
+
+      if (CollectionUtils.isEmpty(usersTrustIds)) {
+        query.must(QueryBuilders.termQuery("_id", "_NO_MATCH_"));
+      } else {
+        query.must(QueryBuilders.termsQuery(TRUST_IDS, usersTrustIds));
+      }
+    }
+
+    if (permissionService.isProgrammeObserver()) {
+      Collection<Long> usersProgrammeIds = permissionService.getUsersProgrammeIds();
+
+      if (CollectionUtils.isEmpty(usersProgrammeIds)) {
+        query.must(QueryBuilders.termQuery("_id", "_NO_MATCH_"));
+      } else {
+        query.must(QueryBuilders.termsQuery(PROGRAMME_IDS, usersProgrammeIds));
+      }
+    }
+  }
+
+  private BoolQueryBuilder buildColumnFilterQuery(List<ColumnFilter> columnFilters) {
+    BoolQueryBuilder mustBetweenDifferentColumnFilters = new BoolQueryBuilder();
+
+    if (CollectionUtils.isEmpty(columnFilters)) {
+      return mustBetweenDifferentColumnFilters;
+    }
+
+    for (ColumnFilter columnFilter : columnFilters) {
+      BoolQueryBuilder shouldBetweenSameColumnFilter = new BoolQueryBuilder();
+
+      for (Object value : columnFilter.getValues()) {
+        if (value == null) {
+          continue;
+        }
+
+        String filterName = columnFilter.getName();
+        String filterValue = getFilterValue(value);
+
+        shouldBetweenSameColumnFilter.should(
+            createColumnFilterQuery(filterName, filterValue)
+        );
+      }
+
+      if (shouldBetweenSameColumnFilter.hasClauses()) {
+        shouldBetweenSameColumnFilter.minimumShouldMatch(1);
+        mustBetweenDifferentColumnFilters.must(shouldBetweenSameColumnFilter);
+      }
+    }
+
+    return mustBetweenDifferentColumnFilters;
+  }
+
+  private Pageable mapSortFields(Pageable pageable) {
+    if (pageable == null || pageable.getSort().isUnsorted()) {
+      return pageable;
+    }
+
+    List<Sort.Order> mappedOrders = pageable.getSort().stream()
+        .map(order -> {
+          String mappedProperty = SORT_FIELD_MAPPINGS.getOrDefault(
+              order.getProperty(),
+              order.getProperty()
+          );
+
+          return new Sort.Order(order.getDirection(), mappedProperty);
+        })
+        .collect(Collectors.toList());
+
+    return PageRequest.of(
+        pageable.getPageNumber(),
+        pageable.getPageSize(),
+        Sort.by(mappedOrders)
+    );
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -79,7 +79,6 @@ public class PostElasticSearchService {
   private static final String APPROVED_GRADE_ID = "approvedGradeId";
   private static final String ID = "id";
   private static final String PROGRAMME_IDS = "programmeIds";
-  private static final Long NO_MATCH_ID = -1L;
   private static final Set<String> MATCH_QUERY_FIELDS = Sets.newHashSet(
       CURRENT_TRAINEE_SURNAMES,
       CURRENT_TRAINEE_FORENAMES,
@@ -257,22 +256,12 @@ public class PostElasticSearchService {
   private void applyPermissionFilters(BoolQueryBuilder query) {
     if (permissionService.isUserTrustAdmin()) {
       Collection<Long> usersTrustIds = permissionService.getUsersTrustIds();
-
-      if (CollectionUtils.isEmpty(usersTrustIds)) {
-        query.must(QueryBuilders.termQuery(TRUST_IDS, Collections.singleton(NO_MATCH_ID)));
-      } else {
-        query.must(QueryBuilders.termsQuery(TRUST_IDS, usersTrustIds));
-      }
+      query.must(QueryBuilders.termsQuery(TRUST_IDS, usersTrustIds));
     }
 
     if (permissionService.isProgrammeObserver()) {
       Collection<Long> usersProgrammeIds = permissionService.getUsersProgrammeIds();
-
-      if (CollectionUtils.isEmpty(usersProgrammeIds)) {
-        query.must(QueryBuilders.termQuery(PROGRAMME_IDS, Collections.singleton(NO_MATCH_ID)));
-      } else {
-        query.must(QueryBuilders.termsQuery(PROGRAMME_IDS, usersProgrammeIds));
-      }
+      query.must(QueryBuilders.termsQuery(PROGRAMME_IDS, usersProgrammeIds));
     }
   }
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -30,6 +30,7 @@ import com.transformuk.hee.tis.tcs.service.service.impl.PermissionService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.PostViewMapper;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -144,6 +145,8 @@ public class PostElasticSearchService {
 
       LOG.debug("Post ES query is: {}", fullQuery);
 
+      pageable = pageable == null ? PageRequest.of(0, 20) : pageable;
+
       pageable = replaceSortById(pageable);
       pageable = mapSortFields(pageable);
 
@@ -160,6 +163,7 @@ public class PostElasticSearchService {
           .collect(Collectors.toList());
 
       List<PostViewDTO> postViewDtos = postViewMapper.toDtos(postViews);
+      postViewDtos = postViewDtos == null ? Collections.emptyList() : postViewDtos;
 
       postViewDecorator.decorate(postViewDtos);
 
@@ -228,7 +232,7 @@ public class PostElasticSearchService {
   }
 
   private Pageable replaceSortById(Pageable pageable) {
-    if (pageable == null || pageable.getSort().isUnsorted()) {
+    if (pageable.getSort().isUnsorted()) {
       return pageable;
     }
 
@@ -312,7 +316,7 @@ public class PostElasticSearchService {
   }
 
   private Pageable mapSortFields(Pageable pageable) {
-    if (pageable == null || pageable.getSort().isUnsorted()) {
+    if (pageable.getSort().isUnsorted()) {
       return pageable;
     }
 

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -21,15 +21,15 @@
 
 package com.transformuk.hee.tis.tcs.service.service;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.tcs.api.dto.PostViewDTO;
 import com.transformuk.hee.tis.tcs.service.api.decorator.PostViewDecorator;
 import com.transformuk.hee.tis.tcs.service.job.post.PostView;
 import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
 import com.transformuk.hee.tis.tcs.service.service.impl.PermissionService;
+import com.transformuk.hee.tis.tcs.service.service.mapper.PostViewMapper;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,7 +67,7 @@ public class PostElasticSearchService {
   private static final String NATIONAL_POST_NUMBER = "nationalPostNumber";
   private static final String STATUS = "status";
   private static final String OWNER = "owner";
-  private static final String CURRENT_TRAINEE_SURNAME = "currentTraineeSurnames";
+  private static final String CURRENT_TRAINEE_SURNAMES = "currentTraineeSurnames";
   private static final String CURRENT_TRAINEE_FORENAMES = "currentTraineeForenames";
   private static final String PRIMARY_SPECIALTY_CODE = "primarySpecialtyCode";
   private static final String PRIMARY_SPECIALTY_NAME = "primarySpecialtyName";
@@ -79,7 +79,7 @@ public class PostElasticSearchService {
   private static final String ID = "id";
   private static final String PROGRAMME_IDS = "programmeIds";
   private static final Set<String> MATCH_QUERY_FIELDS = Sets.newHashSet(
-      CURRENT_TRAINEE_SURNAME,
+      CURRENT_TRAINEE_SURNAMES,
       CURRENT_TRAINEE_FORENAMES,
       PRIMARY_SPECIALTY_NAME,
       PROGRAMME_NAMES
@@ -96,22 +96,25 @@ public class PostElasticSearchService {
   );
 
   private static final Map<String, String> FIELD_MAPPINGS = Map.of(
-      "currentTraineeSurname", CURRENT_TRAINEE_SURNAME
+      "currentTraineeSurname", CURRENT_TRAINEE_SURNAMES
   );
 
   private final ElasticsearchOperations elasticsearchOperations;
   private final PermissionService permissionService;
   private final PostViewDecorator postViewDecorator;
+  private final PostViewMapper postViewMapper;
 
   /**
    * Constructor for Elasticsearch service class.
    */
   public PostElasticSearchService(PostViewDecorator postViewDecorator,
       ElasticsearchOperations elasticsearchOperations,
-      PermissionService permissionService) {
+      PermissionService permissionService,
+      PostViewMapper postViewMapper) {
     this.postViewDecorator = postViewDecorator;
     this.elasticsearchOperations = elasticsearchOperations;
     this.permissionService = permissionService;
+    this.postViewMapper = postViewMapper;
   }
 
   /**
@@ -127,7 +130,7 @@ public class PostElasticSearchService {
       List<ColumnFilter> columnFilters, Pageable pageable) {
 
     try {
-      BoolQueryBuilder fullQuery = buildColumnFilterQuery(columnFilters);
+      BoolQueryBuilder fullQuery = buildColumnFiltersQuery(columnFilters);
 
       BoolQueryBuilder textSearchQuery = applyTextBasedSearchQuery(searchQuery);
 
@@ -155,7 +158,7 @@ public class PostElasticSearchService {
           .map(SearchHit::getContent)
           .collect(Collectors.toList());
 
-      List<PostViewDTO> postViewDtos = convertPostViewToDto(postViews);
+      List<PostViewDTO> postViewDtos = postViewMapper.toDtos(postViews);
 
       postViewDecorator.decorate(postViewDtos);
 
@@ -209,7 +212,7 @@ public class PostElasticSearchService {
           .should(new MatchQueryBuilder(PROGRAMME_NAMES, searchQuery))
           .should(new MatchQueryBuilder(PRIMARY_SPECIALTY_NAME, searchQuery))
           .should(new WildcardQueryBuilder(OWNER, wildcard))
-          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_SURNAME, wildcard))
+          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_SURNAMES, wildcard))
           .should(new WildcardQueryBuilder(CURRENT_TRAINEE_FORENAMES, wildcard));
 
       if (StringUtils.isNumeric(searchQuery)) {
@@ -224,63 +227,21 @@ public class PostElasticSearchService {
   }
 
   private Pageable replaceSortById(Pageable pageable) {
-    Sort sort = pageable.getSort();
+    List<Sort.Order> sortOrders = new ArrayList<>();
 
-    Iterator<Sort.Order> sortIterator = sort.iterator();
-    List<Sort.Order> sortOrders = Lists.newArrayList();
+    pageable.getSort().forEach(order -> {
+      String property = order.getProperty();
 
-    while (sortIterator.hasNext()) {
-      Sort.Order order = sortIterator.next();
-
-      if (ID.equals(order.getProperty())) {
-        if (order.isAscending()) {
-          sortOrders.add(Sort.Order.asc(ID));
-        } else if (order.isDescending()) {
-          sortOrders.add(Sort.Order.desc(ID));
-        } else {
-          sortOrders.add(Sort.Order.asc(ID));
-        }
-      } else if (NATIONAL_POST_NUMBER.equals(order.getProperty())) {
-        if (order.isAscending()) {
-          sortOrders.add(Sort.Order.asc(NATIONAL_POST_NUMBER));
-        } else if (order.isDescending()) {
-          sortOrders.add(Sort.Order.desc(NATIONAL_POST_NUMBER));
-        } else {
-          sortOrders.add(Sort.Order.asc(NATIONAL_POST_NUMBER));
-        }
+      if (ID.equals(property) || NATIONAL_POST_NUMBER.equals(property)) {
+        sortOrders.add(
+            order.isDescending()
+                ? Sort.Order.desc(property)
+                : Sort.Order.asc(property));
       } else {
         sortOrders.add(order);
       }
-    }
+    });
     return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(sortOrders));
-  }
-
-  private List<PostViewDTO> convertPostViewToDto(List<PostView> content) {
-    return content.stream().map(pv -> {
-      PostViewDTO dto = new PostViewDTO();
-
-      dto.setId(pv.getId());
-
-      dto.setCurrentTraineeSurname(pv.getCurrentTraineeSurnames());
-      dto.setCurrentTraineeForenames(pv.getCurrentTraineeForenames());
-
-      dto.setNationalPostNumber(pv.getNationalPostNumber());
-
-      dto.setPrimarySiteId(pv.getPrimarySiteId());
-
-      dto.setApprovedGradeId(pv.getApprovedGradeId());
-
-      dto.setPrimarySpecialtyId(pv.getPrimarySpecialtyId());
-      dto.setPrimarySpecialtyCode(pv.getPrimarySpecialtyCode());
-      dto.setPrimarySpecialtyName(pv.getPrimarySpecialtyName());
-
-      dto.setProgrammeNames(String.join("; ", pv.getProgrammeNames()));
-      dto.setStatus(pv.getStatus());
-      dto.setFundingType(String.join("; ", pv.getFundingTypes()));
-      dto.setOwner(pv.getOwner());
-
-      return dto;
-    }).collect(Collectors.toList());
   }
 
   private void applyPermissionFilters(BoolQueryBuilder query) {
@@ -305,7 +266,7 @@ public class PostElasticSearchService {
     }
   }
 
-  private BoolQueryBuilder buildColumnFilterQuery(List<ColumnFilter> columnFilters) {
+  private BoolQueryBuilder buildColumnFiltersQuery(List<ColumnFilter> columnFilters) {
     BoolQueryBuilder mustBetweenDifferentColumnFilters = new BoolQueryBuilder();
 
     if (CollectionUtils.isEmpty(columnFilters)) {

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -95,7 +95,7 @@ public class PostElasticSearchService {
       APPROVED_GRADE_ID
   );
 
-  private static final Map<String, String> SORT_FIELD_MAPPINGS = Map.of(
+  private static final Map<String, String> FIELD_MAPPINGS = Map.of(
       "currentTraineeSurname", CURRENT_TRAINEE_SURNAME
   );
 
@@ -181,12 +181,14 @@ public class PostElasticSearchService {
   }
 
   private QueryBuilder createColumnFilterQuery(String fieldName, String filterValue) {
-    if (MATCH_QUERY_FIELDS.contains(fieldName)) {
-      return new MatchQueryBuilder(fieldName, filterValue);
+    String mappedFieldName = mapFieldName(fieldName);
+
+    if (MATCH_QUERY_FIELDS.contains(mappedFieldName)) {
+      return new MatchQueryBuilder(mappedFieldName, filterValue);
     }
 
-    if (TERM_QUERY_FIELDS.contains(fieldName)) {
-      return new TermQueryBuilder(fieldName, filterValue);
+    if (TERM_QUERY_FIELDS.contains(mappedFieldName)) {
+      return new TermQueryBuilder(mappedFieldName, filterValue);
     }
 
     throw new IllegalArgumentException(
@@ -200,11 +202,15 @@ public class PostElasticSearchService {
     if (StringUtils.isNotEmpty(searchQuery)) {
       searchQuery = StringUtils.remove(searchQuery, '"');
 
+      String wildcard = "*" + searchQuery + "*";
+
       shouldQuery
-          .should(new WildcardQueryBuilder(NATIONAL_POST_NUMBER, "*" + searchQuery + "*"))
+          .should(new WildcardQueryBuilder(NATIONAL_POST_NUMBER, wildcard))
           .should(new MatchQueryBuilder(PROGRAMME_NAMES, searchQuery))
-          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_SURNAME, "*" + searchQuery + "*"))
-          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_FORENAMES, "*" + searchQuery + "*"));
+          .should(new MatchQueryBuilder(PRIMARY_SPECIALTY_NAME, searchQuery))
+          .should(new WildcardQueryBuilder(OWNER, wildcard))
+          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_SURNAME, wildcard))
+          .should(new WildcardQueryBuilder(CURRENT_TRAINEE_FORENAMES, wildcard));
 
       if (StringUtils.isNumeric(searchQuery)) {
         shouldQuery
@@ -338,7 +344,7 @@ public class PostElasticSearchService {
 
     List<Sort.Order> mappedOrders = pageable.getSort().stream()
         .map(order -> {
-          String mappedProperty = SORT_FIELD_MAPPINGS.getOrDefault(
+          String mappedProperty = FIELD_MAPPINGS.getOrDefault(
               order.getProperty(),
               order.getProperty()
           );
@@ -352,5 +358,9 @@ public class PostElasticSearchService {
         pageable.getPageSize(),
         Sort.by(mappedOrders)
     );
+  }
+
+  private String mapFieldName(String fieldName) {
+    return FIELD_MAPPINGS.getOrDefault(fieldName, fieldName);
   }
 }

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -72,7 +72,7 @@ public class PostElasticSearchService {
   private static final String PRIMARY_SPECIALTY_CODE = "primarySpecialtyCode";
   private static final String PRIMARY_SPECIALTY_NAME = "primarySpecialtyName";
   private static final String PROGRAMME_NAMES = "programmeNames";
-  private static final String FUNDING_TYPE = "fundingType";
+  private static final String FUNDING_TYPES = "fundingTypes";
   private static final String PRIMARY_SPECIALTY_ID = "primarySpecialtyId";
   private static final String PRIMARY_SITE_ID = "primarySiteId";
   private static final String APPROVED_GRADE_ID = "approvedGradeId";
@@ -89,14 +89,15 @@ public class PostElasticSearchService {
       OWNER,
       NATIONAL_POST_NUMBER,
       PRIMARY_SPECIALTY_CODE,
-      FUNDING_TYPE,
+      FUNDING_TYPES,
       PRIMARY_SPECIALTY_ID,
       PRIMARY_SITE_ID,
       APPROVED_GRADE_ID
   );
 
   private static final Map<String, String> FIELD_MAPPINGS = Map.of(
-      "currentTraineeSurname", CURRENT_TRAINEE_SURNAMES
+      "currentTraineeSurname", CURRENT_TRAINEE_SURNAMES,
+      "fundingType", FUNDING_TYPES
   );
 
   private final ElasticsearchOperations elasticsearchOperations;
@@ -227,6 +228,10 @@ public class PostElasticSearchService {
   }
 
   private Pageable replaceSortById(Pageable pageable) {
+    if (pageable == null || pageable.getSort().isUnsorted()) {
+      return pageable;
+    }
+
     List<Sort.Order> sortOrders = new ArrayList<>();
 
     pageable.getSort().forEach(order -> {
@@ -282,6 +287,14 @@ public class PostElasticSearchService {
         }
 
         String filterName = columnFilter.getName();
+        if ("currentTraineeSurname".equals(filterName)) {
+          filterName = CURRENT_TRAINEE_SURNAMES;
+        } else if ("programmeName".equals(filterName)) {
+          filterName = PROGRAMME_NAMES;
+        } else if ("fundingType".equals(filterName)) {
+          filterName = FUNDING_TYPES;
+        }
+
         String filterValue = getFilterValue(value);
 
         shouldBetweenSameColumnFilter.should(

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PostViewMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PostViewMapper.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.transformuk.hee.tis.tcs.service.service.mapper;
+
+import com.transformuk.hee.tis.tcs.api.dto.PostViewDTO;
+import com.transformuk.hee.tis.tcs.service.job.post.PostView;
+import java.util.List;
+import org.apache.commons.collections4.CollectionUtils;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+/**
+ * Mapper for post elastic search index.
+ */
+@Mapper(componentModel = "spring")
+public interface PostViewMapper {
+
+  @Mapping(source = "currentTraineeSurnames", target = "currentTraineeSurname")
+  @Mapping(source = "programmeNames", target = "programmeNames", qualifiedByName = "joinWithSemicolon")
+  @Mapping(source = "fundingTypes", target = "fundingType", qualifiedByName = "joinWithSemicolon")
+  PostViewDTO toDto(PostView postView);
+
+  List<PostViewDTO> toDtos(List<PostView> postViews);
+
+  @Named("joinWithSemicolon")
+  default String joinWithSemicolon(List<String> values) {
+    if (CollectionUtils.isEmpty(values)) {
+      return "";
+    }
+
+    return String.join("; ", values);
+  }
+}

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PostViewMapper.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/mapper/PostViewMapper.java
@@ -36,12 +36,16 @@ import org.mapstruct.Named;
 public interface PostViewMapper {
 
   @Mapping(source = "currentTraineeSurnames", target = "currentTraineeSurname")
-  @Mapping(source = "programmeNames", target = "programmeNames", qualifiedByName = "joinWithSemicolon")
+  @Mapping(source = "programmeNames", target = "programmeNames",
+      qualifiedByName = "joinWithSemicolon")
   @Mapping(source = "fundingTypes", target = "fundingType", qualifiedByName = "joinWithSemicolon")
   PostViewDTO toDto(PostView postView);
 
   List<PostViewDTO> toDtos(List<PostView> postViews);
 
+  /**
+   * Customised method for semicolon delimiter.
+   */
   @Named("joinWithSemicolon")
   default String joinWithSemicolon(List<String> values) {
     if (CollectionUtils.isEmpty(values)) {

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
@@ -132,12 +132,12 @@ public class PostResource2Test {
   public void setup() {
     PostResource postResource = new PostResource(postService, postValidator,
         placementViewRepository, placementViewDecorator,
-        placementViewMapper, placementService, placementSummaryDecorator);
+        placementViewMapper, placementService, placementSummaryDecorator,
+        postElasticSearchService);
     this.restPostMockMvc = MockMvcBuilders.standaloneSetup(postResource)
         .setCustomArgumentResolvers(pageableArgumentResolver)
         .setControllerAdvice(exceptionTranslator)
         .setMessageConverters(jacksonMessageConverter).build();
-    postResource.setPostElasticSearchService(postElasticSearchService);
     ReflectionTestUtils.setField(postResource, "enableEsSearch", true);
     TestUtils.mockUserprofile("jamesh", "1-1RUZV6H", "1-1RSSQ05", "1-1RSSPZ7");
 

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.tcs.service.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -127,10 +128,10 @@ public class PostResource2Test {
   @Captor
   private ArgumentCaptor<PostSavedEvent> postSavedEventArgumentCaptor;
   private PostEsrEventDto postEsrReconciledDto;
-
+  private PostResource postResource;
   @Before
   public void setup() {
-    PostResource postResource = new PostResource(postService, postValidator,
+    postResource = new PostResource(postService, postValidator,
         placementViewRepository, placementViewDecorator,
         placementViewMapper, placementService, placementSummaryDecorator,
         postElasticSearchService);
@@ -367,7 +368,8 @@ public class PostResource2Test {
   }
 
   @Test
-  public void shouldCallElasticSearchServiceWhenEnableEsSearchIsTrue() throws Exception {
+  public void shouldUseElasticSearchServiceWhenEnableEsSearchIsEnabled() throws Exception {
+    ReflectionTestUtils.setField(postResource, "enableEsSearch", true);
     PostViewDTO postViewDTO = new PostViewDTO();
     postViewDTO.setId(243906L);
     postViewDTO.setNationalPostNumber("NWN/RM317/018/HT/002");
@@ -400,6 +402,8 @@ public class PostResource2Test {
         .andExpect(jsonPath("$[0].status").value("CURRENT"))
         .andExpect(jsonPath("$[0].owner").value("North West"));
 
+    Boolean enableEsSearch = (Boolean) ReflectionTestUtils.getField(postResource, "enableEsSearch");
+    assertThat(enableEsSearch).isTrue();
     verify(postElasticSearchService).searchForPage(
         any(),
         anyList(),

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
@@ -1,6 +1,8 @@
 package com.transformuk.hee.tis.tcs.service.api;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -8,6 +10,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -25,6 +28,7 @@ import com.transformuk.hee.tis.tcs.TestUtils;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostEsrEventDto;
 import com.transformuk.hee.tis.tcs.api.dto.PostFundingDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PostViewDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.PostSpecialtyType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
@@ -38,6 +42,7 @@ import com.transformuk.hee.tis.tcs.service.exception.ExceptionTranslator;
 import com.transformuk.hee.tis.tcs.service.model.PostEsrEvent;
 import com.transformuk.hee.tis.tcs.service.repository.PlacementViewRepository;
 import com.transformuk.hee.tis.tcs.service.service.PlacementService;
+import com.transformuk.hee.tis.tcs.service.service.PostElasticSearchService;
 import com.transformuk.hee.tis.tcs.service.service.PostService;
 import com.transformuk.hee.tis.tcs.service.service.mapper.PlacementViewMapper;
 import java.lang.reflect.Method;
@@ -59,10 +64,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -98,6 +107,8 @@ public class PostResource2Test {
   @MockBean
   private PlacementService placementService;
   @MockBean
+  private PostElasticSearchService postElasticSearchService;
+  @MockBean
   private PlacementSummaryDecorator placementSummaryDecorator;
   private MockMvc restPostMockMvc;
   @Autowired
@@ -126,6 +137,8 @@ public class PostResource2Test {
         .setCustomArgumentResolvers(pageableArgumentResolver)
         .setControllerAdvice(exceptionTranslator)
         .setMessageConverters(jacksonMessageConverter).build();
+    postResource.setPostElasticSearchService(postElasticSearchService);
+    ReflectionTestUtils.setField(postResource, "enableEsSearch", true);
     TestUtils.mockUserprofile("jamesh", "1-1RUZV6H", "1-1RSSQ05", "1-1RSSPZ7");
 
     PostFundingDTO postFundingDTO = new PostFundingDTO();
@@ -351,6 +364,50 @@ public class PostResource2Test {
         .andExpect(jsonPath("$.fieldErrors[0].field").value("specialties"))
         .andExpect(jsonPath("$.fieldErrors[0].message").value(StringContains.
             containsString("Only one Specialty of type PRIMARY allowed")));
+  }
+
+  @Test
+  public void shouldCallElasticSearchServiceWhenEnableEsIsTrue() throws Exception {
+    PostViewDTO postViewDTO = new PostViewDTO();
+    postViewDTO.setId(243906L);
+    postViewDTO.setNationalPostNumber("NWN/RM317/018/HT/002");
+    postViewDTO.setStatus(Status.CURRENT);
+    postViewDTO.setOwner("North West");
+    postViewDTO.setPrimarySpecialtyName("Gastroenterology");
+    postViewDTO.setProgrammeNames("Gastroenterology");
+    postViewDTO.setFundingType("Funded - Tariff");
+
+    Page<PostViewDTO> page = new PageImpl<>(
+        Collections.singletonList(postViewDTO)
+    );
+
+    when(postElasticSearchService.searchForPage(any(), anyList(), any(Pageable.class)))
+        .thenReturn(page);
+
+    String columnFilters = "{\"status\":[\"CURRENT\"],\"owner\":[\"North West\"]}";
+
+    restPostMockMvc.perform(get("/api/posts")
+            .param("page", "0")
+            .param("size", "100")
+            .param("sort", "nationalPostNumber,asc")
+            .param("sort", "id")
+            .param("enableEs", "true")
+            .param("columnFilters", columnFilters)
+            .with(user("test-user").authorities(() -> "post:view")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].id").value(243906))
+        .andExpect(jsonPath("$[0].nationalPostNumber").value("NWN/RM317/018/HT/002"))
+        .andExpect(jsonPath("$[0].status").value("CURRENT"))
+        .andExpect(jsonPath("$[0].owner").value("North West"));
+
+    verify(postElasticSearchService).searchForPage(
+        any(),
+        anyList(),
+        any(Pageable.class)
+    );
+    verify(postService, never()).findAll(any(Pageable.class));
+    verify(postService, never()).advancedSearch(any(), anyList(), any(Pageable.class));
   }
 
   @Test

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResource2Test.java
@@ -367,7 +367,7 @@ public class PostResource2Test {
   }
 
   @Test
-  public void shouldCallElasticSearchServiceWhenEnableEsIsTrue() throws Exception {
+  public void shouldCallElasticSearchServiceWhenEnableEsSearchIsTrue() throws Exception {
     PostViewDTO postViewDTO = new PostViewDTO();
     postViewDTO.setId(243906L);
     postViewDTO.setNationalPostNumber("NWN/RM317/018/HT/002");
@@ -391,7 +391,6 @@ public class PostResource2Test {
             .param("size", "100")
             .param("sort", "nationalPostNumber,asc")
             .param("sort", "id")
-            .param("enableEs", "true")
             .param("columnFilters", columnFilters)
             .with(user("test-user").authorities(() -> "post:view")))
         .andExpect(status().isOk())

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
@@ -150,6 +150,8 @@ public class PostResourceIntTest {
   private PostMapper postMapper;
   @Mock
   private ReferenceServiceImpl referenceService;
+  @Mock
+  private PostElasticSearchService postElasticSearchService;
   @Autowired
   @InjectMocks
   private PostFundingValidator postFundingValidator;
@@ -166,8 +168,6 @@ public class PostResourceIntTest {
   private PlacementViewMapper placementViewMapper;
   @Autowired
   private PlacementService placementService;
-  @Autowired
-  private PostElasticSearchService postElasticSearchService;
   @Autowired
   private PlacementSummaryDecorator placementSummaryDecorator;
   @Autowired
@@ -292,7 +292,7 @@ public class PostResourceIntTest {
     MockitoAnnotations.initMocks(this);
     PostResource postResource = new PostResource(postService, postValidator,
         placementViewRepository, placementViewDecorator, placementViewMapper, placementService,
-        placementSummaryDecorator);
+        placementSummaryDecorator, postElasticSearchService);
     this.restPostMockMvc = MockMvcBuilders.standaloneSetup(postResource)
         .setCustomArgumentResolvers(pageableArgumentResolver)
         .setControllerAdvice(exceptionTranslator)

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/api/PostResourceIntTest.java
@@ -61,6 +61,7 @@ import com.transformuk.hee.tis.tcs.service.repository.PlacementViewRepository;
 import com.transformuk.hee.tis.tcs.service.repository.PostRepository;
 import com.transformuk.hee.tis.tcs.service.repository.SpecialtyRepository;
 import com.transformuk.hee.tis.tcs.service.service.PlacementService;
+import com.transformuk.hee.tis.tcs.service.service.PostElasticSearchService;
 import com.transformuk.hee.tis.tcs.service.service.impl.PostServiceImpl;
 import com.transformuk.hee.tis.tcs.service.service.mapper.PlacementViewMapper;
 import com.transformuk.hee.tis.tcs.service.service.mapper.PostMapper;
@@ -165,6 +166,8 @@ public class PostResourceIntTest {
   private PlacementViewMapper placementViewMapper;
   @Autowired
   private PlacementService placementService;
+  @Autowired
+  private PostElasticSearchService postElasticSearchService;
   @Autowired
   private PlacementSummaryDecorator placementSummaryDecorator;
   @Autowired
@@ -295,9 +298,9 @@ public class PostResourceIntTest {
         .setControllerAdvice(exceptionTranslator)
         .setMessageConverters(jacksonMessageConverter).build();
     TestUtils.mockUserprofile("jamesh", "1-1RUZV6H", "1-1RSSQ05", "1-1RSSPZ7", "1-1RUZV1D");
+    initTest();
   }
 
-  @Before
   public void initTest() {
     post = createEntity();
     post.setOwner(OWNER);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
@@ -181,7 +181,6 @@ class PostElasticSearchServiceTest {
     assertThat(queryAsString).contains(
         "nationalPostNumber",
         "programmeNames",
-        "currentTraineeSurname",
         "currentTraineeForenames",
         "Smith"
     );

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
@@ -24,6 +24,7 @@ package com.transformuk.hee.tis.tcs.service.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -38,6 +39,7 @@ import com.transformuk.hee.tis.tcs.service.api.decorator.PostViewDecorator;
 import com.transformuk.hee.tis.tcs.service.job.post.PostView;
 import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
 import com.transformuk.hee.tis.tcs.service.service.impl.PermissionService;
+import com.transformuk.hee.tis.tcs.service.service.mapper.PostViewMapper;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -67,9 +69,13 @@ class PostElasticSearchServiceTest {
   private PostViewDecorator postViewDecorator;
   @Mock
   private PermissionService permissionService;
+  @Mock
+  private PostViewMapper postViewMapper;
+
   @InjectMocks
   private PostElasticSearchService postElasticSearchService;
   private PostView postView;
+  private PostViewDTO postViewDto;
 
   @BeforeEach
   void setUp() {
@@ -87,6 +93,22 @@ class PostElasticSearchServiceTest {
     postView.setPrimarySpecialtyName("General Surgery");
     postView.setPrimarySiteId(200L);
     postView.setApprovedGradeId(300L);
+
+    postViewDto = new PostViewDTO();
+    postViewDto.setId(1000L);
+    postViewDto.setNationalPostNumber("EOE/123/ABC/001");
+    postViewDto.setStatus(Status.CURRENT);
+    postViewDto.setOwner("East of England");
+    postViewDto.setProgrammeNames("General Surgery");
+    postViewDto.setFundingType("Tariff");
+    postViewDto.setCurrentTraineeSurname("Smith");
+    postViewDto.setCurrentTraineeForenames("John");
+    postViewDto.setPrimarySpecialtyId(100L);
+    postViewDto.setPrimarySpecialtyCode("GPE");
+    postViewDto.setPrimarySpecialtyName("General Surgery");
+    postViewDto.setPrimarySiteId(200L);
+    postViewDto.setApprovedGradeId(300L);
+
     lenient().when(permissionService.isUserTrustAdmin()).thenReturn(false);
     lenient().when(permissionService.isProgrammeObserver()).thenReturn(false);
   }
@@ -104,6 +126,8 @@ class PostElasticSearchServiceTest {
         Sort.by(Sort.Order.asc("nationalPostNumber"), Sort.Order.asc("id"))
     );
     SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(postViewMapper.toDtos(anyList())).thenReturn(List.of(postViewDto));
 
     when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
         .thenReturn(mockedSearchHits);

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
@@ -109,6 +109,8 @@ class PostElasticSearchServiceTest {
     postViewDto.setPrimarySiteId(200L);
     postViewDto.setApprovedGradeId(300L);
 
+    lenient().when(postViewMapper.toDtos(anyList())).thenReturn(List.of(postViewDto));
+
     lenient().when(permissionService.isUserTrustAdmin()).thenReturn(false);
     lenient().when(permissionService.isProgrammeObserver()).thenReturn(false);
   }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
@@ -1,0 +1,353 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (NHS England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.transformuk.hee.tis.tcs.service.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.transformuk.hee.tis.tcs.api.dto.PostViewDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.Status;
+import com.transformuk.hee.tis.tcs.service.api.decorator.PostViewDecorator;
+import com.transformuk.hee.tis.tcs.service.job.post.PostView;
+import com.transformuk.hee.tis.tcs.service.model.ColumnFilter;
+import com.transformuk.hee.tis.tcs.service.service.impl.PermissionService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+
+@ExtendWith(MockitoExtension.class)
+class PostElasticSearchServiceTest {
+
+  @Mock
+  private ElasticsearchOperations elasticsearchOperations;
+  @Mock
+  private PostViewDecorator postViewDecorator;
+  @Mock
+  private PermissionService permissionService;
+  @InjectMocks
+  private PostElasticSearchService postElasticSearchService;
+  private PostView postView;
+
+  @BeforeEach
+  void setUp() {
+    postView = new PostView();
+    postView.setId(1000L);
+    postView.setNationalPostNumber("EOE/123/ABC/001");
+    postView.setStatus(Status.CURRENT);
+    postView.setOwner("East of England");
+    postView.setProgrammeNames(Lists.newArrayList("General Surgery"));
+    postView.setFundingTypes(Lists.newArrayList("Tariff"));
+    postView.setCurrentTraineeSurnames("Smith");
+    postView.setCurrentTraineeForenames("John");
+    postView.setPrimarySpecialtyId(100L);
+    postView.setPrimarySpecialtyCode("GPE");
+    postView.setPrimarySpecialtyName("General Surgery");
+    postView.setPrimarySiteId(200L);
+    postView.setApprovedGradeId(300L);
+    lenient().when(permissionService.isUserTrustAdmin()).thenReturn(false);
+    lenient().when(permissionService.isProgrammeObserver()).thenReturn(false);
+  }
+
+  @Test
+  void shouldElasticsearchReturnCorrectPostViewDtosUsingColumnFilters() {
+    List<ColumnFilter> filters = Lists.newArrayList(
+        columnFilter("status", Status.CURRENT),
+        columnFilter("owner", "East of England", "Wessex")
+    );
+
+    Pageable pageable = PageRequest.of(
+        0,
+        100,
+        Sort.by(Sort.Order.asc("nationalPostNumber"), Sort.Order.asc("id"))
+    );
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    Page<PostViewDTO> result = postElasticSearchService.searchForPage(null, filters, pageable);
+
+    assertThat(result.getContent()).hasSize(1);
+
+    PostViewDTO dto = result.getContent().get(0);
+    assertThat(dto.getId()).isEqualTo(1000L);
+    assertThat(dto.getNationalPostNumber()).isEqualTo("EOE/123/ABC/001");
+    assertThat(dto.getStatus()).isEqualTo(Status.CURRENT);
+    assertThat(dto.getOwner()).isEqualTo("East of England");
+    assertThat(dto.getProgrammeNames()).isEqualTo("General Surgery");
+    assertThat(dto.getFundingType()).isEqualTo("Tariff");
+    assertThat(dto.getCurrentTraineeSurname()).isEqualTo("Smith");
+    assertThat(dto.getCurrentTraineeForenames()).isEqualTo("John");
+
+    verify(postViewDecorator).decorate(result.getContent());
+  }
+
+  @Test
+  void shouldUseNationalPostNumberDirectlyForSorting() {
+    Pageable pageable = PageRequest.of(
+        0,
+        100,
+        Sort.by(Sort.Order.asc("nationalPostNumber"), Sort.Order.desc("id"))
+    );
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage(null, Collections.emptyList(), pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    Pageable actualPageable = queryCaptor.getValue().getPageable();
+
+    assertThat(actualPageable.getPageNumber()).isZero();
+    assertThat(actualPageable.getPageSize()).isEqualTo(100);
+
+    List<Sort.Order> orders = Lists.newArrayList(actualPageable.getSort().iterator());
+
+    assertThat(orders).hasSize(2);
+    assertThat(orders.get(0).getProperty()).isEqualTo("nationalPostNumber");
+    assertThat(orders.get(0).isAscending()).isTrue();
+
+    assertThat(orders.get(1).getProperty()).isEqualTo("id");
+    assertThat(orders.get(1).isDescending()).isTrue();
+  }
+
+  @Test
+  void shouldBuildTextSearchQueryForStringSearchTerm() {
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage("Smith", Collections.emptyList(), pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString).contains(
+        "nationalPostNumber",
+        "programmeNames",
+        "currentTraineeSurname",
+        "currentTraineeForenames",
+        "Smith"
+    );
+  }
+
+  @Test
+  void shouldBuildNumericTextSearchQueryWithIdFields() {
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage("100", Collections.emptyList(), pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString).contains(
+        "id",
+        "primarySiteId",
+        "approvedGradeId",
+        "primarySpecialtyId"
+    );
+  }
+
+  @Test
+  void shouldThrowExceptionForUnsupportedColumnFilter() {
+    List<ColumnFilter> filters = Collections.singletonList(
+        columnFilter("unsupportedFilter", "test")
+    );
+
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    assertThatThrownBy(() ->
+        postElasticSearchService.searchForPage(null, filters, pageable)
+    )
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("unsupportedFilter")
+        .hasMessageContaining("Failed to search posts in Elasticsearch.");
+  }
+
+  @Test
+  void shouldSkipNullColumnFilterValues() {
+    List<ColumnFilter> filters = Collections.singletonList(
+        columnFilter("owner", null, "East of England")
+    );
+
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage(null, filters, pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString).contains("East of England");
+  }
+
+  @Test
+  void shouldUseEnumNameForEnumColumnFilterValues() {
+    List<ColumnFilter> filters = Collections.singletonList(
+        columnFilter("status", Status.CURRENT)
+    );
+
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage(null, filters, pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString).contains("status", "CURRENT");
+  }
+
+  @Test
+  void shouldApplyTrustPermissionFilterWhenUserIsTrustAdmin() {
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    when(permissionService.isUserTrustAdmin()).thenReturn(true);
+    when(permissionService.getUsersTrustIds()).thenReturn(Sets.newHashSet(10L, 20L));
+    when(permissionService.isProgrammeObserver()).thenReturn(false);
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage(null, Collections.emptyList(), pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString).contains("trustIds", "10", "20");
+  }
+
+  @Test
+  void shouldApplyProgrammePermissionFilterWhenUserIsProgrammeObserver() {
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("id"));
+
+    when(permissionService.isUserTrustAdmin()).thenReturn(false);
+    when(permissionService.isProgrammeObserver()).thenReturn(true);
+    when(permissionService.getUsersProgrammeIds()).thenReturn(Sets.newHashSet(100L, 200L));
+
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    postElasticSearchService.searchForPage(null, Collections.emptyList(), pageable);
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString).contains("programmeIds", "100", "200");
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchHits<PostView> searchHits(PostView... postViews) {
+    SearchHits<PostView> searchHits = mock(SearchHits.class);
+
+    List<SearchHit<PostView>> hits = Arrays.stream(postViews)
+        .map(pView -> {
+          SearchHit<PostView> searchHit = mock(SearchHit.class);
+          when(searchHit.getContent()).thenReturn(pView);
+          return searchHit;
+        })
+        .collect(Collectors.toList());
+
+    when(searchHits.getSearchHits()).thenReturn(hits);
+    when(searchHits.getTotalHits()).thenReturn((long) postViews.length);
+
+    return searchHits;
+  }
+
+  private ColumnFilter columnFilter(String name, Object... values) {
+    return new ColumnFilter(name, Arrays.asList(values));
+  }
+}

--- a/tcs-service/src/test/resources/config/application.yml
+++ b/tcs-service/src/test/resources/config/application.yml
@@ -83,6 +83,11 @@ spring:
     port: 5672
     username: guest
     password: guest
+    listener:
+      simple:
+        auto-startup: false
+      direct:
+        auto-startup: false
 
 server:
   port: 10344


### PR DESCRIPTION
- The front end calls /api/posts.
- The controller checks whether ES search is enabled.
- If ES is enabled, the controller sends searchQuery, filters, and pageable to PostElasticSearchService.
- The service builds an Elasticsearch bool query.
- Each column filter.
- Multiple values inside one filter.
- Free-text search is added across post number, programme, trainee names, specialty, owner, and funding fields.
