### PR TITLE
fix: update java version for sonar

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cache: maven
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
Sonar Cloud now requires the scanner/runtime used for analysis to run on Java 21 or later. Their Maven scanner documentation lists “Java 21 or later” as a prerequisite, with Java 17 deprecated. Sonar’s general requirements also say Java 17 support for scanner runtimes ends for Sonar Cloud in July 2026.
