### PR TITLE
fix: add case insensitive npn search

### DIFF
--- a/tcs-service/pom.xml
+++ b/tcs-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>tcs-service</artifactId>
-  <version>6.61.0</version>
+  <version>6.61.1</version>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
+++ b/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchService.java
@@ -234,8 +234,9 @@ public class PostElasticSearchService {
       searchQuery = StringUtils.remove(searchQuery, '"');
       String wildcard = "*" + searchQuery + "*";
 
+      addNationalPostNumberWildcardQuery(shouldQuery, searchQuery);
+
       shouldQuery
-          .should(new WildcardQueryBuilder(NATIONAL_POST_NUMBER, wildcard))
           .should(new WildcardQueryBuilder(PROGRAMME_NAMES, wildcard))
           .should(new MatchQueryBuilder(PRIMARY_SPECIALTY_NAME, searchQuery))
           .should(new WildcardQueryBuilder(FUNDING_TYPES, wildcard))
@@ -416,5 +417,15 @@ public class PostElasticSearchService {
     Preconditions.checkNotNull(postId, "Post id cannot be null");
     // postId is the document id in the PostView index, so we can delete it directly
     elasticsearchOperations.delete(String.valueOf(postId), PostView.class);
+  }
+
+  private void addNationalPostNumberWildcardQuery(BoolQueryBuilder query, String searchQuery) {
+    query.should(new WildcardQueryBuilder(
+        NATIONAL_POST_NUMBER, "*" + searchQuery + "*"
+    ));
+
+    query.should(new WildcardQueryBuilder(
+        NATIONAL_POST_NUMBER, "*" + searchQuery.toUpperCase() + "*"
+    ));
   }
 }

--- a/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
+++ b/tcs-service/src/test/java/com/transformuk/hee/tis/tcs/service/service/PostElasticSearchServiceTest.java
@@ -535,6 +535,32 @@ class PostElasticSearchServiceTest {
     verify(elasticsearchOperations, never()).delete(any(String.class), eq(PostView.class));
   }
 
+  @Test
+  void shouldContainCaseInsensitiveNationalPostNumberSearch() {
+    SearchHits<PostView> mockedSearchHits = searchHits(postView);
+
+    when(elasticsearchOperations.search(any(NativeSearchQuery.class), eq(PostView.class)))
+        .thenReturn(mockedSearchHits);
+
+    when(postViewMapper.toDtos(anyList())).thenReturn(List.of(postViewDto));
+
+    ArgumentCaptor<NativeSearchQuery> queryCaptor =
+        ArgumentCaptor.forClass(NativeSearchQuery.class);
+
+    postElasticSearchService.searchForPage(
+        "nwn",
+        Collections.emptyList(),
+        PageRequest.of(0, 20)
+    );
+
+    verify(elasticsearchOperations).search(queryCaptor.capture(), eq(PostView.class));
+
+    String queryAsString = queryCaptor.getValue().getQuery().toString();
+
+    assertThat(queryAsString)
+        .contains("nationalPostNumber", "*nwn*", "*NWN*");
+  }
+
   private void mockBaseQuery(List<PostView> queryResult) {
     when(sqlQuerySupplier.getQuery(SqlQuerySupplier.POST_VIEW)).thenReturn(QUERY_TEMPLATE);
     when(elasticsearchOperations.indexOps(PostView.class)).thenReturn(indexOperations);


### PR DESCRIPTION
User raised an issue on searching NPN with lower case value. This tweak will help them to achieve this. 

Some points for our future improvement:
- We had to use lower version of client elasticsearch and our version is maintained by Spring boot version 2.3.4
- caseInsensitive(true) option is available in higher version of ES. So we have to upgrade Spring boot soon and hence the Java version.

NO-CARD