### PR TITLE
fix: separate java version for build and analyse

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cache: maven
           distribution: temurin
-          java-version: 21
+          java-version: 17
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
@@ -58,6 +58,19 @@ jobs:
 
       - name: Run tests
         run: mvn test
+
+      - name: Set up JDK for Sonar
+        uses: actions/setup-java@v5
+        with:
+          cache: maven
+          distribution: temurin
+          java-version: 21
+
+      - name: maven-settings-xml-action for Sonar
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+            servers: '[{ "id": "codeartifact", "username": "aws", "password": "${env.CODEARTIFACT_AUTH_TOKEN}" }]'
+            repositories: '[{ "id": "codeartifact", "url": "https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/" }]'
 
       - name: Run quality analysis
         env:


### PR DESCRIPTION
Build and Sonar analysis will use different JDK version. The changes here will make sure the following:

Build          → Java 17
Tests          → Java 17
Sonar analysis → Java 21
Dockerize      → Java 17

It has been tested by pushing to the branch and it succeeded.